### PR TITLE
chore: обновление Rust-зависимостей

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ members = [
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }
-rdkafka = "0.38"
+rdkafka = "0.39"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-opensearch = "2.2"
+opensearch = "2.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-bytes = "1.0"
+bytes = "1.12"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-bake:
 
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.5.0
+    image: confluentinc/cp-zookeeper:7.9.8
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
 
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: confluentinc/cp-kafka:7.9.8
     depends_on:
       - zookeeper
     ports:
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
 
   opensearch:
-    image: opensearchproject/opensearch:3.3.2
+    image: opensearchproject/opensearch:3.7.0
     environment:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
@@ -61,7 +61,7 @@ services:
       retries: 10
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:3.3.0
+    image: opensearchproject/opensearch-dashboards:3.7.0
     ports:
       - "5601:5601"
     environment:
@@ -132,7 +132,7 @@ services:
     restart: unless-stopped
 
   prometheus:
-    image: prom/prometheus:v2.48.0
+    image: prom/prometheus:v3.12.0
     ports:
       - "9091:9090"
     volumes:
@@ -157,7 +157,7 @@ services:
       retries: 5
 
   grafana:
-    image: grafana/grafana:10.2.2
+    image: grafana/grafana:12.3.8
     ports:
       - "3000:3000"
     environment:

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -9,33 +9,33 @@ name = "proxy"
 path = "src/main.rs"
 
 [dependencies]
-hyper = { version = "1.0", features = ["full"] }
+hyper = { version = "1.10", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 http-body-util = "0.1"
-quick_cache = "0.6"
-rcgen = "0.13"
-rdkafka = "0.38"
-prometheus = { version = "0.13", features = ["process"] }
+quick_cache = "0.7"
+rcgen = "0.14"
+rdkafka = "0.39"
+prometheus = { version = "0.14", features = ["process"] }
 tokio-rustls = { version = "0.26", features = ["ring"] }
 rustls = "0.23"
-rustls-pemfile = "2.1"
-sha2 = "0.10"
+rustls-pemfile = "2.2"
+sha2 = "0.11"
 base64 = "0.22"
 url = "2.5"
-bytes = "1.0"
+bytes = "1.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Authentication
-ldap3 = { version = "0.11", optional = true }
+ldap3 = { version = "0.12", optional = true }
 hex = "0.4"
 
 # ACL and Categorization
-regex = "1.10"
-reqwest = { version = "0.11", features = ["json"] }
+regex = "1.12"
+reqwest = { version = "0.13", features = ["json"] }
 
 [features]
 default = []

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -101,7 +101,7 @@ impl CertCache {
 
         let ca_cert = Arc::new(
             ca_params
-                .self_signed(&ca_key)
+                .self_signed(ca_key.as_ref())
                 .expect("CA cert instance failed"),
         );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Обновлены Rust-зависимости workspace и Docker-образы в `docker-compose.yml` до актуальных версий.

## Rust-зависимости

### Workspace (`Cargo.toml`)
| Пакет | Было | Стало |
|-------|------|-------|
| rdkafka | 0.38 | 0.39 |
| opensearch | 2.2 | 2.4 |
| bytes | 1.0 | 1.12 |

### Proxy (`proxy/Cargo.toml`)
| Пакет | Было | Стало |
|-------|------|-------|
| hyper | 1.0 | 1.10 |
| quick_cache | 0.6 | 0.7 |
| rcgen | 0.13 | 0.14 |
| prometheus | 0.13 | 0.14 |
| reqwest | 0.11 | 0.13 |
| sha2 | 0.10 | 0.11 |
| ldap3 | 0.11 | 0.12 |
| regex | 1.10 | 1.12 |
| rustls-pemfile | 2.1 | 2.2 |
| rdkafka | 0.38 | 0.39 |
| bytes | 1.0 | 1.12 |

## Docker-образы (`docker-compose.yml`)

| Сервис | Было | Стало |
|--------|------|-------|
| Zookeeper | 7.5.0 | **7.9.8** |
| Kafka | 7.5.0 | **7.9.8** |
| OpenSearch | 3.3.2 | **3.7.0** |
| OpenSearch Dashboards | 3.3.0 | **3.7.0** |
| Prometheus | v2.48.0 | **v3.12.0** |
| Grafana | 10.2.2 | **12.3.8** |

Kafka обновлена до последней ветки 7.x с поддержкой ZooKeeper. Confluent Platform 8.x требует KRaft и не совместима с текущей конфигурацией без миграции.

## Исправление совместимости

В `rcgen` 0.14 `Arc<KeyPair>` больше не реализует трейт `SigningKey`. Исправлено использование `ca_key.as_ref()` при вызове `self_signed()`.

## Проверка

- `cargo build --workspace --all-targets` — успешно
- `cargo test --workspace --all-targets` — 24 теста пройдены
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91cffc13-a431-400a-98ba-2df02f9862fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91cffc13-a431-400a-98ba-2df02f9862fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

