### PR TITLE
ci: fix fmt and clippy failures in Rust CI

### DIFF
--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -22,7 +22,7 @@ struct CacheEvent {
     status: u16,
     cache_key: String,
     timestamp: u64,
-    #[serde(default)]  // ИСПРАВЛЕНИЕ: делаем поле опциональным
+    #[serde(default)] // ИСПРАВЛЕНИЕ: делаем поле опциональным
     headers: HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     cache_status: Option<String>,
@@ -48,6 +48,7 @@ struct Indexer {
 }
 
 impl Indexer {
+    #[allow(clippy::too_many_arguments)]
     async fn new(
         kafka_brokers: &str,
         opensearch_url: &str,
@@ -70,22 +71,19 @@ impl Indexer {
         info!("Subscribed to Kafka topic: {}", kafka_topic);
 
         // Создаём транспорт с аутентификацией
-        let mut transport_builder = TransportBuilder::new(
-            SingleNodeConnectionPool::new(opensearch_url.parse()?),
-        );
+        let mut transport_builder =
+            TransportBuilder::new(SingleNodeConnectionPool::new(opensearch_url.parse()?));
 
         // Добавляем credentials если указаны
         if let (Some(username), Some(password)) = (opensearch_username, opensearch_password) {
             info!("Using authentication for OpenSearch: {}", username);
-            transport_builder = transport_builder
-                .auth(Credentials::Basic(username, password));
+            transport_builder = transport_builder.auth(Credentials::Basic(username, password));
         }
 
         // Отключаем проверку SSL если нужно
         if !ssl_verify {
             warn!("SSL certificate verification is disabled!");
-            transport_builder = transport_builder
-                .cert_validation(CertificateValidation::None);
+            transport_builder = transport_builder.cert_validation(CertificateValidation::None);
         }
 
         let transport = transport_builder.build()?;
@@ -205,7 +203,11 @@ impl Indexer {
                                 }
                             }
                             Err(e) => {
-                                warn!("Failed to parse event: {} - Payload: {}", e, String::from_utf8_lossy(payload));
+                                warn!(
+                                    "Failed to parse event: {} - Payload: {}",
+                                    e,
+                                    String::from_utf8_lossy(payload)
+                                );
                             }
                         }
                     }

--- a/cache-indexer/tests/integration_test.rs
+++ b/cache-indexer/tests/integration_test.rs
@@ -81,7 +81,10 @@ mod tests {
         });
 
         assert!(mapping["mappings"]["properties"]["url"]["type"].is_string());
-        assert_eq!(mapping["mappings"]["properties"]["method"]["type"], "keyword");
+        assert_eq!(
+            mapping["mappings"]["properties"]["method"]["type"],
+            "keyword"
+        );
         assert_eq!(mapping["mappings"]["properties"]["status"]["type"], "short");
     }
 

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -168,7 +168,10 @@ pub struct AuthManager {
 
 impl AuthManager {
     pub fn new(config: AuthConfig) -> Self {
-        info!("Authentication manager initialized with backend: {}", config.backend);
+        info!(
+            "Authentication manager initialized with backend: {}",
+            config.backend
+        );
         Self {
             config,
             user_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -225,20 +228,25 @@ impl AuthManager {
             #[cfg(feature = "auth-ldap")]
             AuthBackend::Ldap => self.authenticate_ldap(username, password).await?,
             #[cfg(feature = "auth-ntlm")]
-            AuthBackend::Ntlm => {
-                return Err("NTLM not implemented yet".to_string())
-            }
+            AuthBackend::Ntlm => return Err("NTLM not implemented yet".to_string()),
         };
 
         // Cache successful authentication
         self.cache_user(username, password, user_info.clone()).await;
 
-        info!("User {} authenticated successfully via {}", username, self.config.backend);
+        info!(
+            "User {} authenticated successfully via {}",
+            username, self.config.backend
+        );
         Ok(user_info)
     }
 
     /// Basic authentication (no external validation)
-    async fn authenticate_basic(&self, username: &str, _password: &str) -> Result<UserInfo, String> {
+    async fn authenticate_basic(
+        &self,
+        username: &str,
+        _password: &str,
+    ) -> Result<UserInfo, String> {
         Ok(UserInfo {
             username: username.to_string(),
             display_name: Some(username.to_string()),
@@ -251,12 +259,18 @@ impl AuthManager {
     /// LDAP authentication
     #[cfg(feature = "auth-ldap")]
     async fn authenticate_ldap(&self, username: &str, password: &str) -> Result<UserInfo, String> {
-        let ldap_config = self.config.ldap.as_ref()
+        let ldap_config = self
+            .config
+            .ldap
+            .as_ref()
             .ok_or_else(|| "LDAP not configured".to_string())?;
 
         // Try each LDAP server
         for server in &ldap_config.servers {
-            match self.try_ldap_server(server, ldap_config, username, password).await {
+            match self
+                .try_ldap_server(server, ldap_config, username, password)
+                .await
+            {
                 Ok(user_info) => return Ok(user_info),
                 Err(e) => {
                     warn!("LDAP server {} failed: {}", server, e);
@@ -278,8 +292,7 @@ impl AuthManager {
         password: &str,
     ) -> Result<UserInfo, String> {
         // Connect to LDAP server
-        let settings = LdapConnSettings::new()
-            .set_conn_timeout(config.timeout);
+        let settings = LdapConnSettings::new().set_conn_timeout(config.timeout);
 
         let mut ldap = LdapConn::with_settings(settings, server)
             .map_err(|e| format!("LDAP connection failed: {}", e))?;
@@ -293,10 +306,16 @@ impl AuthManager {
         // Search for user
         let filter = config.user_filter.replace("{username}", username);
         let result = ldap
-            .search(&config.base_dn, Scope::Subtree, &filter, vec!["cn", "mail", "memberOf"])
+            .search(
+                &config.base_dn,
+                Scope::Subtree,
+                &filter,
+                vec!["cn", "mail", "memberOf"],
+            )
             .map_err(|e| format!("LDAP search failed: {}", e))?;
 
-        let (entries, _) = result.success()
+        let (entries, _) = result
+            .success()
             .map_err(|e| format!("LDAP search error: {}", e))?;
 
         if entries.is_empty() {
@@ -311,15 +330,21 @@ impl AuthManager {
             .map_err(|_| "Invalid credentials".to_string())?;
 
         // Extract user information
-        let display_name = entry.attrs.get("cn")
+        let display_name = entry
+            .attrs
+            .get("cn")
             .and_then(|v| v.first())
             .map(|s| s.to_string());
 
-        let email = entry.attrs.get("mail")
+        let email = entry
+            .attrs
+            .get("mail")
             .and_then(|v| v.first())
             .map(|s| s.to_string());
 
-        let groups = entry.attrs.get("memberOf")
+        let groups = entry
+            .attrs
+            .get("memberOf")
             .map(|v| v.iter().map(|s| s.to_string()).collect())
             .unwrap_or_default();
 
@@ -346,7 +371,10 @@ impl AuthManager {
             ttl: self.config.cache_ttl,
         };
 
-        self.user_cache.write().await.insert(username.to_string(), cached);
+        self.user_cache
+            .write()
+            .await
+            .insert(username.to_string(), cached);
     }
 
     /// Create 407 Proxy Authentication Required response
@@ -363,9 +391,7 @@ impl AuthManager {
                 format!("Basic realm=\"{}\"", self.config.realm)
             }
             #[cfg(feature = "auth-ntlm")]
-            AuthBackend::Ntlm => {
-                "NTLM".to_string()
-            }
+            AuthBackend::Ntlm => "NTLM".to_string(),
         };
 
         Response::builder()
@@ -406,7 +432,7 @@ mod tests {
 
         let manager = AuthManager::new(config);
         let result = manager.authenticate("testuser", "testpass").await;
-        
+
         assert!(result.is_ok());
         let user_info = result.unwrap();
         assert_eq!(user_info.username, "testuser");
@@ -422,10 +448,10 @@ mod tests {
         };
 
         let manager = AuthManager::new(config);
-        
+
         // First authentication
         manager.authenticate("testuser", "password").await.unwrap();
-        
+
         // Should be cached
         let cached = manager.get_cached_user("testuser").await;
         assert!(cached.is_some());
@@ -443,10 +469,10 @@ mod tests {
 
         let manager = AuthManager::new(config);
         manager.authenticate("testuser", "password").await.unwrap();
-        
+
         // Wait for expiration
         tokio::time::sleep(Duration::from_millis(150)).await;
-        
+
         let cached = manager.get_cached_user("testuser").await;
         assert!(cached.unwrap().is_expired());
     }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -116,8 +116,10 @@ struct ProxyService {
     http_cache: Arc<Cache<Arc<str>, CachedResponse>>,
     cache_config: CacheConfig,
     kafka_producer: Option<Arc<FutureProducer>>,
-    http_client:
-        hyper_util::client::legacy::Client<hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>, Body>,
+    http_client: hyper_util::client::legacy::Client<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+        Body,
+    >,
     metrics: Arc<Metrics>,
     mitm_enabled: bool,
 }
@@ -151,12 +153,11 @@ impl ProxyService {
             .enable_http1()
             .build();
 
-        let http_client = hyper_util::client::legacy::Client::builder(
-            hyper_util::rt::TokioExecutor::new(),
-        )
-        .pool_idle_timeout(Duration::from_secs(90))
-        .pool_max_idle_per_host(32)
-        .build(https);
+        let http_client =
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .pool_idle_timeout(Duration::from_secs(90))
+                .pool_max_idle_per_host(32)
+                .build(https);
 
         Self {
             cert_cache,
@@ -283,7 +284,7 @@ impl ProxyService {
                 }
                 let response = cached.to_response();
                 let body_size = cached.body.len();
-                guard.finish(cached.status, body_size);
+                guard.finish(cached.status, 0, body_size);
                 return response;
             }
         }
@@ -302,10 +303,11 @@ impl ProxyService {
                 error!("Body collection failed: {}", e);
                 let mut resp = Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
                 *resp.status_mut() = StatusCode::BAD_REQUEST;
-                guard.finish(400, 15);
+                guard.finish(400, 0, 15);
                 return resp;
             }
         };
+        let request_body_size = body_bytes.len();
         let req = Request::from_parts(parts, Body::new(body_bytes));
 
         let domain = Self::extract_domain(&url);
@@ -347,7 +349,7 @@ impl ProxyService {
                         let mut resp =
                             Response::new(Body::new(Bytes::from_static(b"502 Bad Gateway")));
                         *resp.status_mut() = StatusCode::BAD_GATEWAY;
-                        guard.finish(502, 15);
+                        guard.finish(502, request_body_size, 15);
                         return resp;
                     }
                 };
@@ -406,7 +408,7 @@ impl ProxyService {
                         resp.headers_mut().insert(name, val);
                     }
                 }
-                guard.finish(status.as_u16(), body_size);
+                guard.finish(status.as_u16(), request_body_size, body_size);
                 resp
             }
             Err(e) => {
@@ -417,7 +419,7 @@ impl ProxyService {
                     .inc();
                 let mut response = Response::new(Body::new(Bytes::from_static(b"502 Bad Gateway")));
                 *response.status_mut() = StatusCode::BAD_GATEWAY;
-                guard.finish(502, 15);
+                guard.finish(502, request_body_size, 15);
                 response
             }
         }
@@ -432,7 +434,7 @@ async fn metrics_server(metrics: Arc<Metrics>) {
             return;
         }
     };
-    
+
     info!("📊 Metrics server started on 0.0.0.0:9090");
 
     loop {
@@ -452,15 +454,14 @@ async fn metrics_server(metrics: Arc<Metrics>) {
                 async move {
                     let path = req.uri().path();
                     debug!("Metrics request from {}: {}", addr, path);
-                    
+
                     let response = match path {
                         "/metrics" => {
                             debug!("Exporting metrics...");
                             // Wrap in catch_unwind to catch panics
-                            let export_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                                metrics.export()
-                            }));
-                            
+                            let export_result =
+                                panic::catch_unwind(panic::AssertUnwindSafe(|| metrics.export()));
+
                             match export_result {
                                 Ok(Ok(body)) => {
                                     debug!("Metrics exported successfully: {} bytes", body.len());
@@ -471,25 +472,35 @@ async fn metrics_server(metrics: Arc<Metrics>) {
                                         .body(Body::new(Bytes::from(body)))
                                         .unwrap_or_else(|e| {
                                             error!("Failed to build metrics response: {}", e);
-                                            Response::new(Body::new(Bytes::from_static(b"500 Internal Server Error")))
+                                            Response::new(Body::new(Bytes::from_static(
+                                                b"500 Internal Server Error",
+                                            )))
                                         })
                                 }
                                 Ok(Err(e)) => {
                                     error!("Failed to export metrics: {}", e);
                                     Response::builder()
                                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                        .body(Body::new(Bytes::from_static(b"500 Internal Server Error")))
+                                        .body(Body::new(Bytes::from_static(
+                                            b"500 Internal Server Error",
+                                        )))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Body::new(Bytes::from_static(b"500 Internal Server Error")))
+                                            Response::new(Body::new(Bytes::from_static(
+                                                b"500 Internal Server Error",
+                                            )))
                                         })
                                 }
                                 Err(panic_info) => {
                                     error!("Metrics export panicked: {:?}", panic_info);
                                     Response::builder()
                                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                        .body(Body::new(Bytes::from_static(b"500 Panic in metrics export")))
+                                        .body(Body::new(Bytes::from_static(
+                                            b"500 Panic in metrics export",
+                                        )))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Body::new(Bytes::from_static(b"500 Internal Server Error")))
+                                            Response::new(Body::new(Bytes::from_static(
+                                                b"500 Internal Server Error",
+                                            )))
                                         })
                                 }
                             }
@@ -499,9 +510,11 @@ async fn metrics_server(metrics: Arc<Metrics>) {
                             Response::builder()
                                 .status(StatusCode::OK)
                                 .header("Content-Type", "application/json")
-                                .body(Body::new(Bytes::from_static(b"{\"status\":\"ok\"}")))  
+                                .body(Body::new(Bytes::from_static(b"{\"status\":\"ok\"}")))
                                 .unwrap_or_else(|_| {
-                                    Response::new(Body::new(Bytes::from_static(b"{\"status\":\"ok\"}")))  
+                                    Response::new(Body::new(Bytes::from_static(
+                                        b"{\"status\":\"ok\"}",
+                                    )))
                                 })
                         }
                         "/ready" => {
@@ -509,9 +522,11 @@ async fn metrics_server(metrics: Arc<Metrics>) {
                             Response::builder()
                                 .status(StatusCode::OK)
                                 .header("Content-Type", "application/json")
-                                .body(Body::new(Bytes::from_static(b"{\"status\":\"ready\"}")))  
+                                .body(Body::new(Bytes::from_static(b"{\"status\":\"ready\"}")))
                                 .unwrap_or_else(|_| {
-                                    Response::new(Body::new(Bytes::from_static(b"{\"status\":\"ready\"}")))  
+                                    Response::new(Body::new(Bytes::from_static(
+                                        b"{\"status\":\"ready\"}",
+                                    )))
                                 })
                         }
                         _ => {
@@ -528,10 +543,7 @@ async fn metrics_server(metrics: Arc<Metrics>) {
                 }
             });
 
-            if let Err(e) = http1::Builder::new()
-                .serve_connection(io, service)
-                .await
-            {
+            if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
                 error!("Metrics server connection error from {}: {}", addr, e);
             }
         });
@@ -564,10 +576,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::fs::read("./certs/ca.key")
     })?;
 
-    let ca_cert = tokio::fs::read("/certs/ca.crt").await.or_else(|_| {
-        warn!("Failed to read /certs/ca.crt, trying ./certs/ca.crt");
-        std::fs::read("./certs/ca.crt")
-    }).unwrap_or_default();
+    let ca_cert = tokio::fs::read("/certs/ca.crt")
+        .await
+        .or_else(|_| {
+            warn!("Failed to read /certs/ca.crt, trying ./certs/ca.crt");
+            std::fs::read("./certs/ca.crt")
+        })
+        .unwrap_or_default();
 
     let cert_cache = CertCache::from_pem(&ca_key, &ca_cert)?;
     let mitm_enabled = std::env::var("MITM_ENABLED")
@@ -600,7 +615,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         metrics.clone(),
         mitm_enabled,
     ));
-    
+
     let http_port = std::env::var("HTTP_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -629,10 +644,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // quick_cache API: len() and weight() only
             let entries = cache_clone.len();
             let weight = cache_clone.weight();
-            
+
             metrics_clone.cache_entries.set(entries as f64);
             metrics_clone.cache_size_bytes.set(weight as f64);
-            
+
             debug!(
                 "Cache stats: entries={}, weight={}KB",
                 entries,
@@ -672,7 +687,8 @@ async fn handle_connect_tunnel(
                     let duration_ms = request_start.elapsed().as_millis() as u64;
                     let domain = parse_authority(&authority).0;
 
-                    if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                    if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
+                    {
                         let event = CacheEvent {
                             url: format!("https://{}", authority),
                             method: "CONNECT".to_string(),
@@ -763,8 +779,7 @@ async fn handle_connect_mitm(
                 Ok(req) => req,
                 Err(e) => {
                     error!("Failed to rewrite MITM request for {}: {}", authority, e);
-                    let mut resp =
-                        Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
+                    let mut resp = Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
                     *resp.status_mut() = StatusCode::BAD_REQUEST;
                     return Ok::<_, Infallible>(resp);
                 }

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -31,6 +31,7 @@ pub struct Metrics {
     pub cache_bypasses_total: Counter,
     pub cache_entries: Gauge,
     pub cache_size_bytes: Gauge,
+    #[allow(dead_code)]
     pub cache_evictions_total: Counter,
     pub cache_lookup_duration_seconds: Histogram,
 
@@ -77,22 +78,26 @@ impl Metrics {
         )?;
         registry.register(Box::new(request_duration_seconds.clone()))?;
 
-        let request_size_bytes = Histogram::with_opts(HistogramOpts::new(
-            "bsdm_proxy_request_size_bytes",
-            "HTTP request size in bytes",
-        )
-        .buckets(vec![
-            100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 10000000.0,
-        ]))?;
+        let request_size_bytes = Histogram::with_opts(
+            HistogramOpts::new(
+                "bsdm_proxy_request_size_bytes",
+                "HTTP request size in bytes",
+            )
+            .buckets(vec![
+                100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 10000000.0,
+            ]),
+        )?;
         registry.register(Box::new(request_size_bytes.clone()))?;
 
-        let response_size_bytes = Histogram::with_opts(HistogramOpts::new(
-            "bsdm_proxy_response_size_bytes",
-            "HTTP response size in bytes",
-        )
-        .buckets(vec![
-            100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 10000000.0,
-        ]))?;
+        let response_size_bytes = Histogram::with_opts(
+            HistogramOpts::new(
+                "bsdm_proxy_response_size_bytes",
+                "HTTP response size in bytes",
+            )
+            .buckets(vec![
+                100.0, 1000.0, 10000.0, 100000.0, 1000000.0, 10000000.0,
+            ]),
+        )?;
         registry.register(Box::new(response_size_bytes.clone()))?;
 
         // Cache metrics
@@ -128,11 +133,13 @@ impl Metrics {
         )?;
         registry.register(Box::new(cache_evictions_total.clone()))?;
 
-        let cache_lookup_duration_seconds = Histogram::with_opts(HistogramOpts::new(
-            "bsdm_proxy_cache_lookup_duration_seconds",
-            "Cache lookup duration in seconds",
-        )
-        .buckets(vec![0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01]))?;
+        let cache_lookup_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "bsdm_proxy_cache_lookup_duration_seconds",
+                "Cache lookup duration in seconds",
+            )
+            .buckets(vec![0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01]),
+        )?;
         registry.register(Box::new(cache_lookup_duration_seconds.clone()))?;
 
         // Upstream metrics
@@ -227,6 +234,7 @@ impl Metrics {
     }
 
     /// Get cache hit rate (0.0 to 1.0)
+    #[allow(dead_code)]
     pub fn cache_hit_rate(&self) -> f64 {
         let hits = self.cache_hits_total.get();
         let misses = self.cache_misses_total.get();
@@ -268,21 +276,18 @@ impl RequestMetricsGuard {
         self.cache_status = status.to_string();
     }
 
-    pub fn finish(self, status_code: u16, response_size: usize) {
+    pub fn finish(self, status_code: u16, request_size: usize, response_size: usize) {
         let duration = self.start.elapsed().as_secs_f64();
         self.metrics.requests_in_flight.dec();
         self.metrics
             .requests_total
-            .with_label_values(&[
-                &self.method,
-                &status_code.to_string(),
-                &self.cache_status,
-            ])
+            .with_label_values(&[&self.method, &status_code.to_string(), &self.cache_status])
             .inc();
         self.metrics
             .request_duration_seconds
             .with_label_values(&[&self.method, &self.cache_status])
             .observe(duration);
+        self.metrics.request_size_bytes.observe(request_size as f64);
         self.metrics
             .response_size_bytes
             .observe(response_size as f64);

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -172,8 +172,7 @@ fn parse_private_key(
     pem: &[u8],
 ) -> Result<PrivateKeyDer<'static>, Box<dyn std::error::Error + Send + Sync>> {
     let mut reader = Cursor::new(pem);
-    rustls_pemfile::private_key(&mut reader)?
-        .ok_or_else(|| "no private key found in PEM".into())
+    rustls_pemfile::private_key(&mut reader)?.ok_or_else(|| "no private key found in PEM".into())
 }
 
 pub fn parse_authority(authority: &str) -> (String, u16) {

--- a/proxy/tests/integration_test.rs
+++ b/proxy/tests/integration_test.rs
@@ -23,7 +23,7 @@ mod tests {
         // Same input should produce same hash
         let method = "POST";
         let uri = "https://example.com/api/data";
-        
+
         let cache_key1 = format!("{}-{}", method, uri);
         let mut hasher1 = Sha256::new();
         hasher1.update(cache_key1.as_bytes());
@@ -61,14 +61,20 @@ mod tests {
         headers.insert("Cache-Control".to_string(), "max-age=3600".to_string());
 
         assert_eq!(headers.len(), 2);
-        assert_eq!(headers.get("Content-Type"), Some(&"application/json".to_string()));
-        assert_eq!(headers.get("Cache-Control"), Some(&"max-age=3600".to_string()));
+        assert_eq!(
+            headers.get("Content-Type"),
+            Some(&"application/json".to_string())
+        );
+        assert_eq!(
+            headers.get("Cache-Control"),
+            Some(&"max-age=3600".to_string())
+        );
     }
 
     #[test]
     fn test_timestamp_generation() {
         use std::time::{SystemTime, UNIX_EPOCH};
-        
+
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -76,7 +82,7 @@ mod tests {
 
         // Timestamp should be reasonable (after year 2020)
         assert!(timestamp > 1577836800); // 2020-01-01 00:00:00 UTC
-        // And before year 2100
+                                         // And before year 2100
         assert!(timestamp < 4102444800); // 2100-01-01 00:00:00 UTC
     }
 
@@ -91,7 +97,7 @@ mod tests {
     #[test]
     fn test_method_types() {
         let methods = vec!["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
-        
+
         for method in methods {
             assert!(!method.is_empty());
             assert!(method.chars().all(|c| c.is_ascii_uppercase()));
@@ -100,8 +106,9 @@ mod tests {
 
     #[test]
     fn test_status_codes() {
-        let valid_codes: Vec<u16> = vec![200, 201, 204, 301, 302, 400, 401, 403, 404, 500, 502, 503];
-        
+        let valid_codes: Vec<u16> =
+            vec![200, 201, 204, 301, 302, 400, 401, 403, 404, 500, 502, 503];
+
         for code in valid_codes {
             assert!(code >= 100);
             assert!(code < 600);
@@ -117,7 +124,7 @@ mod cert_tests {
     fn test_key_pair_generation() {
         let key_pair = KeyPair::generate().unwrap();
         let pem = key_pair.serialize_pem();
-        
+
         assert!(!pem.is_empty());
         assert!(pem.contains("BEGIN PRIVATE KEY"));
         assert!(pem.contains("END PRIVATE KEY"));
@@ -129,7 +136,9 @@ mod cert_tests {
         let mut params = CertificateParams::new(vec![domain.to_string()]).unwrap();
         params.distinguished_name = DistinguishedName::new();
         params.distinguished_name.push(DnType::CommonName, domain);
-        params.distinguished_name.push(DnType::OrganizationName, "Test Org");
+        params
+            .distinguished_name
+            .push(DnType::OrganizationName, "Test Org");
 
         // Verify params were set correctly
         assert!(!params.subject_alt_names.is_empty());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes failing **Rust CI** workflow on `main` after merge of PR #19.

## Root cause

| Step | Status before fix |
|------|-------------------|
| `cargo fmt --check` | Failed — code not formatted |
| `cargo clippy -D warnings` | Failed — dead_code in metrics, too_many_arguments in cache-indexer |
| `cargo build` / `cargo test` | Passed |

## Changes

- `cargo fmt --all` across workspace
- Wire `request_size_bytes` metric via `RequestMetricsGuard::finish`
- `#[allow(dead_code)]` on reserved metrics helpers
- `#[allow(clippy::too_many_arguments)]` on `Indexer::new`

## Verification

All CI steps pass locally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

