### PR TITLE
feat(proxy): integrate proxy authentication into runtime

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       - HTTP_PORT=1488
       - METRICS_PORT=9090
       - MITM_ENABLED=true
+      - AUTH_ENABLED=false
       - SHUTDOWN_TIMEOUT_SECONDS=30
       - RUST_LOG=info,bsdm_proxy=debug
       - RUST_BACKTRACE=1

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -40,7 +40,7 @@ regex = "1.12"
 reqwest = { version = "0.13", features = ["json"] }
 
 [features]
-default = []
+default = ["auth-basic"]
 auth-basic = []
 auth-ldap = ["ldap3"]
 auth-ntlm = []  # NTLM support - TODO: implement with windows-sys or custom

--- a/proxy/src/auth_config.rs
+++ b/proxy/src/auth_config.rs
@@ -1,0 +1,127 @@
+//! Load authentication configuration from environment variables.
+
+use bsdm_proxy::{AuthBackend, AuthConfig};
+use std::time::Duration;
+use tracing::warn;
+
+#[cfg(feature = "auth-ldap")]
+use bsdm_proxy::LdapConfig;
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+fn parse_backend(value: &str) -> AuthBackend {
+    match value.to_ascii_lowercase().as_str() {
+        "ldap" => {
+            #[cfg(feature = "auth-ldap")]
+            {
+                return AuthBackend::Ldap;
+            }
+            #[cfg(not(feature = "auth-ldap"))]
+            {
+                warn!(
+                    "AUTH_BACKEND=ldap but proxy was built without auth-ldap feature, using basic"
+                );
+            }
+        }
+        "ntlm" => {
+            #[cfg(feature = "auth-ntlm")]
+            {
+                return AuthBackend::Ntlm;
+            }
+            #[cfg(not(feature = "auth-ntlm"))]
+            {
+                warn!(
+                    "AUTH_BACKEND=ntlm but proxy was built without auth-ntlm feature, using basic"
+                );
+            }
+        }
+        _ => {}
+    }
+    AuthBackend::Basic
+}
+
+#[cfg(feature = "auth-ldap")]
+fn load_ldap_config(enabled: bool, backend: AuthBackend) -> Option<LdapConfig> {
+    if !enabled || backend != AuthBackend::Ldap {
+        return None;
+    }
+
+    let servers = std::env::var("LDAP_SERVERS")
+        .unwrap_or_else(|_| "ldap://localhost:389".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
+    let timeout_secs = std::env::var("LDAP_TIMEOUT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+
+    Some(LdapConfig {
+        servers,
+        base_dn: std::env::var("LDAP_BASE_DN").unwrap_or_else(|_| "dc=example,dc=com".to_string()),
+        bind_dn: std::env::var("LDAP_BIND_DN").ok(),
+        bind_password: std::env::var("LDAP_BIND_PASSWORD").ok(),
+        user_filter: std::env::var("LDAP_USER_FILTER")
+            .unwrap_or_else(|_| "(sAMAccountName={username})".to_string()),
+        group_filter: std::env::var("LDAP_GROUP_FILTER")
+            .ok()
+            .or_else(|| Some("(member={user_dn})".to_string())),
+        timeout: Duration::from_secs(timeout_secs),
+        use_tls: env_flag("LDAP_USE_TLS"),
+    })
+}
+
+pub fn load_auth_config() -> AuthConfig {
+    let enabled = env_flag("AUTH_ENABLED");
+    let backend = std::env::var("AUTH_BACKEND")
+        .map(|v| parse_backend(&v))
+        .unwrap_or(AuthBackend::Basic);
+
+    let realm = std::env::var("AUTH_REALM").unwrap_or_else(|_| "BSDM-Proxy".to_string());
+    let cache_ttl_secs = std::env::var("AUTH_CACHE_TTL")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(300);
+
+    AuthConfig {
+        enabled,
+        backend,
+        realm,
+        cache_ttl: Duration::from_secs(cache_ttl_secs),
+        #[cfg(feature = "auth-ldap")]
+        ldap: load_ldap_config(enabled, backend),
+        #[cfg(feature = "auth-ntlm")]
+        ntlm: {
+            use bsdm_proxy::NtlmConfig;
+            if enabled && backend == AuthBackend::Ntlm {
+                Some(NtlmConfig {
+                    domain: std::env::var("NTLM_DOMAIN")
+                        .unwrap_or_else(|_| "WORKGROUP".to_string()),
+                    workstation: std::env::var("NTLM_WORKSTATION").ok(),
+                })
+            } else {
+                None
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_auth_disabled() {
+        std::env::remove_var("AUTH_ENABLED");
+        let config = load_auth_config();
+        assert!(!config.enabled);
+        assert_eq!(config.backend, AuthBackend::Basic);
+    }
+}

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,8 +1,11 @@
+mod auth_config;
 mod metrics;
 mod tls;
 
+use auth_config::load_auth_config;
 use base64::engine::general_purpose;
 use base64::Engine;
+use bsdm_proxy::{AuthManager, UserInfo};
 use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION};
@@ -126,6 +129,7 @@ struct ProxyService {
     >,
     metrics: Arc<Metrics>,
     mitm_enabled: bool,
+    auth: Option<Arc<AuthManager>>,
 }
 
 impl ProxyService {
@@ -135,6 +139,7 @@ impl ProxyService {
         kafka_brokers: Option<String>,
         metrics: Arc<Metrics>,
         mitm_enabled: bool,
+        auth: Option<Arc<AuthManager>>,
     ) -> Self {
         let kafka_producer = kafka_brokers.and_then(|brokers| {
             ClientConfig::new()
@@ -171,7 +176,41 @@ impl ProxyService {
             http_client,
             metrics,
             mitm_enabled,
+            auth,
         }
+    }
+
+    async fn authenticate_proxy(
+        &self,
+        req: &Request<Incoming>,
+    ) -> Result<Option<Arc<UserInfo>>, Response<Body>> {
+        let Some(auth) = &self.auth else {
+            return Ok(None);
+        };
+        if !auth.is_enabled() {
+            return Ok(None);
+        }
+
+        let Some((username, password)) = auth.extract_credentials(req) else {
+            debug!("Proxy authentication required, credentials missing");
+            return Err(auth.create_auth_required_response());
+        };
+
+        match auth.authenticate(&username, &password).await {
+            Ok(user) => Ok(Some(Arc::new(user))),
+            Err(e) => {
+                warn!("Proxy authentication failed for {}: {}", username, e);
+                Err(auth.create_auth_required_response())
+            }
+        }
+    }
+
+    fn user_fields(user: Option<&UserInfo>) -> (Option<String>, Option<String>) {
+        user.map(|u| {
+            let name = u.username.clone();
+            (Some(name.clone()), Some(name))
+        })
+        .unwrap_or((None, None))
     }
 
     #[inline]
@@ -254,13 +293,22 @@ impl ProxyService {
         }
     }
 
-    async fn handle_request(&self, req: Request<Incoming>, client_ip: String) -> Response<Body> {
+    async fn handle_request(
+        &self,
+        req: Request<Incoming>,
+        client_ip: String,
+        proxy_user: Option<Arc<UserInfo>>,
+    ) -> Response<Body> {
         let mut guard = RequestMetricsGuard::new(self.metrics.clone(), req.method().to_string());
         let request_start = Instant::now();
         let method = req.method().to_string();
         let uri = req.uri().clone();
         let url = uri.to_string();
-        let (user_id, username) = Self::extract_user_info(&req);
+        let (user_id, username) = if let Some(user) = proxy_user.as_deref() {
+            Self::user_fields(Some(user))
+        } else {
+            Self::extract_user_info(&req)
+        };
         let cache_key = self.generate_cache_key(&method, &url);
 
         // Cache lookup with timing
@@ -691,12 +739,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_body_size,
     };
 
+    let auth_config = load_auth_config();
+    let auth = if auth_config.enabled {
+        Some(Arc::new(AuthManager::new(auth_config.clone())))
+    } else {
+        None
+    };
+
     let service = Arc::new(ProxyService::new(
         cert_cache,
         cache_config.clone(),
         kafka_brokers,
         metrics.clone(),
         mitm_enabled,
+        auth,
     ));
 
     let http_port = std::env::var("HTTP_PORT")
@@ -710,6 +766,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "🔐 MITM: {} (ports 443/8443)",
         if mitm_enabled { "enabled" } else { "disabled" }
     );
+    if auth_config.enabled {
+        info!(
+            "👤 Proxy auth: enabled (backend={}, realm={})",
+            auth_config.backend, auth_config.realm
+        );
+    } else {
+        info!("👤 Proxy auth: disabled");
+    }
     info!(
         "📦 Cache: {} entries, TTL: {:?}, max body: {}MB",
         service.http_cache.capacity(),
@@ -746,6 +810,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
+
+    if let Some(auth_manager) = service.auth.clone() {
+        let mut auth_shutdown_rx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => auth_manager.cleanup_cache().await,
+                    changed = auth_shutdown_rx.changed() => {
+                        if changed.is_ok() && *auth_shutdown_rx.borrow() {
+                            debug!("Auth cache cleanup stopped");
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
 
     loop {
         tokio::select! {
@@ -807,6 +889,7 @@ async fn handle_connect_tunnel(
     service: Arc<ProxyService>,
     client_ip: String,
     request_start: Instant,
+    proxy_user: Option<Arc<UserInfo>>,
 ) {
     let mut client_io = TokioIo::new(upgraded);
 
@@ -820,6 +903,7 @@ async fn handle_connect_tunnel(
                     service.metrics.upstream_connections_active.dec();
                     let duration_ms = request_start.elapsed().as_millis() as u64;
                     let domain = parse_authority(&authority).0;
+                    let (user_id, username) = ProxyService::user_fields(proxy_user.as_deref());
 
                     if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)
                     {
@@ -833,8 +917,8 @@ async fn handle_connect_tunnel(
                             cache_status: "BYPASS",
                             timestamp: timestamp.as_secs(),
                             headers: HashMap::new(),
-                            user_id: None,
-                            username: None,
+                            user_id,
+                            username,
                             client_ip,
                             domain,
                             response_size: bytes_u2c,
@@ -868,6 +952,7 @@ async fn handle_connect_mitm(
     authority: String,
     service: Arc<ProxyService>,
     client_ip: String,
+    proxy_user: Option<Arc<UserInfo>>,
 ) {
     let (domain, _port) = parse_authority(&authority);
 
@@ -907,6 +992,7 @@ async fn handle_connect_mitm(
         let service = service.clone();
         let client_ip = client_ip.clone();
         let authority = authority.clone();
+        let proxy_user = proxy_user.clone();
 
         async move {
             let req = match rewrite_mitm_request(req, &authority) {
@@ -919,7 +1005,7 @@ async fn handle_connect_mitm(
                 }
             };
 
-            Ok::<_, Infallible>(service.handle_request(req, client_ip).await)
+            Ok::<_, Infallible>(service.handle_request(req, client_ip, proxy_user).await)
         }
     });
 
@@ -961,17 +1047,25 @@ async fn handle_connection(
                     }
                 };
 
+                let proxy_user = match service.authenticate_proxy(&req).await {
+                    Ok(user) => user,
+                    Err(resp) => return Ok(resp),
+                };
+
                 tasks.spawn({
                     let service = service.clone();
                     let client_ip = client_ip.clone();
                     let authority = authority.clone();
+                    let proxy_user = proxy_user.clone();
                     async move {
                         match hyper::upgrade::on(req).await {
                             Ok(upgraded) => {
                                 let (_, port) = parse_authority(&authority);
                                 if service.mitm_enabled && should_mitm_port(port) {
-                                    handle_connect_mitm(upgraded, authority, service, client_ip)
-                                        .await;
+                                    handle_connect_mitm(
+                                        upgraded, authority, service, client_ip, proxy_user,
+                                    )
+                                    .await;
                                 } else {
                                     handle_connect_tunnel(
                                         upgraded,
@@ -979,6 +1073,7 @@ async fn handle_connection(
                                         service,
                                         client_ip,
                                         request_start,
+                                        proxy_user,
                                     )
                                     .await;
                                 }
@@ -1000,7 +1095,12 @@ async fn handle_connection(
                 return Ok::<_, Infallible>(response);
             }
 
-            Ok::<_, Infallible>(service.handle_request(req, client_ip).await)
+            let proxy_user = match service.authenticate_proxy(&req).await {
+                Ok(user) => user,
+                Err(resp) => return Ok(resp),
+            };
+
+            Ok::<_, Infallible>(service.handle_request(req, client_ip, proxy_user).await)
         }
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates the existing `auth` module into the proxy runtime (roadmap v2.1).

## Behavior

When `AUTH_ENABLED=true`:

1. Clients must send **Proxy-Authorization** on HTTP and CONNECT requests
2. Invalid/missing credentials → **407 Proxy Authentication Required**
3. Successful auth → `username` propagated to Kafka events
4. MITM sessions inherit the user authenticated at CONNECT time
5. Auth cache cleaned every 60 seconds

When `AUTH_ENABLED=false` (default in docker-compose): no change to current behavior.

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `AUTH_ENABLED` | `false` | Enable proxy authentication |
| `AUTH_BACKEND` | `basic` | `basic`, `ldap` (needs feature), `ntlm` (needs feature) |
| `AUTH_REALM` | `BSDM-Proxy` | Realm in 407 response |
| `AUTH_CACHE_TTL` | `300` | Auth cache TTL (seconds) |

LDAP variables: `LDAP_SERVERS`, `LDAP_BASE_DN`, `LDAP_BIND_DN`, `LDAP_BIND_PASSWORD`, etc. (see `docs/authentication.md`).

Build with LDAP: `cargo build -p bsdm-proxy --features auth-ldap`

## Testing

```bash
# Enable basic auth
AUTH_ENABLED=true AUTH_BACKEND=basic ./target/debug/proxy

# Without credentials → 407
curl -x http://localhost:1488 http://httpbin.org/get

# With credentials → 200
curl -x http://localhost:1488 -U user:pass http://httpbin.org/get
```

```
cargo test -p bsdm-proxy
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

