### PR TITLE
test(e2e): add smoke and E2E test harness

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,74 @@
+name: E2E and Smoke Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  smoke:
+    name: Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libssl-dev \
+            pkg-config \
+            cmake \
+            librdkafka-dev \
+            libclang-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build proxy binary
+        run: cargo build -p bsdm-proxy --bin proxy
+
+      - name: Run smoke tests
+        run: cargo test -p bsdm-proxy-e2e --test smoke
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libssl-dev \
+            pkg-config \
+            cmake \
+            librdkafka-dev \
+            libclang-dev
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build proxy binary
+        run: cargo build -p bsdm-proxy --bin proxy
+
+      - name: Run E2E tests
+        run: cargo test -p bsdm-proxy-e2e --test e2e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "proxy",
     "cache-indexer",
+    "e2e",
 ]
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 FROM alpine:3.21 AS proxy
 RUN apk add --no-cache \
     ca-certificates \
-    libgcc
+    libgcc \
+    wget
 
 # Копируем скомпилированный бинарник
 COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/proxy /usr/local/bin/proxy

--- a/config/acl-rules.test.json
+++ b/config/acl-rules.test.json
@@ -1,0 +1,15 @@
+{
+  "default_action": "allow",
+  "rules": [
+    {
+      "id": "block-test-domain",
+      "name": "Block test domain for E2E",
+      "enabled": true,
+      "priority": 100,
+      "action": "deny",
+      "rule_type": {
+        "Domain": "blocked.test"
+      }
+    }
+  ]
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,36 @@
+# Minimal stack for manual / Docker-based smoke and E2E runs.
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml up -d --build
+#   ./scripts/run-smoke-tests.sh --external
+#   docker compose -f docker-compose.test.yml down
+
+services:
+  upstream:
+    image: kennethreitz/httpbin:latest
+  proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    ports:
+      - "1488:1488"
+      - "9090:9090"
+    environment:
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - RUST_LOG=warn
+    volumes:
+      - ./certs:/certs:ro
+      - ./config/acl-rules.test.json:/etc/bsdm-proxy/acl-rules.json:ro
+    depends_on:
+      - upstream
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bsdm-proxy-e2e"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+base64 = "0.22"
+bytes = { workspace = true }
+http-body-util = "0.1"
+hyper = { version = "1.10", features = ["server", "http1", "client"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+rcgen = { version = "0.14", features = ["x509-parser"] }
+reqwest = { version = "0.13", features = ["json"] }
+serde_json = "1"
+tokio = { workspace = true }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,0 +1,349 @@
+//! Shared harness for BSDM-Proxy smoke and E2E tests.
+
+use anyhow::{bail, Context, Result};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose,
+};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::process::Child as TokioChild;
+
+#[derive(Clone, Debug, Default)]
+pub struct HarnessConfig {
+    pub auth_enabled: bool,
+    pub acl_enabled: bool,
+    pub acl_rules_path: Option<PathBuf>,
+    pub categorization_enabled: bool,
+    pub mitm_enabled: bool,
+    pub kafka_brokers: Option<String>,
+}
+
+pub struct ProxyHarness {
+    pub proxy_port: u16,
+    pub metrics_port: u16,
+    pub upstream_port: u16,
+    proxy_process: TokioChild,
+    _upstream_task: tokio::task::JoinHandle<()>,
+}
+
+static HARNESS_LOCK: AtomicUsize = AtomicUsize::new(0);
+
+/// Serialize proxy process startup to avoid port/cert races between tests.
+pub async fn proxy_test_guard() -> ProxyTestGuard {
+    while HARNESS_LOCK
+        .compare_exchange(0, 1, Ordering::Acquire, Ordering::Relaxed)
+        .is_err()
+    {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    ProxyTestGuard
+}
+
+pub struct ProxyTestGuard;
+
+impl Drop for ProxyTestGuard {
+    fn drop(&mut self) {
+        HARNESS_LOCK.store(0, Ordering::Release);
+    }
+}
+
+impl ProxyHarness {
+    pub async fn start(config: HarnessConfig) -> Result<Self> {
+        let proxy_bin = proxy_binary()?;
+        let upstream_task = spawn_mock_upstream().await?;
+        let upstream_port = upstream_task.port;
+        let proxy_port = reserve_port()?;
+        let metrics_port = reserve_port()?;
+
+        let workspace = workspace_path("");
+        write_test_ca(&workspace.join("certs"))?;
+
+        let acl_rules_path = config
+            .acl_rules_path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
+
+        let mut command = Command::new(&proxy_bin);
+        command
+            .current_dir(&workspace)
+            .env("HTTP_PORT", proxy_port.to_string())
+            .env("METRICS_PORT", metrics_port.to_string())
+            .env("MITM_ENABLED", bool_env(config.mitm_enabled))
+            .env("AUTH_ENABLED", bool_env(config.auth_enabled))
+            .env("ACL_ENABLED", bool_env(config.acl_enabled))
+            .env("ACL_DEFAULT_ACTION", "allow")
+            .env(
+                "CATEGORIZATION_ENABLED",
+                bool_env(config.categorization_enabled),
+            )
+            .env("RUST_LOG", "warn")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        if let Some(path) = &acl_rules_path {
+            command.env("ACL_RULES_PATH", path);
+        }
+        if let Some(brokers) = &config.kafka_brokers {
+            command.env("KAFKA_BROKERS", brokers);
+        }
+
+        let proxy_process = tokio::process::Command::from(command)
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| format!("spawn proxy binary at {}", proxy_bin.display()))?;
+
+        wait_for_health(metrics_port, Duration::from_secs(20)).await?;
+
+        Ok(Self {
+            proxy_port,
+            metrics_port,
+            upstream_port,
+            proxy_process,
+            _upstream_task: upstream_task.handle,
+        })
+    }
+
+    pub fn metrics_url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.metrics_port, path)
+    }
+
+    pub fn upstream_url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{}", self.upstream_port, path)
+    }
+
+    pub fn proxy_client(&self) -> Result<reqwest::Client> {
+        let proxy = reqwest::Proxy::http(format!("http://127.0.0.1:{}", self.proxy_port))?;
+        reqwest::Client::builder()
+            .proxy(proxy)
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("build proxied HTTP client")
+    }
+
+    pub fn proxy_auth_client(&self, username: &str, password: &str) -> Result<reqwest::Client> {
+        let token = STANDARD.encode(format!("{username}:{password}"));
+        let proxy = reqwest::Proxy::http(format!("http://127.0.0.1:{}", self.proxy_port))?;
+        reqwest::Client::builder()
+            .proxy(proxy)
+            .default_headers({
+                let mut headers = reqwest::header::HeaderMap::new();
+                headers.insert(
+                    reqwest::header::PROXY_AUTHORIZATION,
+                    format!("Basic {token}").parse().unwrap(),
+                );
+                headers
+            })
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("build authenticated proxied HTTP client")
+    }
+}
+
+impl Drop for ProxyHarness {
+    fn drop(&mut self) {
+        let _ = self.proxy_process.start_kill();
+    }
+}
+
+pub fn proxy_binary() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("BSDM_PROXY_BIN") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Ok(path);
+        }
+        bail!("BSDM_PROXY_BIN points to missing file: {}", path.display());
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_proxy") {
+        return Ok(PathBuf::from(path));
+    }
+
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for profile in ["debug", "release"] {
+        let path = manifest
+            .join("..")
+            .join("target")
+            .join(profile)
+            .join("proxy");
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+
+    bail!("proxy binary not found; run `cargo build -p bsdm-proxy --bin proxy` first")
+}
+
+pub fn workspace_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join(relative)
+}
+
+pub async fn wait_for_health(metrics_port: u16, timeout: Duration) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()?;
+    let url = format!("http://127.0.0.1:{metrics_port}/health");
+    let deadline = Instant::now() + timeout;
+
+    loop {
+        if let Ok(resp) = client.get(&url).send().await {
+            if resp.status().is_success() {
+                return Ok(());
+            }
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for proxy health at {url}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+struct UpstreamServer {
+    port: u16,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+async fn spawn_mock_upstream() -> Result<UpstreamServer> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind mock upstream")?;
+    let port = listener.local_addr()?.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let io = TokioIo::new(stream);
+                let service = service_fn(|req: Request<Incoming>| async move {
+                    let path = req.uri().path();
+                    let body = format!("upstream:{path}");
+                    Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(body))))
+                });
+                let _ = http1::Builder::new().serve_connection(io, service).await;
+            });
+        }
+    });
+
+    Ok(UpstreamServer { port, handle })
+}
+
+pub async fn spawn_tcp_echo_server() -> Result<(u16, tokio::task::JoinHandle<()>)> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind tcp echo server")?;
+    let port = listener.local_addr()?.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = [0u8; 1024];
+                while let Ok(n) = stream.read(&mut buf).await {
+                    if n == 0 {
+                        break;
+                    }
+                    if stream.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+    });
+
+    Ok((port, handle))
+}
+
+pub async fn connect_via_proxy(proxy_port: u16, target: SocketAddr) -> Result<String> {
+    let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}"))
+        .await
+        .context("connect to proxy")?;
+
+    let request = format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .await
+        .context("write CONNECT request")?;
+
+    let mut response = vec![0u8; 1024];
+    let n = stream
+        .read(&mut response)
+        .await
+        .context("read CONNECT response")?;
+    let response_text = String::from_utf8_lossy(&response[..n]).to_string();
+
+    if !response_text.starts_with("HTTP/1.1 200") && !response_text.starts_with("HTTP/1.0 200") {
+        bail!("unexpected CONNECT response: {response_text}");
+    }
+
+    stream
+        .write_all(b"ping")
+        .await
+        .context("write tunneled payload")?;
+
+    let mut payload = [0u8; 16];
+    let n = stream
+        .read(&mut payload)
+        .await
+        .context("read tunneled echo")?;
+
+    Ok(String::from_utf8_lossy(&payload[..n]).to_string())
+}
+
+fn reserve_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").context("reserve port")?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn bool_env(value: bool) -> &'static str {
+    if value {
+        "true"
+    } else {
+        "false"
+    }
+}
+
+fn write_test_ca(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir).context("create certs dir")?;
+    let key_pair = KeyPair::generate().context("generate CA key")?;
+    let mut params =
+        CertificateParams::new(vec!["BSDM Test CA".to_string()]).context("create CA params")?;
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "BSDM Test CA");
+
+    let cert = params
+        .self_signed(&key_pair)
+        .context("self-sign test CA cert")?;
+
+    let key_pem = key_pair.serialize_pem();
+    let cert_pem = cert.pem();
+
+    std::fs::write(dir.join("ca.key"), &key_pem)?;
+    std::fs::write(dir.join("ca.crt"), &cert_pem)?;
+
+    Ok(())
+}

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1,0 +1,162 @@
+//! End-to-end tests — auth, ACL, cache, CONNECT tunnel.
+
+use bsdm_proxy_e2e::{
+    connect_via_proxy, proxy_test_guard, workspace_path, HarnessConfig, ProxyHarness,
+};
+use std::net::SocketAddr;
+
+#[tokio::test]
+async fn e2e_cache_hit_on_repeat_request() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig::default())
+        .await
+        .expect("start proxy");
+
+    let client = harness.proxy_client().expect("proxy client");
+    let url = harness.upstream_url("/cache-me");
+
+    let first = client
+        .get(&url)
+        .send()
+        .await
+        .expect("first GET")
+        .headers()
+        .get("x-cache-status")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+
+    assert_ne!(first.as_deref(), Some("HIT"));
+
+    let second = client.get(&url).send().await.expect("second GET");
+
+    assert_eq!(
+        second
+            .headers()
+            .get("x-cache-status")
+            .and_then(|v| v.to_str().ok()),
+        Some("HIT")
+    );
+}
+
+#[tokio::test]
+async fn e2e_auth_requires_proxy_authorization() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        auth_enabled: true,
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let url = harness.upstream_url("/protected");
+    let unauth = harness
+        .proxy_client()
+        .expect("proxy client")
+        .get(&url)
+        .send()
+        .await
+        .expect("unauthenticated request");
+
+    assert_eq!(
+        unauth.status(),
+        reqwest::StatusCode::PROXY_AUTHENTICATION_REQUIRED
+    );
+
+    let authed = harness
+        .proxy_auth_client("alice", "secret")
+        .expect("auth client")
+        .get(&url)
+        .send()
+        .await
+        .expect("authenticated request");
+
+    assert_eq!(authed.status(), reqwest::StatusCode::OK);
+    assert_eq!(authed.text().await.expect("body"), "upstream:/protected");
+}
+
+#[tokio::test]
+async fn e2e_acl_denies_blocked_domain() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        acl_enabled: true,
+        acl_rules_path: Some(workspace_path("config/acl-rules.test.json")),
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let client = harness.proxy_client().expect("proxy client");
+    let blocked_url = "http://blocked.test/forbidden";
+
+    let response = client
+        .get(blocked_url)
+        .send()
+        .await
+        .expect("blocked request");
+
+    assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn e2e_acl_allows_non_blocked_domain() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        acl_enabled: true,
+        acl_rules_path: Some(workspace_path("config/acl-rules.test.json")),
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let client = harness.proxy_client().expect("proxy client");
+    let url = harness.upstream_url("/allowed");
+
+    let response = client.get(&url).send().await.expect("allowed request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn e2e_connect_tunnel_establishes_tcp_path() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        mitm_enabled: false,
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let (echo_port, _echo_task) = bsdm_proxy_e2e::spawn_tcp_echo_server()
+        .await
+        .expect("echo server");
+    let target = SocketAddr::from(([127, 0, 0, 1], echo_port));
+
+    let echoed = connect_via_proxy(harness.proxy_port, target)
+        .await
+        .expect("CONNECT tunnel");
+
+    assert_eq!(echoed, "ping");
+}
+
+#[tokio::test]
+async fn e2e_auth_and_acl_combined() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        auth_enabled: true,
+        acl_enabled: true,
+        acl_rules_path: Some(workspace_path("config/acl-rules.test.json")),
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let blocked_url = "http://blocked.test/combined";
+    let authed = harness
+        .proxy_auth_client("bob", "pass")
+        .expect("auth client")
+        .get(blocked_url)
+        .send()
+        .await
+        .expect("authenticated blocked request");
+
+    assert_eq!(authed.status(), reqwest::StatusCode::FORBIDDEN);
+}

--- a/e2e/tests/smoke.rs
+++ b/e2e/tests/smoke.rs
@@ -1,0 +1,93 @@
+//! Smoke tests — fast critical-path checks against a live proxy process.
+
+use bsdm_proxy_e2e::{proxy_test_guard, HarnessConfig, ProxyHarness};
+
+#[tokio::test]
+async fn smoke_health_endpoint() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig::default())
+        .await
+        .expect("start proxy");
+
+    let client = reqwest::Client::new();
+    let health: serde_json::Value = client
+        .get(harness.metrics_url("/health"))
+        .send()
+        .await
+        .expect("health request")
+        .json()
+        .await
+        .expect("health json");
+
+    assert_eq!(health["status"], "ok");
+
+    let ready: serde_json::Value = client
+        .get(harness.metrics_url("/ready"))
+        .send()
+        .await
+        .expect("ready request")
+        .json()
+        .await
+        .expect("ready json");
+
+    assert_eq!(ready["status"], "ready");
+}
+
+#[tokio::test]
+async fn smoke_metrics_endpoint() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig::default())
+        .await
+        .expect("start proxy");
+
+    let body = reqwest::Client::new()
+        .get(harness.metrics_url("/metrics"))
+        .send()
+        .await
+        .expect("metrics request")
+        .text()
+        .await
+        .expect("metrics body");
+
+    assert!(body.contains("bsdm_proxy_requests_in_flight"));
+    assert!(body.contains("bsdm_proxy_cache_entries"));
+}
+
+#[tokio::test]
+async fn smoke_proxy_forwards_http() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig::default())
+        .await
+        .expect("start proxy");
+
+    let client = harness.proxy_client().expect("proxy client");
+    let url = harness.upstream_url("/smoke");
+
+    let body = client
+        .get(&url)
+        .send()
+        .await
+        .expect("proxied GET")
+        .text()
+        .await
+        .expect("response body");
+
+    assert_eq!(body, "upstream:/smoke");
+}
+
+#[tokio::test]
+async fn smoke_unknown_metrics_route_returns_404() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig::default())
+        .await
+        .expect("start proxy");
+
+    let status = reqwest::Client::new()
+        .get(harness.metrics_url("/unknown-route"))
+        .send()
+        .await
+        .expect("unknown route request")
+        .status();
+
+    assert_eq!(status, reqwest::StatusCode::NOT_FOUND);
+}

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -609,16 +609,18 @@ async fn metrics_server(
     metrics: Arc<Metrics>,
     draining: Arc<AtomicBool>,
     mut shutdown_rx: watch::Receiver<bool>,
+    metrics_port: u16,
 ) {
-    let listener = match TcpListener::bind("0.0.0.0:9090").await {
+    let bind_addr = format!("0.0.0.0:{}", metrics_port);
+    let listener = match TcpListener::bind(&bind_addr).await {
         Ok(l) => l,
         Err(e) => {
-            error!("Failed to bind metrics server: {}", e);
+            error!("Failed to bind metrics server on {}: {}", bind_addr, e);
             return;
         }
     };
 
-    info!("📊 Metrics server started on 0.0.0.0:9090");
+    info!("📊 Metrics server started on {}", bind_addr);
 
     loop {
         tokio::select! {
@@ -810,10 +812,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(30);
     let shutdown_timeout = Duration::from_secs(shutdown_timeout_secs);
 
+    let metrics_port = std::env::var("METRICS_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9090);
+
     tokio::spawn(metrics_server(
         metrics.clone(),
         draining.clone(),
         shutdown_rx.clone(),
+        metrics_port,
     ));
 
     let ca_key = tokio::fs::read("/certs/ca.key").await.or_else(|_| {

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+EXTERNAL=false
+if [[ "${1:-}" == "--external" ]]; then
+  EXTERNAL=true
+fi
+
+if [[ "$EXTERNAL" == "false" ]]; then
+  echo "Building proxy binary..."
+  cargo build -p bsdm-proxy --bin proxy
+  echo "Running in-process E2E tests..."
+  cargo test -p bsdm-proxy-e2e --test e2e -- --nocapture
+else
+  echo "Running E2E checks against docker-compose.test.yml stack..."
+  PROXY_URL="${PROXY_URL:-http://127.0.0.1:1488}"
+  METRICS_URL="${METRICS_URL:-http://127.0.0.1:9090}"
+
+  curl -fsS "${METRICS_URL}/health" | grep -q '"status":"ok"'
+
+  # Cache HIT: repeat request and look for x-cache-status header.
+  TARGET="https://httpbin.org/cache/200"
+  curl -fsSI -x "${PROXY_URL}" "${TARGET}" | tee /tmp/e2e-first.headers >/dev/null
+  curl -fsSI -x "${PROXY_URL}" "${TARGET}" | tee /tmp/e2e-second.headers >/dev/null
+  grep -qi 'x-cache-status: HIT' /tmp/e2e-second.headers
+
+  echo "External E2E checks passed."
+fi

--- a/scripts/run-smoke-tests.sh
+++ b/scripts/run-smoke-tests.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+EXTERNAL=false
+if [[ "${1:-}" == "--external" ]]; then
+  EXTERNAL=true
+fi
+
+if [[ "$EXTERNAL" == "false" ]]; then
+  echo "Building proxy binary..."
+  cargo build -p bsdm-proxy --bin proxy
+  echo "Running in-process smoke tests..."
+  cargo test -p bsdm-proxy-e2e --test smoke -- --nocapture
+else
+  echo "Running smoke tests against docker-compose.test.yml stack..."
+  PROXY_URL="${PROXY_URL:-http://127.0.0.1:1488}"
+  METRICS_URL="${METRICS_URL:-http://127.0.0.1:9090}"
+
+  curl -fsS "${METRICS_URL}/health" | grep -q '"status":"ok"'
+  curl -fsS "${METRICS_URL}/ready" | grep -q '"status":"ready"'
+  curl -fsS "${METRICS_URL}/metrics" | grep -q 'bsdm_proxy_requests_total'
+
+  # Forward through proxy to public endpoint (no local upstream in external mode).
+  curl -fsS -x "${PROXY_URL}" https://httpbin.org/status/200 >/dev/null
+  echo "External smoke checks passed."
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated smoke and E2E tests that run the real `proxy` binary against a mock upstream — no full Docker stack required for CI.

## Test layout

| Suite | File | What it checks |
|-------|------|----------------|
| **Smoke** (4 tests, ~2s) | `e2e/tests/smoke.rs` | `/health`, `/ready`, `/metrics`, HTTP forward, 404 |
| **E2E** (6 tests, ~3s) | `e2e/tests/e2e.rs` | cache HIT, auth 407/200, ACL deny/allow, CONNECT tunnel, auth+ACL |

## Infrastructure

- **`e2e/`** — `bsdm-proxy-e2e` crate with `ProxyHarness` (spawns proxy + mock upstream)
- **`config/acl-rules.test.json`** — ACL fixture for deny tests
- **`docker-compose.test.yml`** — optional stack for manual/external runs
- **`scripts/run-smoke-tests.sh`** / **`run-e2e-tests.sh`** — local runners (`--external` for Docker mode)
- **`.github/workflows/e2e.yml`** — separate CI job for smoke + E2E

## Other changes

- `METRICS_PORT` env var now honored (was documented but hardcoded to 9090)
- `wget` added to proxy Docker image for healthchecks

## Running locally

```bash
cargo build -p bsdm-proxy --bin proxy
cargo test -p bsdm-proxy-e2e --test smoke
cargo test -p bsdm-proxy-e2e --test e2e

# or
./scripts/run-smoke-tests.sh
./scripts/run-e2e-tests.sh
```

## Request pipeline verified (E2E)

```
auth → ACL → cache → upstream
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

