### PR TITLE
test(e2e): trust self-signed CA for MITM upstream TLS

### DIFF
--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -15,6 +15,9 @@ http-body-util = "0.1"
 hyper = { version = "1.10", features = ["server", "http1", "client"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 rcgen = { version = "0.14", features = ["x509-parser"] }
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", features = ["json", "rustls"] }
+rustls = { version = "0.23", features = ["ring"] }
+rustls-pemfile = "2.2"
 serde_json = "1"
 tokio = { workspace = true }
+tokio-rustls = { version = "0.26", features = ["ring"] }

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -11,16 +11,23 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use rcgen::{
-    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose,
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose,
 };
-use std::net::SocketAddr;
+use rustls::pki_types::CertificateDer;
+use rustls::ServerConfig;
+use rustls_pemfile::certs;
+use std::io::Cursor;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::process::Child as TokioChild;
+use tokio_rustls::TlsAcceptor;
 
 #[derive(Clone, Debug, Default)]
 pub struct HarnessConfig {
@@ -29,6 +36,10 @@ pub struct HarnessConfig {
     pub acl_rules_path: Option<PathBuf>,
     pub categorization_enabled: bool,
     pub mitm_enabled: bool,
+    /// When set, spawn HTTPS mock upstream on this port (for MITM tests on 443/8443).
+    pub https_upstream_port: Option<u16>,
+    /// Trust workspace test CA for upstream TLS (sets UPSTREAM_CA_CERT in proxy).
+    pub upstream_ca_cert: bool,
     pub kafka_brokers: Option<String>,
 }
 
@@ -38,6 +49,7 @@ pub struct ProxyHarness {
     pub upstream_port: u16,
     proxy_process: TokioChild,
     _upstream_task: tokio::task::JoinHandle<()>,
+    _stderr_log: Option<PathBuf>,
 }
 
 static HARNESS_LOCK: AtomicUsize = AtomicUsize::new(0);
@@ -64,13 +76,18 @@ impl Drop for ProxyTestGuard {
 impl ProxyHarness {
     pub async fn start(config: HarnessConfig) -> Result<Self> {
         let proxy_bin = proxy_binary()?;
-        let upstream_task = spawn_mock_upstream().await?;
+        let workspace = workspace_path("");
+        ensure_test_ca()?;
+
+        let upstream_task = if let Some(port) = config.https_upstream_port {
+            spawn_mock_https_upstream(port).await?
+        } else {
+            spawn_mock_upstream().await?
+        };
         let upstream_port = upstream_task.port;
+        wait_for_tcp(upstream_port).await?;
         let proxy_port = reserve_port()?;
         let metrics_port = reserve_port()?;
-
-        let workspace = workspace_path("");
-        write_test_ca(&workspace.join("certs"))?;
 
         let acl_rules_path = config
             .acl_rules_path
@@ -90,15 +107,43 @@ impl ProxyHarness {
                 "CATEGORIZATION_ENABLED",
                 bool_env(config.categorization_enabled),
             )
-            .env("RUST_LOG", "warn")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            .env(
+                "RUST_LOG",
+                if config.mitm_enabled {
+                    "info,proxy=debug"
+                } else {
+                    "warn"
+                },
+            );
+
+        if config.upstream_ca_cert {
+            let ca_path = workspace.join("certs/ca.crt");
+            let ca_path = ca_path.canonicalize().unwrap_or(ca_path);
+            command.env(
+                "UPSTREAM_CA_CERT",
+                ca_path.to_string_lossy().into_owned(),
+            );
+        }
 
         if let Some(path) = &acl_rules_path {
             command.env("ACL_RULES_PATH", path);
         }
         if let Some(brokers) = &config.kafka_brokers {
             command.env("KAFKA_BROKERS", brokers);
+        }
+
+        let stderr_log = if config.mitm_enabled {
+            let log_dir = std::env::temp_dir();
+            Some(log_dir.join(format!("bsdm-proxy-{proxy_port}.log")))
+        } else {
+            None
+        };
+
+        if let Some(log_path) = &stderr_log {
+            let log_file = std::fs::File::create(log_path)?;
+            command.stdout(Stdio::null()).stderr(log_file);
+        } else {
+            command.stdout(Stdio::null()).stderr(Stdio::null());
         }
 
         let proxy_process = tokio::process::Command::from(command)
@@ -114,6 +159,7 @@ impl ProxyHarness {
             upstream_port,
             proxy_process,
             _upstream_task: upstream_task.handle,
+            _stderr_log: stderr_log,
         })
     }
 
@@ -151,6 +197,23 @@ impl ProxyHarness {
             .build()
             .context("build authenticated proxied HTTP client")
     }
+
+    /// HTTP client for MITM tests: trusts the workspace test CA (self-signed).
+    pub fn proxy_mitm_client(&self) -> Result<reqwest::Client> {
+        let ca_pem = std::fs::read(test_ca_cert_path()).context("read test CA certificate")?;
+        let ca = reqwest::Certificate::from_pem(&ca_pem).context("parse test CA certificate")?;
+        let proxy = reqwest::Proxy::all(format!("http://127.0.0.1:{}", self.proxy_port))?;
+        reqwest::Client::builder()
+            .add_root_certificate(ca)
+            .proxy(proxy)
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("build MITM proxied HTTPS client")
+    }
+
+    pub fn mitm_upstream_url(&self, path: &str) -> String {
+        format!("https://127.0.0.1:{}{}", self.upstream_port, path)
+    }
 }
 
 impl Drop for ProxyHarness {
@@ -186,6 +249,10 @@ pub fn proxy_binary() -> Result<PathBuf> {
     bail!("proxy binary not found; run `cargo build -p bsdm-proxy --bin proxy` first")
 }
 
+pub fn test_ca_cert_path() -> PathBuf {
+    workspace_path("certs/ca.crt")
+}
+
 pub fn workspace_path(relative: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
@@ -212,8 +279,22 @@ pub async fn wait_for_health(metrics_port: u16, timeout: Duration) -> Result<()>
     }
 }
 
-struct UpstreamServer {
-    port: u16,
+pub async fn wait_for_tcp(port: u16) -> Result<()> {
+    let addr = format!("127.0.0.1:{port}");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for TCP listener at {addr}");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+pub struct UpstreamServer {
+    pub port: u16,
     handle: tokio::task::JoinHandle<()>,
 }
 
@@ -241,6 +322,103 @@ async fn spawn_mock_upstream() -> Result<UpstreamServer> {
     });
 
     Ok(UpstreamServer { port, handle })
+}
+
+pub async fn spawn_mock_https_upstream(port: u16) -> Result<UpstreamServer> {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let ca_dir = workspace_path("certs");
+    let ca_key_pem = std::fs::read_to_string(ca_dir.join("ca.key"))
+        .context("read test CA key for HTTPS upstream")?;
+    let ca_cert_pem = std::fs::read_to_string(ca_dir.join("ca.crt"))
+        .context("read test CA cert for HTTPS upstream")?;
+
+    let ca_key = KeyPair::from_pem(&ca_key_pem).context("parse test CA key")?;
+    let issuer =
+        Issuer::from_ca_cert_pem(&ca_cert_pem, &ca_key).context("create issuer from test CA")?;
+
+    let server_key = KeyPair::generate().context("generate upstream TLS key")?;
+    let mut params =
+        CertificateParams::new(vec!["127.0.0.1".to_string()]).context("upstream cert params")?;
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "127.0.0.1");
+    params.subject_alt_names = vec![rcgen::SanType::IpAddress(IpAddr::V4(
+        Ipv4Addr::LOCALHOST,
+    ))];
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+
+    let cert = params
+        .signed_by(&server_key, &issuer)
+        .context("sign upstream TLS certificate")?;
+    let server_config = build_rustls_server_config(cert.pem(), server_key.serialize_pem())?;
+    let acceptor = TlsAcceptor::from(server_config);
+
+    let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, port))
+        .await
+        .with_context(|| format!("bind HTTPS mock upstream on 127.0.0.1:{port}"))?;
+    let bound_port = listener.local_addr()?.port();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            let acceptor = acceptor.clone();
+            tokio::spawn(async move {
+                let Ok(tls_stream) = acceptor.accept(stream).await else {
+                    return;
+                };
+                let io = TokioIo::new(tls_stream);
+                let service = service_fn(|req: Request<Incoming>| async move {
+                    let path = req.uri().path();
+                    let body = format!("upstream-tls:{path}");
+                    Ok::<_, hyper::Error>(Response::new(Full::new(Bytes::from(body))))
+                });
+                let _ = http1::Builder::new().serve_connection(io, service).await;
+            });
+        }
+    });
+
+    Ok(UpstreamServer {
+        port: bound_port,
+        handle,
+    })
+}
+
+fn build_rustls_server_config(
+    cert_pem: String,
+    key_pem: String,
+) -> Result<Arc<ServerConfig>> {
+    let mut chain: Vec<CertificateDer<'static>> = certs(&mut Cursor::new(cert_pem.as_bytes()))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|cert| cert.into_owned())
+        .collect();
+    let ca_pem = std::fs::read_to_string(test_ca_cert_path())?;
+    chain.extend(
+        certs(&mut Cursor::new(ca_pem.as_bytes()))
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(|cert| cert.into_owned()),
+    );
+
+    let key = rustls_pemfile::private_key(&mut Cursor::new(key_pem.as_bytes()))
+        .context("parse upstream private key")?
+        .ok_or_else(|| anyhow::anyhow!("no private key in upstream PEM"))?;
+
+    let config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(chain, key)
+        .context("build upstream TLS server config")?;
+
+    Ok(Arc::new(config))
 }
 
 pub async fn spawn_tcp_echo_server() -> Result<(u16, tokio::task::JoinHandle<()>)> {
@@ -320,8 +498,16 @@ fn bool_env(value: bool) -> &'static str {
     }
 }
 
+pub fn ensure_test_ca() -> Result<()> {
+    let dir = workspace_path("certs");
+    std::fs::create_dir_all(&dir).context("create certs dir")?;
+    if dir.join("ca.crt").exists() && dir.join("ca.key").exists() {
+        return Ok(());
+    }
+    write_test_ca(&dir)
+}
+
 fn write_test_ca(dir: &Path) -> Result<()> {
-    std::fs::create_dir_all(dir).context("create certs dir")?;
     let key_pair = KeyPair::generate().context("generate CA key")?;
     let mut params =
         CertificateParams::new(vec!["BSDM Test CA".to_string()]).context("create CA params")?;

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -119,10 +119,7 @@ impl ProxyHarness {
         if config.upstream_ca_cert {
             let ca_path = workspace.join("certs/ca.crt");
             let ca_path = ca_path.canonicalize().unwrap_or(ca_path);
-            command.env(
-                "UPSTREAM_CA_CERT",
-                ca_path.to_string_lossy().into_owned(),
-            );
+            command.env("UPSTREAM_CA_CERT", ca_path.to_string_lossy().into_owned());
         }
 
         if let Some(path) = &acl_rules_path {
@@ -346,9 +343,7 @@ pub async fn spawn_mock_https_upstream(port: u16) -> Result<UpstreamServer> {
     params
         .distinguished_name
         .push(DnType::CommonName, "127.0.0.1");
-    params.subject_alt_names = vec![rcgen::SanType::IpAddress(IpAddr::V4(
-        Ipv4Addr::LOCALHOST,
-    ))];
+    params.subject_alt_names = vec![rcgen::SanType::IpAddress(IpAddr::V4(Ipv4Addr::LOCALHOST))];
     params.key_usages = vec![
         KeyUsagePurpose::DigitalSignature,
         KeyUsagePurpose::KeyEncipherment,
@@ -392,10 +387,7 @@ pub async fn spawn_mock_https_upstream(port: u16) -> Result<UpstreamServer> {
     })
 }
 
-fn build_rustls_server_config(
-    cert_pem: String,
-    key_pem: String,
-) -> Result<Arc<ServerConfig>> {
+fn build_rustls_server_config(cert_pem: String, key_pem: String) -> Result<Arc<ServerConfig>> {
     let mut chain: Vec<CertificateDer<'static>> = certs(&mut Cursor::new(cert_pem.as_bytes()))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -1,7 +1,8 @@
 //! End-to-end tests — auth, ACL, cache, CONNECT tunnel.
 
 use bsdm_proxy_e2e::{
-    connect_via_proxy, proxy_test_guard, workspace_path, HarnessConfig, ProxyHarness,
+    connect_via_proxy, ensure_test_ca, proxy_test_guard, spawn_mock_https_upstream,
+    test_ca_cert_path, wait_for_tcp, workspace_path, HarnessConfig, ProxyHarness,
 };
 use std::net::SocketAddr;
 
@@ -159,4 +160,51 @@ async fn e2e_auth_and_acl_combined() {
         .expect("authenticated blocked request");
 
     assert_eq!(authed.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn e2e_upstream_tls_accepts_test_ca() {
+    let _guard = proxy_test_guard().await;
+    ensure_test_ca().expect("write test ca");
+    let upstream = spawn_mock_https_upstream(8443)
+        .await
+        .expect("spawn https upstream");
+    wait_for_tcp(upstream.port).await.expect("wait for upstream");
+
+    let ca_pem = std::fs::read(test_ca_cert_path()).expect("read ca");
+    let client = reqwest::Client::builder()
+        .add_root_certificate(reqwest::Certificate::from_pem(&ca_pem).expect("parse ca"))
+        .build()
+        .expect("client");
+
+    let url = format!("https://127.0.0.1:{}/direct-tls", upstream.port);
+    let response = client.get(&url).send().await.expect("direct tls get");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response.text().await.expect("body"),
+        "upstream-tls:/direct-tls"
+    );
+}
+
+#[tokio::test]
+async fn e2e_mitm_https_with_self_signed_ca() {
+    let _guard = proxy_test_guard().await;
+    let harness = ProxyHarness::start(HarnessConfig {
+        mitm_enabled: true,
+        https_upstream_port: Some(8443),
+        upstream_ca_cert: true,
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy with MITM");
+
+    let client = harness.proxy_mitm_client().expect("MITM client");
+    let url = harness.mitm_upstream_url("/mitm-test");
+
+    let response = client.get(&url).send().await.expect("MITM HTTPS GET");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response.text().await.expect("body"),
+        "upstream-tls:/mitm-test"
+    );
 }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -169,7 +169,9 @@ async fn e2e_upstream_tls_accepts_test_ca() {
     let upstream = spawn_mock_https_upstream(8443)
         .await
         .expect("spawn https upstream");
-    wait_for_tcp(upstream.port).await.expect("wait for upstream");
+    wait_for_tcp(upstream.port)
+        .await
+        .expect("wait for upstream");
 
     let ca_pem = std::fs::read(test_ca_cert_path()).expect("read ca");
     let client = reqwest::Client::builder()

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -13,8 +13,8 @@ use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
-use hyper_util::rt::TokioIo;
 use hyper_rustls::ConfigBuilderExt;
+use hyper_util::rt::TokioIo;
 use metrics::{Metrics, RequestMetricsGuard};
 use policy_config::{load_policy_config, reload_acl_engine, PolicyConfig};
 use quick_cache::sync::Cache;
@@ -166,8 +166,8 @@ impl ProxyService {
 
         let http_cache = Arc::new(Cache::new(cache_config.capacity));
 
-        let https = build_upstream_https_connector()
-            .expect("failed to build upstream HTTPS connector");
+        let https =
+            build_upstream_https_connector().expect("failed to build upstream HTTPS connector");
 
         let http_client =
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
@@ -604,21 +604,19 @@ impl ProxyService {
     }
 }
 
-fn build_upstream_https_connector(
-) -> Result<
+fn build_upstream_https_connector() -> Result<
     hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
     Box<dyn std::error::Error>,
 > {
     let tls_config = if let Ok(path) = std::env::var("UPSTREAM_CA_CERT") {
         let pem = std::fs::read(&path)
             .map_err(|e| format!("failed to read UPSTREAM_CA_CERT {path}: {e}"))?;
-        let certs: Vec<rustls::pki_types::CertificateDer<'static>> = rustls_pemfile::certs(
-            &mut Cursor::new(pem),
-        )
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .map(|cert| cert.into_owned())
-        .collect();
+        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+            rustls_pemfile::certs(&mut Cursor::new(pem))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .map(|cert| cert.into_owned())
+                .collect();
         let mut roots = rustls::RootCertStore::empty();
         roots.add_parsable_certificates(certs);
         info!("Upstream TLS: trusting custom CA from UPSTREAM_CA_CERT");

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -14,6 +14,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
+use hyper_rustls::ConfigBuilderExt;
 use metrics::{Metrics, RequestMetricsGuard};
 use policy_config::{load_policy_config, reload_acl_engine, PolicyConfig};
 use quick_cache::sync::Cache;
@@ -23,6 +24,7 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::io::Cursor;
 use std::net::{IpAddr, SocketAddr};
 use std::panic;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -164,11 +166,8 @@ impl ProxyService {
 
         let http_cache = Arc::new(Cache::new(cache_config.capacity));
 
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
-            .https_or_http()
-            .enable_http1()
-            .build();
+        let https = build_upstream_https_connector()
+            .expect("failed to build upstream HTTPS connector");
 
         let http_client =
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
@@ -591,7 +590,7 @@ impl ProxyService {
                 resp
             }
             Err(e) => {
-                error!("Upstream error: {}", e);
+                error!("Upstream error for {}: {}", url, e);
                 self.metrics
                     .upstream_errors_total
                     .with_label_values(&[&domain, "connection"])
@@ -603,6 +602,40 @@ impl ProxyService {
             }
         }
     }
+}
+
+fn build_upstream_https_connector(
+) -> Result<
+    hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+    Box<dyn std::error::Error>,
+> {
+    let tls_config = if let Ok(path) = std::env::var("UPSTREAM_CA_CERT") {
+        let pem = std::fs::read(&path)
+            .map_err(|e| format!("failed to read UPSTREAM_CA_CERT {path}: {e}"))?;
+        let certs: Vec<rustls::pki_types::CertificateDer<'static>> = rustls_pemfile::certs(
+            &mut Cursor::new(pem),
+        )
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|cert| cert.into_owned())
+        .collect();
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add_parsable_certificates(certs);
+        info!("Upstream TLS: trusting custom CA from UPSTREAM_CA_CERT");
+        rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth()
+    } else {
+        rustls::ClientConfig::builder()
+            .with_webpki_roots()
+            .with_no_client_auth()
+    };
+
+    Ok(hyper_rustls::HttpsConnectorBuilder::new()
+        .with_tls_config(tls_config)
+        .https_or_http()
+        .enable_http1()
+        .build())
 }
 
 async fn metrics_server(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `UPSTREAM_CA_CERT` env var: proxy upstream HTTPS connector trusts a custom CA PEM instead of only webpki roots
- E2E harness generates workspace test CA, signs mock HTTPS upstream certs, configures proxy (`UPSTREAM_CA_CERT`) and MITM client (`add_root_certificate`)
- Fix harness startup order: `ensure_test_ca()` must run **before** spawning HTTPS upstream so server cert and trust store use the same CA
- `ensure_test_ca()` is idempotent — reuses existing `certs/ca.{crt,key}` when present

## Test plan

- [x] `cargo test -p bsdm-proxy-e2e` — 12/12 pass
- [x] `e2e_mitm_https_with_self_signed_ca` — MITM HTTPS through proxy with self-signed CA
- [x] `e2e_upstream_tls_accepts_test_ca` — direct HTTPS to mock upstream with test CA
- [x] `cargo clippy -p bsdm-proxy -p bsdm-proxy-e2e -- -D warnings`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

