### PR TITLE
release: 0.2.2b

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-proxy"
-version = "2.1.0"
+version = "0.2.2-b"
 dependencies = [
  "base64",
  "bytes",
@@ -194,6 +200,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsdm-proxy-e2e"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-pemfile",
+ "serde_json",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,7 +232,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cache-indexer"
-version = "0.1.0"
+version = "0.2.2-b"
 dependencies = [
  "bytes",
  "opensearch",

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-indexer"
-version = "0.1.0"
+version = "0.2.2-b"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-proxy"
-version = "2.1.0"
+version = "0.2.2-b"
 edition = "2021"
 
 # Binary targets


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release **0.2.2b** (beta): bump crate versions to `0.2.2-b` for `bsdm-proxy` and `cache-indexer`.

Git tag: `v0.2.2b`

## Test plan

- [x] `cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer`
- [x] Release proxy binary health check (`/health` → 200)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

