### PR TITLE
docs: add roadmap milestones M1–M5 (Squid + retro-search + ML)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,36 @@
+---
+name: Feature request
+about: Предложение новой функциональности
+title: "[M?] "
+labels: []
+assignees: []
+---
+
+## Milestone
+
+<!-- Выберите один: M1 (v0.2.x) | M2 (v0.3.x) | M3 (v0.4.x) | M4 (v0.5.x) | M5 (v1.0.x) -->
+<!-- См. docs/roadmap.md -->
+
+- [ ] M1 — Foundation
+- [ ] M2 — Squid parity
+- [ ] M3 — Retro-search
+- [ ] M4 — Threat analytics
+- [ ] M5 — ML security
+
+## Столп
+
+- [ ] Squid parity
+- [ ] Ретропоиск
+- [ ] ML / безопасность
+
+## Описание
+
+<!-- Что нужно и зачем -->
+
+## Критерии готовности
+
+<!-- Как понять, что задача выполнена -->
+
+## Связанные документы
+
+<!-- docs/roadmap.md, docs/*.md -->

--- a/.github/labels-milestones.yml
+++ b/.github/labels-milestones.yml
@@ -1,0 +1,34 @@
+# Milestone labels for issue triage
+# Apply alongside GitHub Milestone when creating issues.
+
+- name: milestone:m1
+  description: M1 Foundation (v0.2.x) — proxy core, ACL, observability
+  color: "0E8A16"
+
+- name: milestone:m2
+  description: M2 Squid parity (v0.3.x) — hierarchy, L2, rate limit
+  color: "1D76DB"
+
+- name: milestone:m3
+  description: M3 Retro-search (v0.4.x) — OpenSearch analytics
+  color: "5319E7"
+
+- name: milestone:m4
+  description: M4 Threat analytics (v0.5.x) — rule-based alerts, C&C heuristics
+  color: "D93F0B"
+
+- name: milestone:m5
+  description: M5 ML security (v1.0.x) — anomaly, phishing, C&C ML
+  color: "B60205"
+
+- name: pillar:squid
+  description: Squid parity — proxy, cache, hierarchy
+  color: "C5DEF5"
+
+- name: pillar:retro-search
+  description: Retro-search — historical traffic analytics
+  color: "E4E669"
+
+- name: pillar:ml-security
+  description: ML security — anomalies, phishing, C&C
+  color: "FEF2C0"

--- a/README.md
+++ b/README.md
@@ -244,29 +244,50 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | [docs/authentication.md](docs/authentication.md) | LDAP, NTLM, Basic Auth |
 | [docs/acl.md](docs/acl.md) | Правила доступа, приоритеты |
 | [docs/categorization.md](docs/categorization.md) | Shallalist, URLhaus, PhishTank |
-| [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш (ICP) |
+| [docs/roadmap.md](docs/roadmap.md) | Roadmap и milestones |
 | [packaging/README.md](packaging/README.md) | Release-пакет и systemd |
 | [OPTIMIZATIONS.md](OPTIMIZATIONS.md) | Оптимизации v2.0 |
 | [docker-compose.yml](docker-compose.yml) | Полный стек |
 
 ## Roadmap
 
-### v0.2.x (текущая линия)
+Цель: **альтернатива Squid с ретропоиском и ML** для аномалий, фишинга и C&C.
+
+Полный план: **[docs/roadmap.md](docs/roadmap.md)**
+
+| Milestone | Версия | Фокус | Статус |
+|-----------|--------|-------|--------|
+| **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability | ~90% |
+| **M2** Squid parity | v0.3.x | Иерархия, L2, rate limit, полный ACL | Planned |
+| **M3** Retro-search | v0.4.x | OpenSearch dashboards, поиск по истории | Planned |
+| **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | Planned |
+| **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | Planned |
+
+### M1 — Foundation (v0.2.x, текущий)
 
 - [x] Prometheus + Grafana + health checks
 - [x] Graceful shutdown
-- [x] Proxy authentication (Basic / LDAP / NTLM)
+- [x] Proxy authentication (Basic / LDAP; NTLM — в backlog M2)
 - [x] ACL + URL categorization
 - [x] E2E / smoke test harness
 - [x] Release packaging (`0.2.2b`)
 - [ ] Rate limiting per user/IP
 - [ ] Hierarchical caching — Phase 3 integration
 
-### v0.3.x
+### M2 — Squid parity (v0.3.x)
 
 - [ ] Redis L2 cache
 - [ ] HTTP/2 upstream client
 - [ ] Compression (Brotli/Zstd)
+- [ ] ACL TimeWindow + group rules
+- [ ] NTLM auth
+- [ ] Hierarchy Phase 4 (discovery, digest, HTCP)
+
+### M3–M5
+
+- [ ] **M3:** индексация threat-полей, OpenSearch Dashboards, saved searches
+- [ ] **M4:** rule-based anomaly alerts, C&C beacon heuristics, SIEM export
+- [ ] **M5:** ML pipeline, anomaly/phishing/C&C models
 
 ## Лицензия
 

--- a/docs/HIERARCHICAL_CACHING_README.md
+++ b/docs/HIERARCHICAL_CACHING_README.md
@@ -135,28 +135,26 @@ if result.response == IcpOpcode::Hit {
 
 ## 📋 Implementation Roadmap
 
-### Phase 1: Core Infrastructure ✅ DONE
-- [x] Peer management module
-- [x] ICP protocol implementation
+См. [roadmap.md](roadmap.md) — milestones M1 (Phase 3) и M2 (Phase 4).
+
+### Phase 1: Core Infrastructure ✅ DONE (M1)
+- [x] Peer management module (`peers.rs`)
+- [x] ICP protocol implementation (`icp.rs`)
 - [x] Unit tests
 
-### Phase 2: Selection & Routing 🚧 IN PROGRESS
-- [ ] Selection strategy trait
-- [ ] Round-robin implementation
-- [ ] Weighted selection
-- [ ] RTT-based selection
-- [ ] Consistent hashing
-- [ ] Hierarchy manager
-- [ ] Request flow coordination
+### Phase 2: Selection & Routing ✅ DONE on disk (M1, not wired)
+- [x] Selection strategies (`selection.rs`) — round-robin, weighted, closest, hash
+- [x] Hierarchy manager (`hierarchy.rs`)
+- [ ] Wire into binary (`lib.rs` / `main.rs`)
 
-### Phase 3: Integration 📅 PLANNED
+### Phase 3: Integration 📅 M1 remaining
 - [ ] Configuration loading (env vars + TOML)
 - [ ] Wire into main.rs request pipeline
 - [ ] Metrics integration (Prometheus)
 - [ ] Docker-compose multi-instance setup
 - [ ] End-to-end tests
 
-### Phase 4: Advanced Features 🔮 FUTURE
+### Phase 4: Advanced Features 🔮 M2
 - [ ] Peer auto-discovery (multicast)
 - [ ] Cache digest (Bloom filters)
 - [ ] HTCP protocol support

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,11 @@
 | [acl.md](acl.md) | Списки контроля доступа (ACL) |
 | [categorization.md](categorization.md) | Категоризация URL и threat intelligence |
 
-## Архитектура и производительность
+## Архитектура и roadmap
 
 | Документ | Описание |
 |----------|----------|
+| [roadmap.md](roadmap.md) | **Roadmap и milestones** (Squid + ретропоиск + ML) |
 | [hierarchical-caching.md](hierarchical-caching.md) | Иерархический кеш, ICP, peer management |
 | [HIERARCHICAL_CACHING_README.md](HIERARCHICAL_CACHING_README.md) | Краткий обзор hierarchical caching |
 | [OPTIMIZATIONS.md](../OPTIMIZATIONS.md) | Оптимизации Hyper + quick_cache |

--- a/docs/development.md
+++ b/docs/development.md
@@ -114,6 +114,16 @@ cargo test -p bsdm-proxy-e2e --test e2e e2e_mitm_https_with_self_signed_ca -- --
 
 Версия берётся из `proxy/Cargo.toml` (например `0.2.2-b` → пакет `0.2.2b`).
 
+## Roadmap и milestones
+
+Полный план: [roadmap.md](roadmap.md)
+
+Создать GitHub milestones (требует admin scope):
+
+```bash
+./scripts/create-milestones.sh
+```
+
 ## CI
 
 | Workflow | Триггер | Шаги |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,221 @@
+# Roadmap BSDM-Proxy
+
+Целевое состояние проекта:
+
+> **Альтернатива Squid с ретропоиском и ML для выявления отклонений, фишинга и C&C**
+
+Три столпа развития:
+
+| Столп | Описание |
+|-------|----------|
+| **Squid parity** | Forward proxy, кеш, ACL, auth, иерархия, rate limiting |
+| **Ретропоиск** | Поиск и аналитика по историческому HTTP-трафику |
+| **ML-безопасность** | Аномалии, фишинг и C&C поверх логов и поведенческих сигналов |
+
+Текущая версия: **0.2.2b** · [Releases](https://github.com/onixus/bsdm-proxy/releases)
+
+---
+
+## Обзор milestones
+
+| Milestone | Версия | Фокус | Готовность |
+|-----------|--------|-------|------------|
+| [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ~90% |
+| [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | Иерархия, L2, rate limit, полный ACL | ~0% |
+| [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~15% |
+| [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
+| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C beacon detection | ~0% |
+
+```mermaid
+gantt
+  title Roadmap milestones
+  dateFormat YYYY-MM
+  section Proxy
+  M1 Foundation           :done, m1, 2025-10, 2026-03
+  M2 Squid parity         :m2, 2026-03, 2026-06
+  section Analytics
+  M3 Retro-search         :m3, 2026-05, 2026-08
+  M4 Threat analytics     :m4, 2026-07, 2026-10
+  section ML
+  M5 ML security          :m5, 2026-09, 2027-03
+```
+
+---
+
+## M1 — Foundation (v0.2.x)
+
+Базовый корпоративный HTTPS-прокси с политиками и наблюдаемостью.
+
+### Выполнено
+
+- [x] Hyper forward proxy + HTTP CONNECT
+- [x] MITM TLS (порты 443/8443), динамические сертификаты
+- [x] L1 in-memory cache (`quick_cache`)
+- [x] Kafka producer (async cache events)
+- [x] cache-indexer → OpenSearch
+- [x] Prometheus metrics (20+) + Grafana dashboard
+- [x] Health endpoints (`/health`, `/ready`, `/metrics`)
+- [x] Graceful shutdown
+- [x] Proxy auth: Basic + LDAP (feature `auth-ldap`)
+- [x] ACL: domain, URL prefix, regex, category, IP, user
+- [x] URL categorization: Shallalist, URLhaus, PhishTank, custom DB
+- [x] E2E / smoke test harness
+- [x] Release packaging (`0.2.2b`) + systemd
+
+### В работе / осталось в M1
+
+- [ ] Rate limiting per user/IP — [#TBD]
+- [ ] Hierarchical caching Phase 3 — интеграция `peers.rs`, `icp.rs`, `hierarchy.rs` в `main.rs` — [#TBD]
+- [ ] Исправить README: NTLM помечен как done, но не реализован (`auth.rs`)
+
+**Критерий завершения M1:** rate limit + hierarchy в production path, все E2E зелёные.
+
+---
+
+## M2 — Squid parity (v0.3.x)
+
+Полноценная замена Squid для корпоративного сценария (без ML).
+
+### Задачи
+
+- [ ] **Hierarchy Phase 4** — peer discovery, cache digest, HTCP (опционально mTLS)
+- [ ] **Redis L2 cache** — распределённый кеш между инстансами
+- [ ] **HTTP/2 upstream client**
+- [ ] **Compression** — Brotli/Zstd для cacheable responses
+- [ ] **ACL completeness**
+  - [ ] TimeWindow rules (сейчас TODO в `acl.rs`)
+  - [ ] Group-based rules (сейчас игнорируются)
+  - [ ] REST API управления ACL (`/api/acl/*` из docs)
+- [ ] **NTLM auth** — реализация или снятие с roadmap
+- [ ] **Negative caching** coordination
+- [ ] **Cache refresh / revalidate** — Squid-style freshness
+- [ ] **docker-compose.hierarchy.yml** — 3-tier demo stack
+- [ ] Hierarchy Prometheus metrics (`bsdm_proxy_hierarchy_*`)
+
+**Критерий завершения M2:** 3-tier cache hierarchy в docker-compose, hit rate sibling/parent измеряется, Redis L2 работает.
+
+**Зависимости:** M1 (hierarchy Phase 3).
+
+---
+
+## M3 — Retro-search (v0.4.x)
+
+Ретроспективный поиск и аналитика по HTTP-трафику.
+
+### Текущий gap
+
+Pipeline Kafka → OpenSearch есть, но:
+- поле `categories` теряется в `cache-indexer`
+- нет OpenSearch Dashboards в стеке
+- нет saved searches и search API
+
+### Задачи
+
+- [ ] **Расширить схему событий**
+  - [ ] `categories`, `acl_action`, `threat_sources` в indexer
+  - [ ] OpenSearch index template + mapping
+  - [ ] ILM / retention policy
+- [ ] **OpenSearch Dashboards** в `docker-compose.yml`
+- [ ] **Saved searches / playbooks**
+  - [ ] Все запросы пользователя X за период
+  - [ ] Доступ к домену Y
+  - [ ] Blocked + phishing/malware events
+  - [ ] Top domains per user / per IP
+- [ ] **Search API** (опционально) — thin REST поверх OpenSearch
+- [ ] **Session correlation** — `session_id`, redirect chains
+- [ ] **Экспорт** — CSV/JSON для SOC
+
+**Критерий завершения M3:** аналитик находит «кто ходил на домен X за 30 дней» через Dashboards без ручного curl; categories индексируются.
+
+**Зависимости:** M1 (стабильный event pipeline).
+
+---
+
+## M4 — Threat analytics (v0.5.x)
+
+Rule-based обнаружение угроз и алертинг (без ML, быстрый win).
+
+### Задачи
+
+- [ ] **Обогащение событий** — reputation score, URLhaus/PhishTank metadata в индексе
+- [ ] **Rule-based anomaly alerts**
+  - [ ] Burst к новому/редкому домену
+  - [ ] Off-hours activity spike
+  - [ ] Множество blocked requests от одного user/IP
+- [ ] **C&C heuristics (rules)**
+  - [ ] Периодические короткие запросы к одному host:port (beacon pattern)
+  - [ ] Long-tail / high-entropy domain scoring
+  - [ ] Корреляция: user → множество POST к редким хостам
+- [ ] **Alerting pipeline** — OpenSearch Alerting → webhook / email / SIEM
+- [ ] **Threat dashboard** — Grafana или OpenSearch Dashboards
+- [ ] **Categorization metrics** в Prometheus (документированы, не реализованы)
+- [ ] **PhishTank API key** support (`PHISHTANK_API_KEY`)
+
+**Критерий завершения M4:** автоматический алерт при beacon-подобном паттерне; threat dashboard показывает top blocked categories.
+
+**Зависимости:** M3 (полная схема данных в OpenSearch).
+
+---
+
+## M5 — ML security (v1.0.x)
+
+ML-слой для аномалий, фишинга и C&C.
+
+### Задачи
+
+- [ ] **Feature store** — извлечение признаков из OpenSearch (frequency, entropy, timing, UA, geo)
+- [ ] **Anomaly detection**
+  - [ ] Baseline per user/IP (volume, unique domains, time distribution)
+  - [ ] Isolation Forest / statistical models (batch)
+  - [ ] OpenSearch Anomaly Detection integration
+- [ ] **Phishing ML**
+  - [ ] URL feature model (дополнение PhishTank blocklist)
+  - [ ] HTML/content features через MITM body (опционально)
+- [ ] **C&C ML**
+  - [ ] Beacon detection (FFT / autocorrelation интервалов)
+  - [ ] DGA domain classifier
+- [ ] **Real-time scoring** (optional) — inline risk score в proxy path
+- [ ] **Feedback loop** — FP/FN разметка → переобучение
+- [ ] **ML pipeline** — training worker (Python/Rust) + model registry
+
+**Критерий завершения M5:** ML anomaly score в индексе; алерт на C&C beacon без URL в blocklist; документированный pipeline обучения.
+
+**Зависимости:** M3 (данные), M4 (heuristics как baseline).
+
+---
+
+## Матрица зрелости
+
+| Столп | Сейчас (0.2.2b) | После M2 | После M3 | После M5 |
+|-------|-----------------|----------|----------|----------|
+| Squid parity | ~45% | ~85% | ~85% | ~90% |
+| Ретропоиск | ~15% | ~15% | ~80% | ~90% |
+| ML / C&C / phishing | ~5% | ~5% | ~10% | ~75% |
+| **Целевое состояние** | **~20%** | **~35%** | **~60%** | **~85%** |
+
+---
+
+## GitHub milestones
+
+Issues привязывайте к milestones:
+
+| GitHub Milestone | Версия | Label suggestion |
+|------------------|--------|------------------|
+| `M1: Foundation (v0.2.x)` | 0.2.x | `milestone:m1` |
+| `M2: Squid parity (v0.3.x)` | 0.3.x | `milestone:m2` |
+| `M3: Retro-search (v0.4.x)` | 0.4.x | `milestone:m3` |
+| `M4: Threat analytics (v0.5.x)` | 0.5.x | `milestone:m4` |
+| `M5: ML security (v1.0.x)` | 1.0.x | `milestone:m5` |
+
+---
+
+## Связанные документы
+
+- [hierarchical-caching.md](hierarchical-caching.md) — дизайн ICP/HTCP (M2)
+- [categorization.md](categorization.md) — threat intel feeds (M1/M4)
+- [acl.md](acl.md) — политики доступа (M1/M2)
+- [development.md](development.md) — сборка и тесты
+
+---
+
+*Последнее обновление: v0.2.2b*

--- a/scripts/create-milestones.sh
+++ b/scripts/create-milestones.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Create GitHub milestones for BSDM-Proxy roadmap.
+# Requires: gh auth with repo admin scope
+# Usage: ./scripts/create-milestones.sh
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-onixus/bsdm-proxy}"
+
+create_milestone() {
+  local title="$1"
+  local description="$2"
+  gh api "repos/${REPO}/milestones" \
+    --method POST \
+    -f "title=${title}" \
+    -f "description=${description}" \
+    -f "state=open" \
+    && echo "Created: ${title}" \
+    || echo "Skip or failed: ${title} (may already exist)"
+}
+
+create_milestone "M1: Foundation (v0.2.x)" \
+  "Proxy core, ACL, categorization, observability, rate limiting, hierarchy Phase 3. docs/roadmap.md"
+
+create_milestone "M2: Squid parity (v0.3.x)" \
+  "Cache hierarchy Phase 4, Redis L2, HTTP/2, compression, full ACL, NTLM. docs/roadmap.md"
+
+create_milestone "M3: Retro-search (v0.4.x)" \
+  "OpenSearch schema, dashboards, saved searches, historical traffic analytics. docs/roadmap.md"
+
+create_milestone "M4: Threat analytics (v0.5.x)" \
+  "Rule-based anomaly alerts, C&C heuristics, threat enrichment, SIEM export. docs/roadmap.md"
+
+create_milestone "M5: ML security (v1.0.x)" \
+  "ML anomaly detection, phishing ML, C&C beacon detection, feedback loop. docs/roadmap.md"
+
+echo "Done. List: gh api repos/${REPO}/milestones"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Добавлен полный roadmap с milestones под целевое состояние: **альтернатива Squid + ретропоиск + ML**.

### Milestones

| Milestone | Версия | Фокус | Готовность |
|-----------|--------|-------|------------|
| **M1** Foundation | v0.2.x | Прокси, ACL, observability, rate limit, hierarchy Phase 3 | ~90% |
| **M2** Squid parity | v0.3.x | L2, HTTP/2, compression, полный ACL, NTLM | Planned |
| **M3** Retro-search | v0.4.x | OpenSearch dashboards, индексация threat-полей | ~15% |
| **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | ~5% |
| **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | Planned |

### Файлы

- `docs/roadmap.md` — полный план, матрица зрелости, критерии завершения
- `README.md` — краткая таблица milestones, NTLM → backlog M2
- `.github/ISSUE_TEMPLATE/feature_request.md` — шаблон issue
- `scripts/create-milestones.sh` — создание GitHub milestones

## Test plan

- [x] Markdown structure review
- [ ] `gh api repos/onixus/bsdm-proxy/milestones` after running create-milestones.sh (needs admin)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

