### PR TITLE
fix(M1): B5 optional CA, B1 wire hierarchy modules, B2 rand dep

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Git pre-push hook — runs the same fmt/clippy gates as Rust CI.
+set -e
+ROOT="$(git rev-parse --show-toplevel)"
+exec "$ROOT/scripts/pre-push-check.sh"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "ldap3",
  "prometheus",
  "quick_cache",
+ "rand",
  "rcgen",
  "rdkafka",
  "regex",

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Grafana: http://localhost:3000 → **BSDM Proxy Dashboard** (7 панелей, a
 
 ## Тестирование
 
+Перед push: `./scripts/pre-push-check.sh` (или `./scripts/install-git-hooks.sh` для auto hook).
+
 ```bash
 # Unit + integration (workspace)
 cargo test --workspace

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,28 @@ cargo fmt --all
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-CI запускает `cargo fmt --check` — перед пушем обязательно `cargo fmt --all`.
+CI запускает `cargo fmt --check` — **перед каждым push** прогоняйте проверки:
+
+```bash
+./scripts/pre-push-check.sh
+```
+
+### Git pre-push hook (рекомендуется)
+
+Автоматически запускает `fmt --check` и `clippy` перед `git push`:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+Один раз пропустить: `git push --no-verify`
+
+Проверка вручную без hook:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+```
 
 ## Тесты
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 http-body-util = "0.1"
 quick_cache = "0.7"
+rand = "0.9"
 rcgen = { version = "0.14", features = ["x509-parser"] }
 rdkafka = "0.39"
 prometheus = { version = "0.14", features = ["process"] }

--- a/proxy/src/hierarchy.rs
+++ b/proxy/src/hierarchy.rs
@@ -4,15 +4,11 @@
 //! Local cache → Siblings (ICP) → Parents → Origin
 
 use crate::icp::{IcpClient, IcpOpcode};
-use crate::peers::{CachePeer, PeerRegistry, PeerType};
+use crate::peers::{CachePeer, PeerRegistry};
 use crate::selection::SelectionStrategy;
-use bytes::Bytes;
-use hyper::{Request, Response, StatusCode};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tracing::{debug, info, warn};
-
-type Body = http_body_util::Full<Bytes>;
 
 /// Result of hierarchy query
 #[derive(Debug, Clone)]
@@ -132,7 +128,7 @@ impl HierarchyManager {
     async fn query_siblings(&self, url: &str) -> Option<Arc<CachePeer>> {
         let icp_client = self.icp_client.as_ref()?;
         let siblings = self.peer_registry.sibling_caches().await;
-        
+
         if siblings.is_empty() {
             return None;
         }
@@ -141,11 +137,9 @@ impl HierarchyManager {
         let sibling_addrs: Vec<_> = siblings
             .iter()
             .filter_map(|s| {
-                s.config.icp_port.map(|port| {
-                    format!("{}:{}", s.config.host, port)
-                        .parse()
-                        .ok()
-                })
+                s.config
+                    .icp_port
+                    .map(|port| format!("{}:{}", s.config.host, port).parse().ok())
             })
             .flatten()
             .take(self.config.max_sibling_queries)
@@ -155,7 +149,11 @@ impl HierarchyManager {
             return None;
         }
 
-        debug!("Querying {} siblings via ICP for {}", sibling_addrs.len(), url);
+        debug!(
+            "Querying {} siblings via ICP for {}",
+            sibling_addrs.len(),
+            url
+        );
 
         // Query siblings in parallel
         let results = icp_client
@@ -184,15 +182,13 @@ impl HierarchyManager {
     /// Select a parent cache using configured strategy
     async fn select_parent(&self, url: &str) -> Option<Arc<CachePeer>> {
         let parents = self.peer_registry.parent_caches().await;
-        
+
         if parents.is_empty() {
             return None;
         }
 
         // Use selection strategy
-        self.selection_strategy
-            .select(&parents, url)
-            .cloned()
+        self.selection_strategy.select(&parents, url).cloned()
     }
 
     /// Record successful fetch from peer
@@ -211,7 +207,7 @@ impl HierarchyManager {
     pub async fn record_peer_error(&self, peer: &CachePeer) {
         peer.stats.record_request().await;
         peer.stats.record_error().await;
-        
+
         // Check if peer should be marked unhealthy
         let error_rate = peer.stats.error_rate();
         if error_rate > 0.5 {
@@ -228,15 +224,18 @@ impl HierarchyManager {
     pub async fn stats_summary(&self) -> String {
         let mut summary = String::new();
         summary.push_str(&format!("Hierarchy enabled: {}\n", self.config.enabled));
-        summary.push_str(&format!("Selection strategy: {}\n", self.selection_strategy.name()));
+        summary.push_str(&format!(
+            "Selection strategy: {}\n",
+            self.selection_strategy.name()
+        ));
         summary.push_str(&format!("ICP timeout: {:?}\n", self.config.icp_timeout));
-        
+
         let siblings = self.peer_registry.sibling_caches().await;
         let parents = self.peer_registry.parent_caches().await;
-        
+
         summary.push_str(&format!("Siblings: {}\n", siblings.len()));
         summary.push_str(&format!("Parents: {}\n", parents.len()));
-        
+
         summary.push_str(&self.peer_registry.stats_summary().await);
         summary
     }
@@ -247,6 +246,7 @@ mod tests {
     use super::*;
     use crate::peers::PeerConfig;
     use crate::selection::RoundRobinStrategy;
+    use crate::PeerType;
 
     #[tokio::test]
     async fn test_hierarchy_disabled() {
@@ -256,9 +256,9 @@ mod tests {
         };
         let registry = PeerRegistry::new();
         let strategy = Box::new(RoundRobinStrategy::new());
-        
+
         let manager = HierarchyManager::new(config, registry, strategy);
-        
+
         let result = manager.resolve_source("http://example.com/test").await;
         assert!(matches!(result, HierarchyResult::OriginRequired));
     }
@@ -270,7 +270,7 @@ mod tests {
             ..Default::default()
         };
         let registry = PeerRegistry::new();
-        
+
         // Add parent
         let parent_config = PeerConfig {
             host: "parent.example.com".to_string(),
@@ -281,10 +281,10 @@ mod tests {
             max_connections: 100,
         };
         registry.add_peer(parent_config).await;
-        
+
         let strategy = Box::new(RoundRobinStrategy::new());
         let manager = HierarchyManager::new(config, registry, strategy);
-        
+
         let result = manager.resolve_source("http://example.com/test").await;
         assert!(matches!(result, HierarchyResult::ParentHit(_)));
     }
@@ -292,7 +292,7 @@ mod tests {
     #[tokio::test]
     async fn test_peer_statistics() {
         let registry = PeerRegistry::new();
-        
+
         let peer_config = PeerConfig {
             host: "test.example.com".to_string(),
             port: 1488,
@@ -302,19 +302,30 @@ mod tests {
             max_connections: 100,
         };
         let peer = registry.add_peer(peer_config).await;
-        
+
         let config = HierarchyConfig::default();
         let strategy = Box::new(RoundRobinStrategy::new());
         let manager = HierarchyManager::new(config, registry, strategy);
-        
+
         // Record some hits
         manager.record_peer_hit(&peer, 1024).await;
         manager.record_peer_hit(&peer, 2048).await;
         manager.record_peer_miss(&peer).await;
-        
-        assert_eq!(peer.stats.requests.load(std::sync::atomic::Ordering::Relaxed), 3);
-        assert_eq!(peer.stats.hits.load(std::sync::atomic::Ordering::Relaxed), 2);
-        assert_eq!(peer.stats.misses.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+        assert_eq!(
+            peer.stats
+                .requests
+                .load(std::sync::atomic::Ordering::Relaxed),
+            3
+        );
+        assert_eq!(
+            peer.stats.hits.load(std::sync::atomic::Ordering::Relaxed),
+            2
+        );
+        assert_eq!(
+            peer.stats.misses.load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
         assert_eq!(peer.stats.hit_rate(), 2.0 / 3.0);
     }
 }

--- a/proxy/src/icp.rs
+++ b/proxy/src/icp.rs
@@ -12,7 +12,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::UdpSocket;
-use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tracing::{debug, error, warn};
 
@@ -181,7 +180,7 @@ impl IcpClient {
     pub async fn new(bind_addr: &str) -> Result<Self> {
         let socket = UdpSocket::bind(bind_addr).await?;
         let local_addr = socket.local_addr()?;
-        
+
         Ok(Self {
             socket: Arc::new(socket),
             request_counter: AtomicU32::new(1),
@@ -218,12 +217,18 @@ impl IcpClient {
                     }
                 }
             }
-        }).await;
+        })
+        .await;
 
         match result {
             Ok(Ok(response)) => {
                 let latency = start.elapsed();
-                debug!("ICP response from {}: {} ({}ms)", peer, response.opcode, latency.as_millis());
+                debug!(
+                    "ICP response from {}: {} ({}ms)",
+                    peer,
+                    response.opcode,
+                    latency.as_millis()
+                );
                 Ok(IcpResult {
                     peer,
                     response: response.opcode,
@@ -247,9 +252,10 @@ impl IcpClient {
         for &peer in peers {
             let client = self.clone();
             let url = url.to_string();
-            let task = tokio::spawn(async move {
-                client.query_peer(peer, &url, query_timeout).await.ok()
-            });
+            let task =
+                tokio::spawn(
+                    async move { client.query_peer(peer, &url, query_timeout).await.ok() },
+                );
             tasks.push(task);
         }
 
@@ -271,7 +277,7 @@ impl IcpClient {
         query_timeout: Duration,
     ) -> Option<SocketAddr> {
         let results = self.query_peers(peers, url, query_timeout).await;
-        
+
         results
             .into_iter()
             .find(|r| r.response == IcpOpcode::Hit)
@@ -283,9 +289,7 @@ impl Clone for IcpClient {
     fn clone(&self) -> Self {
         Self {
             socket: self.socket.clone(),
-            request_counter: AtomicU32::new(
-                self.request_counter.load(Ordering::Relaxed)
-            ),
+            request_counter: AtomicU32::new(self.request_counter.load(Ordering::Relaxed)),
             local_addr: self.local_addr,
         }
     }
@@ -299,16 +303,13 @@ pub struct IcpServer {
 
 impl IcpServer {
     /// Create a new ICP server
-    pub async fn new<F>(
-        bind_addr: &str,
-        query_handler: F,
-    ) -> Result<Self>
+    pub async fn new<F>(bind_addr: &str, query_handler: F) -> Result<Self>
     where
         F: Fn(&str) -> bool + Send + Sync + 'static,
     {
         let socket = UdpSocket::bind(bind_addr).await?;
         let local_addr = socket.local_addr()?;
-        
+
         debug!("ICP server listening on {}", local_addr);
 
         Ok(Self {
@@ -326,7 +327,7 @@ impl IcpServer {
                 Ok((len, addr)) => {
                     let data = buf[..len].to_vec();
                     let server = self.clone();
-                    
+
                     tokio::spawn(async move {
                         if let Err(e) = server.handle_query(&data, addr).await {
                             error!("ICP query handling error: {}", e);
@@ -380,12 +381,9 @@ mod tests {
 
         let encoded = msg.encode().unwrap();
         assert!(encoded.len() > 20);
-        
-        let decoded = IcpMessage::decode(
-            &encoded,
-            "127.0.0.1:3130".parse().unwrap()
-        ).unwrap();
-        
+
+        let decoded = IcpMessage::decode(&encoded, "127.0.0.1:3130".parse().unwrap()).unwrap();
+
         assert_eq!(decoded.opcode, IcpOpcode::Query);
         assert_eq!(decoded.request_number, 12345);
         assert_eq!(decoded.url, "http://example.com/test");
@@ -395,10 +393,7 @@ mod tests {
     fn test_hit_miss_encoding() {
         let hit = IcpMessage::hit(999, "127.0.0.1:3130".parse().unwrap());
         let encoded = hit.encode().unwrap();
-        let decoded = IcpMessage::decode(
-            &encoded,
-            "127.0.0.1:3130".parse().unwrap()
-        ).unwrap();
+        let decoded = IcpMessage::decode(&encoded, "127.0.0.1:3130".parse().unwrap()).unwrap();
         assert_eq!(decoded.opcode, IcpOpcode::Hit);
         assert_eq!(decoded.request_number, 999);
     }
@@ -406,14 +401,10 @@ mod tests {
     #[tokio::test]
     async fn test_client_server() {
         // Create server that always returns HIT
-        let server = Arc::new(
-            IcpServer::new("127.0.0.1:0", |_url| true)
-                .await
-                .unwrap()
-        );
-        
+        let server = Arc::new(IcpServer::new("127.0.0.1:0", |_url| true).await.unwrap());
+
         let server_addr = server.socket.local_addr().unwrap();
-        
+
         // Start server
         let server_clone = server.clone();
         tokio::spawn(async move {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -3,11 +3,19 @@
 pub mod acl;
 pub mod auth;
 pub mod categorization;
+pub mod hierarchy;
+pub mod icp;
+pub mod peers;
+pub mod selection;
 
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
 pub use auth::{AuthBackend, AuthConfig, AuthManager, UserInfo};
 pub use categorization::{CategorizationConfig, CategorizationEngine, Category};
+pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};
+pub use icp::{IcpClient, IcpMessage, IcpOpcode, IcpServer};
+pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
+pub use selection::{parse_strategy, SelectionStrategy};
 
 // Conditional re-exports based on features
 #[cfg(feature = "auth-ldap")]
@@ -15,3 +23,14 @@ pub use auth::LdapConfig;
 
 #[cfg(feature = "auth-ntlm")]
 pub use auth::NtlmConfig;
+
+#[cfg(test)]
+mod tests {
+    use super::parse_strategy;
+
+    #[test]
+    fn hierarchy_modules_are_linked() {
+        assert_eq!(parse_strategy("round-robin").name(), "round-robin");
+        assert_eq!(parse_strategy("weighted").name(), "weighted");
+    }
+}

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -855,23 +855,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         metrics_port,
     ));
 
-    let ca_key = tokio::fs::read("/certs/ca.key").await.or_else(|_| {
-        warn!("Failed to read /certs/ca.key, trying ./certs/ca.key");
-        std::fs::read("./certs/ca.key")
-    })?;
-
-    let ca_cert = tokio::fs::read("/certs/ca.crt")
-        .await
-        .or_else(|_| {
-            warn!("Failed to read /certs/ca.crt, trying ./certs/ca.crt");
-            std::fs::read("./certs/ca.crt")
-        })
-        .unwrap_or_default();
-
-    let cert_cache = CertCache::from_pem(&ca_key, &ca_cert)?;
     let mitm_enabled = std::env::var("MITM_ENABLED")
         .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
         .unwrap_or(true);
+
+    let cert_cache = CertCache::load_for_startup(mitm_enabled).await?;
     let kafka_brokers = std::env::var("KAFKA_BROKERS").ok();
     let cache_capacity = std::env::var("CACHE_CAPACITY")
         .ok()

--- a/proxy/src/peers.rs
+++ b/proxy/src/peers.rs
@@ -68,7 +68,8 @@ impl PeerStats {
 
     pub fn hit_rate(&self) -> f64 {
         let hits = self.hits.load(Ordering::Relaxed) as f64;
-        let total = (self.hits.load(Ordering::Relaxed) + self.misses.load(Ordering::Relaxed)) as f64;
+        let total =
+            (self.hits.load(Ordering::Relaxed) + self.misses.load(Ordering::Relaxed)) as f64;
         if total == 0.0 {
             0.0
         } else {
@@ -106,10 +107,12 @@ impl PeerConfig {
         }
 
         let host = parts[0].to_string();
-        let port = parts[1].parse::<u16>()
+        let port = parts[1]
+            .parse::<u16>()
             .map_err(|e| format!("Invalid port: {}", e))?;
         let weight = if parts.len() > 2 {
-            parts[2].parse::<f64>()
+            parts[2]
+                .parse::<f64>()
                 .map_err(|e| format!("Invalid weight: {}", e))?
         } else {
             1.0
@@ -140,9 +143,11 @@ pub struct CachePeer {
 impl CachePeer {
     pub fn new(config: PeerConfig) -> Self {
         let id = format!("{}:{}:{}", config.peer_type, config.host, config.port);
-        info!("Creating cache peer: {} (type: {}, weight: {})", 
-              id, config.peer_type, config.weight);
-        
+        info!(
+            "Creating cache peer: {} (type: {}, weight: {})",
+            id, config.peer_type, config.weight
+        );
+
         Self {
             id,
             config,
@@ -186,7 +191,7 @@ impl CachePeer {
         let base_score = self.config.weight;
         let error_rate = self.stats.error_rate();
         let rtt_factor = 1.0 / (1.0 + (self.rtt().as_millis() as f64 / 100.0));
-        
+
         base_score * (1.0 - error_rate) * rtt_factor
     }
 
@@ -233,7 +238,8 @@ impl PeerRegistry {
 
     /// Get all healthy peers
     pub async fn healthy_peers(&self) -> Vec<Arc<CachePeer>> {
-        self.all_peers().await
+        self.all_peers()
+            .await
             .into_iter()
             .filter(|p| p.is_healthy())
             .collect()
@@ -241,7 +247,8 @@ impl PeerRegistry {
 
     /// Get peers by type
     pub async fn peers_by_type(&self, peer_type: PeerType) -> Vec<Arc<CachePeer>> {
-        self.all_peers().await
+        self.all_peers()
+            .await
             .into_iter()
             .filter(|p| p.config.peer_type == peer_type)
             .collect()
@@ -249,7 +256,8 @@ impl PeerRegistry {
 
     /// Get healthy peers by type
     pub async fn healthy_peers_by_type(&self, peer_type: PeerType) -> Vec<Arc<CachePeer>> {
-        self.healthy_peers().await
+        self.healthy_peers()
+            .await
             .into_iter()
             .filter(|p| p.config.peer_type == peer_type)
             .collect()
@@ -273,7 +281,7 @@ impl PeerRegistry {
         for peer in peers {
             // Passive health check based on error rate
             let error_rate = peer.stats.error_rate();
-            
+
             if error_rate > 0.5 {
                 peer.set_healthy(false);
             } else if error_rate < 0.1 && !peer.is_healthy() {
@@ -356,7 +364,7 @@ mod tests {
         };
 
         let peer = CachePeer::new(config);
-        
+
         peer.stats.record_request().await;
         peer.stats.record_hit(1024).await;
         peer.stats.record_request().await;
@@ -405,12 +413,9 @@ mod tests {
 
     #[test]
     fn test_peer_config_parse() {
-        let result = PeerConfig::parse_from_string(
-            "parent.example.com:1488:1.5",
-            PeerType::Parent
-        );
+        let result = PeerConfig::parse_from_string("parent.example.com:1488:1.5", PeerType::Parent);
         assert!(result.is_ok());
-        
+
         let config = result.unwrap();
         assert_eq!(config.host, "parent.example.com");
         assert_eq!(config.port, 1488);

--- a/proxy/src/selection.rs
+++ b/proxy/src/selection.rs
@@ -3,7 +3,7 @@
 //! Different algorithms for choosing which parent cache to use
 //! when multiple options are available.
 
-use crate::peers::{CachePeer, PeerType};
+use crate::peers::CachePeer;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -13,7 +13,7 @@ use std::sync::Arc;
 pub trait SelectionStrategy: Send + Sync {
     /// Select a peer from the available list
     fn select<'a>(&self, peers: &'a [Arc<CachePeer>], url: &str) -> Option<&'a Arc<CachePeer>>;
-    
+
     /// Strategy name for logging/metrics
     fn name(&self) -> &'static str;
 }
@@ -75,14 +75,14 @@ impl SelectionStrategy for WeightedStrategy {
 
         // Calculate total score
         let total_score: f64 = peers.iter().map(|p| p.score()).sum();
-        
+
         if total_score == 0.0 {
             return None; // All peers unhealthy
         }
 
         // Weighted random selection
         let mut rng = rand::random::<f64>() * total_score;
-        
+
         for peer in peers {
             let score = peer.score();
             if rng <= score {
@@ -183,6 +183,7 @@ pub fn parse_strategy(name: &str) -> Box<dyn SelectionStrategy> {
 mod tests {
     use super::*;
     use crate::peers::PeerConfig;
+    use crate::PeerType;
     use std::time::Duration;
 
     fn create_test_peer(host: &str, weight: f64, rtt_ms: u64) -> Arc<CachePeer> {

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -57,6 +57,42 @@ impl CertCache {
         })
     }
 
+    /// Load CA for proxy startup. When MITM is off, missing CA files are allowed.
+    pub async fn load_for_startup(mitm_enabled: bool) -> Result<Self, Box<dyn std::error::Error>> {
+        async fn read_key() -> std::io::Result<Vec<u8>> {
+            tokio::fs::read("/certs/ca.key")
+                .await
+                .or_else(|_| std::fs::read("./certs/ca.key"))
+        }
+
+        async fn read_cert() -> Vec<u8> {
+            tokio::fs::read("/certs/ca.crt")
+                .await
+                .or_else(|_| std::fs::read("./certs/ca.crt"))
+                .unwrap_or_default()
+        }
+
+        if mitm_enabled {
+            let ca_key = read_key().await.map_err(|e| {
+                format!("MITM enabled but CA key not found at /certs/ca.key or ./certs/ca.key: {e}")
+            })?;
+            let ca_cert = read_cert().await;
+            return Self::from_pem(&ca_key, &ca_cert);
+        }
+
+        match read_key().await {
+            Ok(ca_key) => {
+                let ca_cert = read_cert().await;
+                Self::from_pem(&ca_key, &ca_cert)
+            }
+            Err(_) => {
+                warn!("MITM disabled and no CA key on disk; using ephemeral in-memory CA");
+                let key_pair = KeyPair::generate()?;
+                Self::from_pem(key_pair.serialize_pem().as_bytes(), b"")
+            }
+        }
+    }
+
     fn in_memory_ca_params() -> Result<CertificateParams, rcgen::Error> {
         let mut ca_params = CertificateParams::new(vec!["BSDM Proxy CA".to_string()])?;
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
@@ -213,6 +249,19 @@ pub fn rewrite_mitm_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn load_for_startup_without_ca_when_mitm_disabled() {
+        let dir = std::env::temp_dir().join(format!("bsdm-proxy-ca-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+        let result = CertCache::load_for_startup(false).await;
+        std::env::set_current_dir(prev).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(result.is_ok());
+    }
 
     #[test]
     fn test_parse_authority_default_port() {

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Install repository git hooks (pre-push: fmt + clippy).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+chmod +x .githooks/pre-push scripts/pre-push-check.sh
+
+git config core.hooksPath .githooks
+
+echo "Git hooks installed (core.hooksPath=.githooks)"
+echo "Pre-push will run: scripts/pre-push-check.sh"
+echo ""
+echo "To skip once: git push --no-verify"

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Local checks matching Rust CI before push (fmt + clippy).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> cargo fmt --check"
+cargo fmt --all -- --check
+
+echo "==> cargo clippy --workspace --all-targets -- -D warnings"
+cargo clippy --workspace --all-targets -- -D warnings
+
+echo "Pre-push checks passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First wave of M1 blocker fixes (see [docs/architecture.md](docs/architecture.md)).

### B5 — Optional CA when MITM off ([#36](https://github.com/onixus/bsdm-proxy/issues/36))
- `CertCache::load_for_startup(mitm_enabled)` reads `MITM_ENABLED` before CA files
- `MITM_ENABLED=false` → proxy starts without `/certs/ca.key` (ephemeral in-memory CA)
- `MITM_ENABLED=true` → clear error if CA key missing
- Test: `tls::load_for_startup_without_ca_when_mitm_disabled`

### B1 — Wire hierarchy modules ([#32](https://github.com/onixus/bsdm-proxy/issues/32))
- Export `peers`, `icp`, `selection`, `hierarchy` from `lib.rs`
- 27 lib unit tests now run in CI (ICP, peers, hierarchy, selection)

### B2 — Add rand dependency ([#33](https://github.com/onixus/bsdm-proxy/issues/33))
- `rand = "0.9"` for `WeightedStrategy`

### DX — Pre-push hook
- `./scripts/pre-push-check.sh` — `fmt --check` + clippy (как Rust CI)
- `./scripts/install-git-hooks.sh` — установка `.githooks/pre-push`

## Next blockers (not in this PR)
- B3: HTTP fetch from hierarchy peer
- B4: Start ICP server in runtime
- B6: Rate limiting

## Test plan

- [x] `cargo clippy -p bsdm-proxy --all-targets -- -D warnings`
- [x] `cargo test -p bsdm-proxy` — 45 tests
- [x] `cargo test -p bsdm-proxy-e2e` — 12/12
- [x] `./scripts/pre-push-check.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

