### PR TITLE
fix(proxy): M1 blockers B1–B5 — hierarchy runtime, optional MITM CA

### DIFF
--- a/proxy/src/cache_key.rs
+++ b/proxy/src/cache_key.rs
@@ -1,0 +1,32 @@
+//! HTTP cache key generation (shared by proxy and ICP server).
+
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+
+/// Deterministic cache key from HTTP method and URL.
+pub fn http_cache_key(method: &str, url: &str) -> Arc<str> {
+    let mut hasher = Sha256::new();
+    hasher.update(method.as_bytes());
+    hasher.update(b":");
+    hasher.update(url.as_bytes());
+    hex::encode(hasher.finalize()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_inputs_produce_same_key() {
+        let a = http_cache_key("GET", "http://example.com/a");
+        let b = http_cache_key("GET", "http://example.com/a");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn different_methods_differ() {
+        let get = http_cache_key("GET", "http://example.com/a");
+        let head = http_cache_key("HEAD", "http://example.com/a");
+        assert_ne!(get, head);
+    }
+}

--- a/proxy/src/hierarchy.rs
+++ b/proxy/src/hierarchy.rs
@@ -85,6 +85,11 @@ impl HierarchyManager {
         self.config.enabled
     }
 
+    /// Timeout for HTTP requests to parent/sibling peers.
+    pub fn parent_timeout(&self) -> Duration {
+        self.config.parent_timeout
+    }
+
     /// Determine where to fetch the resource from
     pub async fn resolve_source(&self, url: &str) -> HierarchyResult {
         if !self.config.enabled {

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -1,0 +1,143 @@
+//! Load hierarchical caching configuration from environment variables.
+
+use crate::hierarchy::{HierarchyConfig, HierarchyManager};
+use crate::peers::{PeerConfig, PeerRegistry, PeerType};
+use crate::selection::parse_strategy;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{info, warn};
+
+fn env_flag(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+fn parse_peer_list(
+    value: &str,
+    peer_type: PeerType,
+    default_icp_port: Option<u16>,
+) -> Vec<PeerConfig> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(
+            |entry| match PeerConfig::parse_from_string(entry, peer_type) {
+                Ok(mut config) => {
+                    if config.icp_port.is_none() {
+                        config.icp_port = default_icp_port;
+                    }
+                    Some(config)
+                }
+                Err(e) => {
+                    warn!("Skipping invalid peer '{}': {}", entry, e);
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
+pub fn load_hierarchy_config() -> HierarchyConfig {
+    let icp_timeout_ms = std::env::var("ICP_TIMEOUT_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    let parent_timeout_secs = std::env::var("PARENT_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+    let max_sibling_queries = std::env::var("ICP_MAX_SIBLING_QUERIES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    HierarchyConfig {
+        enabled: env_flag("HIERARCHY_ENABLED"),
+        icp_timeout: Duration::from_millis(icp_timeout_ms),
+        parent_timeout: Duration::from_secs(parent_timeout_secs),
+        max_sibling_queries,
+        retry_parents: true,
+    }
+}
+
+/// Build hierarchy manager from environment. Returns `None` when disabled.
+pub async fn build_hierarchy_manager(
+    config: &HierarchyConfig,
+) -> Result<Option<Arc<HierarchyManager>>, Box<dyn std::error::Error + Send + Sync>> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    let registry = PeerRegistry::new();
+    let sibling_icp_port = std::env::var("ICP_PEER_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .or(Some(3130));
+
+    if let Ok(parents) = std::env::var("CACHE_PARENTS") {
+        for peer_config in parse_peer_list(&parents, PeerType::Parent, None) {
+            registry.add_peer(peer_config).await;
+        }
+    }
+
+    if let Ok(siblings) = std::env::var("CACHE_SIBLINGS") {
+        for peer_config in parse_peer_list(&siblings, PeerType::Sibling, sibling_icp_port) {
+            registry.add_peer(peer_config).await;
+        }
+    }
+
+    let strategy_name =
+        std::env::var("CACHE_SELECTION_STRATEGY").unwrap_or_else(|_| "round-robin".to_string());
+    let strategy = parse_strategy(&strategy_name);
+
+    let mut manager = HierarchyManager::new(config.clone(), registry, strategy);
+
+    let client_bind = std::env::var("ICP_CLIENT_BIND").unwrap_or_else(|_| "0.0.0.0:0".to_string());
+    manager.init_icp(&client_bind).await?;
+
+    info!(
+        "Hierarchy enabled (strategy={}, ICP client bind={})",
+        strategy_name, client_bind
+    );
+
+    Ok(Some(Arc::new(manager)))
+}
+
+pub fn icp_server_bind_addr() -> String {
+    std::env::var("ICP_BIND").unwrap_or_else(|_| "0.0.0.0:3130".to_string())
+}
+
+pub fn should_start_icp_server(config: &HierarchyConfig) -> bool {
+    config.enabled
+        && std::env::var("ICP_SERVER_ENABLED")
+            .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+            .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_parents_list() {
+        let peers = parse_peer_list("127.0.0.1:1488:1.5", PeerType::Parent, None);
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].host, "127.0.0.1");
+        assert_eq!(peers[0].port, 1488);
+        assert!((peers[0].weight - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_siblings_get_default_icp_port() {
+        let peers = parse_peer_list("10.0.0.2:1488", PeerType::Sibling, Some(3130));
+        assert_eq!(peers[0].icp_port, Some(3130));
+    }
+
+    #[test]
+    fn parse_siblings_with_explicit_icp_port() {
+        let peers = parse_peer_list("10.0.0.2:1488:1.0:3140", PeerType::Sibling, Some(3130));
+        assert_eq!(peers[0].icp_port, Some(3140));
+    }
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -2,18 +2,26 @@
 
 pub mod acl;
 pub mod auth;
+pub mod cache_key;
 pub mod categorization;
 pub mod hierarchy;
+pub mod hierarchy_config;
 pub mod icp;
+pub mod peer_fetch;
 pub mod peers;
 pub mod selection;
 
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
 pub use auth::{AuthBackend, AuthConfig, AuthManager, UserInfo};
+pub use cache_key::http_cache_key;
 pub use categorization::{CategorizationConfig, CategorizationEngine, Category};
 pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};
+pub use hierarchy_config::{
+    build_hierarchy_manager, icp_server_bind_addr, load_hierarchy_config, should_start_icp_server,
+};
 pub use icp::{IcpClient, IcpMessage, IcpOpcode, IcpServer};
+pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
 pub use selection::{parse_strategy, SelectionStrategy};
 

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -6,7 +6,11 @@ mod tls;
 use auth_config::load_auth_config;
 use base64::engine::general_purpose;
 use base64::Engine;
-use bsdm_proxy::{AclAction, AclDecision, AuthManager, Category, UserInfo};
+use bsdm_proxy::{
+    build_hierarchy_manager, fetch_via_peer, http_cache_key, icp_server_bind_addr,
+    load_hierarchy_config, should_start_icp_server, AclAction, AclDecision, AuthManager, Category,
+    HierarchyManager, HierarchyResult, IcpServer, UserInfo,
+};
 use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
@@ -21,7 +25,6 @@ use quick_cache::sync::Cache;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::io::Cursor;
@@ -139,9 +142,11 @@ struct ProxyService {
     auth: Option<Arc<AuthManager>>,
     acl_engine: Option<Arc<Mutex<bsdm_proxy::AclEngine>>>,
     categorization: Option<Arc<bsdm_proxy::CategorizationEngine>>,
+    hierarchy: Option<Arc<HierarchyManager>>,
 }
 
 impl ProxyService {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         cert_cache: CertCache,
         cache_config: CacheConfig,
@@ -150,6 +155,7 @@ impl ProxyService {
         mitm_enabled: bool,
         auth: Option<Arc<AuthManager>>,
         policy: &PolicyConfig,
+        hierarchy: Option<Arc<HierarchyManager>>,
     ) -> Self {
         let kafka_producer = kafka_brokers.and_then(|brokers| {
             ClientConfig::new()
@@ -186,6 +192,7 @@ impl ProxyService {
             auth,
             acl_engine: policy.acl_engine.clone(),
             categorization: policy.categorization.clone(),
+            hierarchy,
         }
     }
 
@@ -315,11 +322,39 @@ impl ProxyService {
 
     #[inline]
     fn generate_cache_key(&self, method: &str, url: &str) -> Arc<str> {
-        let mut hasher = Sha256::new();
-        hasher.update(method.as_bytes());
-        hasher.update(b":");
-        hasher.update(url.as_bytes());
-        hex::encode(hasher.finalize()).into()
+        http_cache_key(method, url)
+    }
+
+    /// Try fetching via hierarchy peer (sibling ICP HIT or parent selection).
+    async fn try_fetch_via_hierarchy(
+        &self,
+        method: &str,
+        url: &str,
+        req: Request<Body>,
+    ) -> Option<(Arc<bsdm_proxy::CachePeer>, hyper::Response<Incoming>)> {
+        if !CACHEABLE_METHODS.contains(&method) {
+            return None;
+        }
+
+        let hierarchy = self.hierarchy.as_ref()?;
+
+        let peer = match hierarchy.resolve_source(url).await {
+            HierarchyResult::SiblingHit(peer) | HierarchyResult::ParentHit(peer) => peer,
+            HierarchyResult::LocalHit | HierarchyResult::OriginRequired => return None,
+        };
+
+        let timeout = hierarchy.parent_timeout();
+        match fetch_via_peer(&peer, req, timeout).await {
+            Ok(response) => {
+                info!("Peer response via {} for {}", peer.id, url);
+                Some((peer, response))
+            }
+            Err(e) => {
+                warn!("Peer fetch failed via {} for {}: {}", peer.id, url, e);
+                hierarchy.record_peer_error(&peer).await;
+                None
+            }
+        }
     }
 
     #[inline]
@@ -485,12 +520,23 @@ impl ProxyService {
             }
         };
         let request_body_size = body_bytes.len();
-        let req = Request::from_parts(parts, Body::new(body_bytes));
+        let req = Request::from_parts(parts, Body::new(body_bytes.clone()));
 
         let domain = Self::extract_domain(&url);
         let upstream_start = Instant::now();
 
-        match self.http_client.request(req).await {
+        let peer_fetch = self
+            .try_fetch_via_hierarchy(&method, &url, req.clone())
+            .await;
+        let hierarchy_peer = peer_fetch.as_ref().map(|(peer, _)| peer.clone());
+
+        let fetch_result = if let Some((_, response)) = peer_fetch {
+            Ok(response)
+        } else {
+            self.http_client.request(req).await
+        };
+
+        match fetch_result {
             Ok(response) => {
                 let upstream_duration = upstream_start.elapsed().as_secs_f64();
                 let status = response.status();
@@ -531,6 +577,12 @@ impl ProxyService {
                     }
                 };
                 let body_size = body_bytes.len();
+
+                if let (Some(hierarchy), Some(peer)) =
+                    (self.hierarchy.as_ref(), hierarchy_peer.as_ref())
+                {
+                    hierarchy.record_peer_hit(peer, body_size as u64).await;
+                }
 
                 let cache_status = if self.is_cacheable(&method, status.as_u16(), body_size) {
                     let headers_arc: Arc<[(Arc<str>, Arc<str>)]> = headers_map
@@ -895,6 +947,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("URL categorization enabled");
     }
 
+    let hierarchy_config = load_hierarchy_config();
+    let hierarchy = build_hierarchy_manager(&hierarchy_config)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error> { e })?;
+
     let service = Arc::new(ProxyService::new(
         cert_cache,
         cache_config.clone(),
@@ -903,7 +960,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         mitm_enabled,
         auth,
         &policy_config,
+        hierarchy.clone(),
     ));
+
+    if should_start_icp_server(&hierarchy_config) {
+        let icp_bind = icp_server_bind_addr();
+        let cache_for_icp = service.http_cache.clone();
+        match IcpServer::new(&icp_bind, move |url: &str| {
+            let key = http_cache_key("GET", url);
+            cache_for_icp
+                .get(&key)
+                .is_some_and(|cached| !cached.is_expired())
+        })
+        .await
+        {
+            Ok(server) => {
+                info!("ICP server listening on {}", icp_bind);
+                let server = Arc::new(server);
+                tokio::spawn(async move {
+                    server.serve().await;
+                });
+            }
+            Err(e) => warn!("ICP server disabled: failed to bind {}: {}", icp_bind, e),
+        }
+    }
+
+    if hierarchy_config.enabled {
+        if let Some(ref manager) = hierarchy {
+            info!("{}", manager.stats_summary().await);
+        }
+    }
 
     if policy_config.acl_auto_reload {
         if let (Some(acl_engine), Some(rules_path)) = (

--- a/proxy/src/peer_fetch.rs
+++ b/proxy/src/peer_fetch.rs
@@ -1,0 +1,132 @@
+//! Forward HTTP requests to a parent/sibling cache peer (forward proxy).
+
+use crate::peers::CachePeer;
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::body::Incoming;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tracing::debug;
+
+type Body = Full<Bytes>;
+
+#[derive(Debug)]
+pub enum PeerFetchError {
+    Connect(std::io::Error),
+    Handshake(hyper::Error),
+    Request(hyper::Error),
+    Timeout,
+}
+
+impl std::fmt::Display for PeerFetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "connect failed: {e}"),
+            Self::Handshake(e) => write!(f, "TLS/HTTP handshake failed: {e}"),
+            Self::Request(e) => write!(f, "request failed: {e}"),
+            Self::Timeout => write!(f, "peer request timed out"),
+        }
+    }
+}
+
+impl std::error::Error for PeerFetchError {}
+
+/// Send an HTTP forward-proxy request through a cache peer.
+pub async fn fetch_via_peer(
+    peer: &CachePeer,
+    req: Request<Body>,
+    timeout: Duration,
+) -> Result<Response<Incoming>, PeerFetchError> {
+    let addr = format!("{}:{}", peer.config.host, peer.config.port);
+    debug!("Fetching via peer {} ({})", peer.id, addr);
+
+    let stream = tokio::time::timeout(timeout, TcpStream::connect(&addr))
+        .await
+        .map_err(|_| PeerFetchError::Timeout)?
+        .map_err(PeerFetchError::Connect)?;
+
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) =
+        tokio::time::timeout(timeout, hyper::client::conn::http1::handshake(io))
+            .await
+            .map_err(|_| PeerFetchError::Timeout)?
+            .map_err(PeerFetchError::Handshake)?;
+
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            debug!("Peer connection closed: {}", e);
+        }
+    });
+
+    tokio::time::timeout(timeout, sender.send_request(req))
+        .await
+        .map_err(|_| PeerFetchError::Timeout)?
+        .map_err(PeerFetchError::Request)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peers::{CachePeer, PeerConfig, PeerType};
+    use http_body_util::BodyExt;
+    use hyper::service::service_fn;
+    use hyper::{Method, StatusCode};
+    use hyper_util::rt::TokioIo;
+    use std::convert::Infallible;
+    use tokio::net::TcpListener;
+
+    async fn spawn_echo_proxy() -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let service = service_fn(|req: Request<Incoming>| async move {
+                        let path = req.uri().path();
+                        Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(format!(
+                            "peer:{path}"
+                        )))))
+                    });
+                    let _ = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, service)
+                        .await;
+                });
+            }
+        });
+
+        (port, handle)
+    }
+
+    #[tokio::test]
+    async fn fetch_via_peer_returns_peer_response() {
+        let (port, _task) = spawn_echo_proxy().await;
+        let peer = CachePeer::new(PeerConfig {
+            host: "127.0.0.1".to_string(),
+            port,
+            peer_type: PeerType::Parent,
+            weight: 1.0,
+            icp_port: None,
+            max_connections: 10,
+        });
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/via-peer")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        let response = fetch_via_peer(&peer, req, Duration::from_secs(5))
+            .await
+            .expect("peer fetch");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), b"peer:/via-peer");
+    }
+}

--- a/proxy/src/peers.rs
+++ b/proxy/src/peers.rs
@@ -103,19 +103,28 @@ impl PeerConfig {
     pub fn parse_from_string(s: &str, peer_type: PeerType) -> Result<Self, String> {
         let parts: Vec<&str> = s.split(':').collect();
         if parts.len() < 2 {
-            return Err("Invalid peer format. Expected host:port[:weight]".to_string());
+            return Err("Invalid peer format. Expected host:port[:weight][:icp_port]".to_string());
         }
 
         let host = parts[0].to_string();
         let port = parts[1]
             .parse::<u16>()
             .map_err(|e| format!("Invalid port: {}", e))?;
-        let weight = if parts.len() > 2 {
+        let weight = if parts.len() > 2 && !parts[2].is_empty() {
             parts[2]
                 .parse::<f64>()
                 .map_err(|e| format!("Invalid weight: {}", e))?
         } else {
             1.0
+        };
+        let icp_port = if parts.len() > 3 && !parts[3].is_empty() {
+            Some(
+                parts[3]
+                    .parse::<u16>()
+                    .map_err(|e| format!("Invalid ICP port: {}", e))?,
+            )
+        } else {
+            None
         };
 
         Ok(Self {
@@ -123,7 +132,7 @@ impl PeerConfig {
             port,
             peer_type,
             weight,
-            icp_port: None,
+            icp_port,
             max_connections: 100,
         })
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes M1 wave-1 blockers B1–B5: hierarchy modules wired into runtime, optional MITM CA, and pre-push checks.

### B1 (#32) — Export hierarchy modules from lib
- `hierarchy`, `peers`, `icp`, `selection` exported from `proxy/src/lib.rs`
- 33 library unit tests run in CI

### B2 (#33) — Add `rand` dependency
- `rand = "0.9"` in `proxy/Cargo.toml` for weighted peer selection

### B3 (#34) — HTTP fetch from hierarchy peer
- New `peer_fetch` module: `fetch_via_peer()` sends forward-proxy HTTP/1 requests to parent/sibling peers
- After L1 cache miss, `handle_request` calls `HierarchyManager::resolve_source()` and fetches via peer on `ParentHit`/`SiblingHit`
- Falls back to origin on peer error; records peer stats

### B4 (#35) — Start ICP server in runtime
- New `hierarchy_config` module loads `HIERARCHY_ENABLED`, `CACHE_PARENTS`, `CACHE_SIBLINGS`, strategy, timeouts from env
- ICP UDP server starts on `ICP_BIND` (default `0.0.0.0:3130`) and responds HIT/MISS based on local `http_cache`
- Shared `http_cache_key()` used by proxy and ICP handler

### B5 (#36) — Optional CA when MITM disabled
- `CertCache::load_for_startup(mitm_enabled)` skips CA load when `MITM_ENABLED=false`

### DX
- `scripts/pre-push-check.sh` + `.githooks/pre-push` run `fmt --check` and clippy before push

## Env vars (hierarchy)

```
HIERARCHY_ENABLED=true
CACHE_PARENTS=host:port[:weight]
CACHE_SIBLINGS=host:port[:weight][:icp_port]
ICP_BIND=0.0.0.0:3130
ICP_CLIENT_BIND=0.0.0.0:0
ICP_PEER_PORT=3130
CACHE_SELECTION_STRATEGY=round-robin
ICP_TIMEOUT_MS=100
PARENT_TIMEOUT_SECONDS=5
```

## Test plan

- [x] `./scripts/pre-push-check.sh`
- [x] `cargo test -p bsdm-proxy` (33 lib + 7 bin + 11 integration)
- [x] `peer_fetch` mock peer test
- [x] `hierarchy_config` peer list parsing tests

Closes #32, closes #33, closes #34, closes #35, closes #36
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

