### PR TITLE
chore(release): 0.2.3-test release package

### DIFF
--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-indexer"
-version = "0.2.2-b"
+version = "0.2.3-test"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-proxy"
-version = "0.2.2-b"
+version = "0.2.3-test"
 edition = "2021"
 
 # Binary targets

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -6,8 +6,9 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 VERSION="$(grep '^version' proxy/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
-# Cargo 0.2.2-b → package label 0.2.2b
+# Cargo 0.2.2-b → 0.2.2b, 0.2.3-test → 0.2.3test
 PACKAGE_VERSION="${VERSION//-b/b}"
+PACKAGE_VERSION="${PACKAGE_VERSION//-test/test}"
 ARCH="$(uname -m)"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 PACKAGE_NAME="bsdm-proxy-${PACKAGE_VERSION}-${OS}-${ARCH}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump workspace version to **0.2.3-test** (`proxy`, `cache-indexer`).
- Extend `scripts/build-package.sh` to map Cargo `-test` suffix to package label (`0.2.3test`).
- Built local test release archive on linux x86_64.

## Package

| Artifact | Path |
|----------|------|
| Archive | `dist/bsdm-proxy-0.2.3test-linux-x86_64.tar.gz` (~12M) |
| Staging dir | `dist/bsdm-proxy-0.2.3test-linux-x86_64/` |
| VERSION file | `0.2.3-test` |

### SHA256

```
3997d559f35b46fdbeac66f1e804d3711f03676ef919cfbbaf4bffdff1de8b99  bin/cache-indexer
23618f22842ac4d030a652c5a86a258eb518271a1c22d131c841cf0cd2e11b4d  bin/proxy
```

## Verification

- `./scripts/build-package.sh` completed successfully.
- Extracted `proxy` binary starts and responds on `/health`.

## Next steps

To publish on GitHub Releases, tag and upload the tarball:

```bash
git tag v0.2.3test
git push origin v0.2.3test
# upload dist/bsdm-proxy-0.2.3test-linux-x86_64.tar.gz to the release
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ab18ae7-ea5a-4947-9739-26a50ca76d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ab18ae7-ea5a-4947-9739-26a50ca76d9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

