### PR TITLE
docs: update project documentation for v0.2.2b hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 | Область | Возможности |
 |---------|-------------|
-| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (порты 443/8443), HTTP CONNECT, кеш L1 |
+| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (порты 443/8443), HTTP CONNECT, кеш L1, **иерархический кеш** (ICP + parent/sibling peers) |
 | **Безопасность** | Proxy-аутентификация (Basic / LDAP / NTLM), ACL, категоризация URL |
 | **Наблюдаемость** | Prometheus (20+ метрик), Grafana, `/health`, `/ready`, `/metrics` |
 | **Аналитика** | Kafka → cache-indexer → OpenSearch |
@@ -27,18 +27,22 @@
 ## Архитектура
 
 ```
-┌─────────┐         ┌──────────────────────────┐         ┌──────────────┐
-│ Клиент  │◄───────►│  BSDM-Proxy              │◄───────►│   Upstream   │
-│         │  HTTPS  │  Auth → ACL → Cache      │  HTTPS  │    Server    │
-└─────────┘         └────────────┬─────────────┘         └──────────────┘
+┌─────────┐         ┌──────────────────────────────────────┐         ┌──────────────┐
+│ Клиент  │◄───────►│  BSDM-Proxy                          │◄───────►│   Upstream   │
+│         │  HTTPS  │  Auth → ACL → L1 → [ICP → peer]      │  HTTPS  │    Server    │
+└─────────┘         └────────────┬─────────────────────────┘         └──────────────┘
                                  │
                         :9090 /metrics
                     ┌────────────┴────────────┐
              ┌──────▼──────┐           ┌──────▼──────┐
              │ quick_cache │           │   Kafka     │
              │   (L1)      │           │  (async)    │
-             └─────────────┘           └──────┬──────┘
-                                              │
+             └──────┬──────┘           └──────┬──────┘
+                    │ ICP :3130 (UDP)         │
+             ┌──────▼──────┐                  │
+             │ sibling /   │                  │
+             │ parent peer │                  │
+             └─────────────┘                  │
                     ┌─────────────────────────┼─────────────────┐
              ┌──────▼─────────┐        ┌──────▼──────┐   ┌──────▼──────┐
              │ Cache-Indexer  │        │ Prometheus  │   │  Grafana    │
@@ -52,7 +56,8 @@
 
 | Компонент | Порт | Описание |
 |-----------|------|----------|
-| **proxy** | 1488 | HTTPS-прокси, MITM, кеш, метрики |
+| **proxy** | 1488 | HTTPS-прокси, MITM, кеш L1, иерархия (опционально) |
+| **ICP** | 3130 | UDP-запросы между cache peers (при `HIERARCHY_ENABLED=true`) |
 | **metrics** | 9090 | `/health`, `/ready`, `/metrics` |
 | **cache-indexer** | — | Kafka → OpenSearch |
 | **Kafka** | 9092 | Очередь событий кеша |
@@ -181,6 +186,26 @@ CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallbac
 
 → [docs/acl.md](docs/acl.md) · [docs/categorization.md](docs/categorization.md)
 
+### Иерархический кеш (опционально)
+
+Включается через `HIERARCHY_ENABLED=true`. После промаха L1: ICP-запрос к siblings → выбор parent → HTTP fetch через peer → fallback на origin.
+
+| Переменная | По умолчанию | Описание |
+|-----------|-------------|----------|
+| `HIERARCHY_ENABLED` | `false` | Включить иерархию |
+| `CACHE_PARENTS` | — | Parent peers: `host:port[:weight]` |
+| `CACHE_SIBLINGS` | — | Sibling peers: `host:port[:weight][:icp_port]` |
+| `CACHE_SELECTION_STRATEGY` | `round-robin` | `round-robin`, `weighted`, `closest`, `hash` |
+| `ICP_BIND` | `0.0.0.0:3130` | Адрес ICP-сервера (UDP) |
+| `ICP_CLIENT_BIND` | `0.0.0.0:0` | Bind для ICP-клиента |
+| `ICP_PEER_PORT` | `3130` | ICP-порт siblings по умолчанию |
+| `ICP_TIMEOUT_MS` | `100` | Таймаут ICP-запроса (мс) |
+| `ICP_SERVER_ENABLED` | `true` | Запускать локальный ICP-сервер |
+| `PARENT_TIMEOUT_SECONDS` | `5` | Таймаут HTTP-запроса к peer |
+| `ICP_MAX_SIBLING_QUERIES` | `10` | Макс. параллельных ICP-запросов |
+
+→ [docs/hierarchical-caching.md](docs/hierarchical-caching.md)
+
 ### Cache-indexer
 
 | Переменная | По умолчанию | Описание |
@@ -246,6 +271,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | [docs/authentication.md](docs/authentication.md) | LDAP, NTLM, Basic Auth |
 | [docs/acl.md](docs/acl.md) | Правила доступа, приоритеты |
 | [docs/categorization.md](docs/categorization.md) | Shallalist, URLhaus, PhishTank |
+| [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш, ICP, peers |
 | [docs/architecture.md](docs/architecture.md) | Архитектура и блокеры |
 | [docs/roadmap.md](docs/roadmap.md) | Roadmap и milestones |
 | [packaging/README.md](packaging/README.md) | Release-пакет и systemd |
@@ -260,8 +286,8 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 
 | Milestone | Версия | Фокус | Статус |
 |-----------|--------|-------|--------|
-| **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability | ~90% |
-| **M2** Squid parity | v0.3.x | Иерархия, L2, rate limit, полный ACL | Planned |
+| **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability, иерархия | ~95% |
+| **M2** Squid parity | v0.3.x | L2 Redis, rate limit, полный ACL, hierarchy Phase 4 | Planned |
 | **M3** Retro-search | v0.4.x | OpenSearch dashboards, поиск по истории | Planned |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | Planned |
 | **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | Planned |
@@ -274,8 +300,9 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] ACL + URL categorization
 - [x] E2E / smoke test harness
 - [x] Release packaging (`0.2.2b`)
+- [x] Hierarchical caching Phase 3 — ICP server, peer fetch, env config
 - [ ] Rate limiting per user/IP
-- [ ] Hierarchical caching — Phase 3 integration
+- [ ] Рефакторинг `main.rs` (вынос `ProxyService` в lib)
 
 ### M2 — Squid parity (v0.3.x)
 
@@ -284,7 +311,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [ ] Compression (Brotli/Zstd)
 - [ ] ACL TimeWindow + group rules
 - [ ] NTLM auth
-- [ ] Hierarchy Phase 4 (discovery, digest, HTCP)
+- [ ] Hierarchy Phase 4 (discovery, digest, HTCP, hierarchy metrics)
 
 ### M3–M5
 

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -10,53 +10,53 @@
 
 ## Critical — M1
 
-| ID | Issue | Блокер |
-|----|-------|--------|
-| B1 | [#32](https://github.com/onixus/bsdm-proxy/issues/32) | Wire hierarchy modules into binary |
-| B2 | [#33](https://github.com/onixus/bsdm-proxy/issues/33) | Add `rand` dependency for WeightedStrategy |
-| B3 | [#34](https://github.com/onixus/bsdm-proxy/issues/34) | Implement HTTP fetch from hierarchy peer |
-| B4 | [#35](https://github.com/onixus/bsdm-proxy/issues/35) | Start ICP server in proxy runtime |
-| B5 | [#36](https://github.com/onixus/bsdm-proxy/issues/36) | Make `ca.key` optional when MITM disabled |
-| B6 | [#37](https://github.com/onixus/bsdm-proxy/issues/37) | Implement rate limiting per user/IP |
+| ID | Issue | Блокер | Статус |
+|----|-------|--------|--------|
+| B1 | [#32](https://github.com/onixus/bsdm-proxy/issues/32) | Wire hierarchy modules into binary | ✅ |
+| B2 | [#33](https://github.com/onixus/bsdm-proxy/issues/33) | Add `rand` dependency for WeightedStrategy | ✅ |
+| B3 | [#34](https://github.com/onixus/bsdm-proxy/issues/34) | Implement HTTP fetch from hierarchy peer | ✅ |
+| B4 | [#35](https://github.com/onixus/bsdm-proxy/issues/35) | Start ICP server in proxy runtime | ✅ |
+| B5 | [#36](https://github.com/onixus/bsdm-proxy/issues/36) | Make `ca.key` optional when MITM disabled | ✅ |
+| B6 | [#37](https://github.com/onixus/bsdm-proxy/issues/37) | Implement rate limiting per user/IP | ❌ |
 
 ## High — M2 / M3
 
-| ID | Issue | Блокер |
-|----|-------|--------|
-| B7 | [#38](https://github.com/onixus/bsdm-proxy/issues/38) | Refactor ProxyService out of `main.rs` |
-| B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path |
-| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex |
-| B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) |
-| B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent |
-| B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate |
-| B13 | [#44](https://github.com/onixus/bsdm-proxy/issues/44) | Implement NTLM or remove from docs |
-| B14 | [#45](https://github.com/onixus/bsdm-proxy/issues/45) | ACL TimeWindow + group rules |
+| ID | Issue | Блокер | Статус |
+|----|-------|--------|--------|
+| B7 | [#38](https://github.com/onixus/bsdm-proxy/issues/38) | Refactor ProxyService out of `main.rs` | ❌ |
+| B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path | ❌ |
+| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | ❌ |
+| B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) | ❌ |
+| B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ❌ |
+| B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ❌ |
+| B13 | [#44](https://github.com/onixus/bsdm-proxy/issues/44) | Implement NTLM or remove from docs | ❌ |
+| B14 | [#45](https://github.com/onixus/bsdm-proxy/issues/45) | ACL TimeWindow + group rules | ❌ |
 
 ## Medium — M3 / M4 / M5
 
-| ID | Issue | Блокер |
-|----|-------|--------|
-| B15 | [#46](https://github.com/onixus/bsdm-proxy/issues/46) | Design analytics/ML worker service |
-| B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics |
-| B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | OpenSearch Dashboards in docker-compose |
-| B18 | [#49](https://github.com/onixus/bsdm-proxy/issues/49) | Behavioral threat signals (beyond blocklists) |
-| B19 | [#50](https://github.com/onixus/bsdm-proxy/issues/50) | Alerting pipeline to SIEM/webhook |
-| B20 | [#51](https://github.com/onixus/bsdm-proxy/issues/51) | Security analytics dashboards (historical) |
+| ID | Issue | Блокер | Статус |
+|----|-------|--------|--------|
+| B15 | [#46](https://github.com/onixus/bsdm-proxy/issues/46) | Design analytics/ML worker service | ❌ |
+| B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics | ❌ |
+| B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | OpenSearch Dashboards in docker-compose | ❌ |
+| B18 | [#49](https://github.com/onixus/bsdm-proxy/issues/49) | Behavioral threat signals (beyond blocklists) | ❌ |
+| B19 | [#50](https://github.com/onixus/bsdm-proxy/issues/50) | Alerting pipeline to SIEM/webhook | ❌ |
+| B20 | [#51](https://github.com/onixus/bsdm-proxy/issues/51) | Security analytics dashboards (historical) | ❌ |
 
 ## Structural
 
-| ID | Issue | Блокер |
-|----|-------|--------|
-| B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main |
-| B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching |
-| B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client |
-| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget |
-| B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API |
+| ID | Issue | Блокер | Статус |
+|----|-------|--------|--------|
+| B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
+| B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ❌ |
+| B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ❌ |
+| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ❌ |
+| B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |
 
 ---
 
 ## Волны разблокировки
 
-1. **Волна 1 (M1):** B5 → B1+B2 → B3+B4 → B6 → B7
+1. **Волна 1 (M1):** ~~B5~~ → ~~B1+B2~~ → ~~B3+B4~~ → **B6** → **B7**
 2. **Волна 2 (M3):** B12 → B11 → B10 → B17
 3. **Волна 3 (M4/M5):** B16 → B15 → B8

--- a/docs/HIERARCHICAL_CACHING_README.md
+++ b/docs/HIERARCHICAL_CACHING_README.md
@@ -1,293 +1,125 @@
 # Hierarchical Caching for BSDM-Proxy
 
-> См. также: [полная документация](hierarchical-caching.md) · [оглавление](README.md)
+> См. также: [полная документация](hierarchical-caching.md) · [оглавление](README.md) · [architecture.md](architecture.md)
 
-## 🎯 Goal
+## Статус: Phase 3 интегрирована (v0.2.2b)
 
-Implement Squid-style hierarchical caching to allow multiple BSDM-Proxy instances to form a cache hierarchy, dramatically improving cache hit rates and reducing upstream traffic.
+Иерархический кеш **включён в runtime** и активируется через `HIERARCHY_ENABLED=true` (по умолчанию выключен).
 
-## 🏗️ Architecture
+## Архитектура
 
-### Cache Hierarchy Levels
+### Уровни кеша
 
 ```
-Level 1: Edge Caches (close to users)
-  ↓ Query siblings via ICP
-  ↓ Query parents on MISS
-Level 2: Regional Caches (fewer, larger)
-  ↓ Query siblings via ICP  
-  ↓ Query central parent on MISS
-Level 3: Central Cache (single, very large)
-  ↓ Fetch from origin
+Level 1: Edge (локальный L1 quick_cache)
+  ↓ ICP query siblings (UDP :3130)
+  ↓ HTTP fetch parent on MISS
+Level 2: Parent caches
+  ↓
 Origin Servers
 ```
 
-### Key Components
+### Реализованные модули
 
-✅ **Peer Management** (`proxy/src/peers.rs`) - DONE
-- Registry of parent and sibling caches
-- Health tracking and statistics
-- RTT measurement
-- Peer scoring algorithm
+| Модуль | Файл | Статус |
+|--------|------|--------|
+| Peer registry | `peers.rs` | ✅ |
+| ICP v2 UDP | `icp.rs` | ✅ client + server |
+| Selection | `selection.rs` | ✅ round-robin, weighted, closest, hash |
+| Hierarchy manager | `hierarchy.rs` | ✅ `resolve_source()` |
+| Env config | `hierarchy_config.rs` | ✅ |
+| Peer HTTP fetch | `peer_fetch.rs` | ✅ `fetch_via_peer()` |
+| Cache key | `cache_key.rs` | ✅ shared proxy + ICP |
+| Runtime wiring | `main.rs` | ✅ request path + ICP spawn |
 
-✅ **ICP Protocol** (`proxy/src/icp.rs`) - DONE
-- UDP-based cache queries (RFC 2186)
-- Fast HIT/MISS responses (<100ms)
-- Parallel queries to multiple siblings
-- Async non-blocking implementation
+## Поток запроса
 
-🚧 **Selection Strategy** (TODO)
-- Round-robin
-- Weighted
-- Closest (RTT-based)
-- Consistent hashing
-
-🚧 **Hierarchy Manager** (TODO)
-- Request flow coordination
-- Cache level traversal
-- Fallback logic
-
-🚧 **Integration** (TODO)
-- Wire into main request pipeline
-- Configuration loading
-- Metrics integration
-
-## 📦 What's Been Implemented
-
-### 1. Peer Management (`peers.rs`)
-
-```rust
-// Create peer registry
-let registry = PeerRegistry::new();
-
-// Add parent cache
-let parent_config = PeerConfig {
-    host: "parent.example.com".to_string(),
-    port: 1488,
-    peer_type: PeerType::Parent,
-    weight: 1.0,
-    icp_port: Some(3130),
-    max_connections: 100,
-};
-registry.add_peer(parent_config).await;
-
-// Get healthy parents
-let parents = registry.parent_caches().await;
+```
+1. Client → proxy
+2. L1 cache lookup
+   ├─ HIT → return
+   └─ MISS → continue
+3. [HIERARCHY_ENABLED] resolve_source(url)
+   ├─ ICP query siblings (parallel)
+   ├─ select parent (strategy)
+   └─ fetch_via_peer() on hit
+4. origin fallback (http_client)
+5. cache insert → response
 ```
 
-**Features:**
-- Parent/sibling peer types
-- Health tracking (automatic unhealthy peer exclusion)
-- Per-peer statistics (requests, hits, misses, errors)
-- RTT tracking
-- Peer scoring (weight × (1 - error_rate) × rtt_factor)
-- Concurrent access with RwLock
+## Конфигурация
 
-### 2. ICP Protocol (`icp.rs`)
-
-```rust
-// Server: respond to ICP queries
-let server = IcpServer::new("0.0.0.0:3130", |url| {
-    // Check if URL is in cache
-    cache.contains(url)
-}).await?;
-
-tokio::spawn(async move { server.serve().await });
-
-// Client: query peers
-let client = IcpClient::new("0.0.0.0:0").await?;
-let peer = "sibling.example.com:3130".parse()?;
-
-let result = client.query_peer(
-    peer,
-    "http://example.com/image.jpg",
-    Duration::from_millis(100)
-).await?;
-
-if result.response == IcpOpcode::Hit {
-    println!("Sibling has the object! Fetch from {}", result.peer);
-}
-```
-
-**Features:**
-- Full ICP v2 protocol (RFC 2186)
-- Query/Hit/Miss/Error opcodes
-- Parallel queries to multiple peers
-- Configurable timeouts
-- Low latency (<1ms encoding/decoding)
-- Unit tests included
-
-## 🚀 Benefits
-
-### Cache Hit Rate Improvement
-- **Before**: 30-40% (single instance)
-- **After**: 70-85% (3-tier hierarchy)
-
-### Bandwidth Savings
-- Reduced origin traffic by 60-70%
-- Faster response times (peer << origin)
-- Lower CDN costs
-
-### Scalability
-- Horizontal scaling: add more edge caches
-- Load distribution across multiple parents
-- Sibling cooperation reduces parent load
-
-## 📋 Implementation Roadmap
-
-См. [roadmap.md](roadmap.md) — milestones M1 (Phase 3) и M2 (Phase 4).
-
-### Phase 1: Core Infrastructure ✅ DONE (M1)
-- [x] Peer management module (`peers.rs`)
-- [x] ICP protocol implementation (`icp.rs`)
-- [x] Unit tests
-
-### Phase 2: Selection & Routing ✅ DONE on disk (M1, not wired)
-- [x] Selection strategies (`selection.rs`) — round-robin, weighted, closest, hash
-- [x] Hierarchy manager (`hierarchy.rs`)
-- [ ] Wire into binary (`lib.rs` / `main.rs`)
-
-### Phase 3: Integration 📅 M1 remaining
-- [ ] Configuration loading (env vars + TOML)
-- [ ] Wire into main.rs request pipeline
-- [ ] Metrics integration (Prometheus)
-- [ ] Docker-compose multi-instance setup
-- [ ] End-to-end tests
-
-### Phase 4: Advanced Features 🔮 M2
-- [ ] Peer auto-discovery (multicast)
-- [ ] Cache digest (Bloom filters)
-- [ ] HTCP protocol support
-- [ ] mTLS between peers
-- [ ] Geographic routing
-
-## 🔧 Configuration (Planned)
-
-### Environment Variables
+### Переменные окружения
 
 ```bash
-# Enable hierarchy
 HIERARCHY_ENABLED=true
 
-# Parent caches (comma-separated: host:port:weight)
+# Parents: host:port[:weight]
 CACHE_PARENTS=parent1.example.com:1488:1.0,parent2.example.com:1488:0.5
 
-# Sibling caches
-CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488
+# Siblings: host:port[:weight][:icp_port]
+CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488:1.0:3130
 
-# ICP settings
-ICP_PORT=3130
+CACHE_SELECTION_STRATEGY=round-robin   # weighted, closest, hash
+
+ICP_BIND=0.0.0.0:3130                  # локальный ICP server (UDP)
+ICP_CLIENT_BIND=0.0.0.0:0                # ICP client bind
+ICP_PEER_PORT=3130                       # default ICP port для siblings
 ICP_TIMEOUT_MS=100
-
-# Selection strategy
-CACHE_SELECTION_STRATEGY=weighted  # round-robin, weighted, closest, hash
+ICP_SERVER_ENABLED=true                  # false — не слушать ICP
+PARENT_TIMEOUT_SECONDS=5                 # HTTP timeout к peer
+ICP_MAX_SIBLING_QUERIES=10
 ```
 
-### TOML Configuration
+Пример в пакете: [packaging/config/bsdm-proxy.env.example](../packaging/config/bsdm-proxy.env.example)
 
-```toml
-[hierarchy]
-enabled = true
-selection_strategy = "weighted"
-
-[[hierarchy.parents]]
-host = "parent.example.com"
-port = 1488
-weight = 1.0
-icp_port = 3130
-
-[[hierarchy.siblings]]
-host = "sibling.example.com"
-port = 1488
-icp_port = 3130
-```
-
-## 🧪 Testing
-
-### Run Unit Tests
+## Быстрый старт (два инстанса)
 
 ```bash
-# Test peer management
-cargo test --lib peers
+# Terminal 1: parent (с ICP)
+HIERARCHY_ENABLED=true \
+MITM_ENABLED=false \
+HTTP_PORT=1488 \
+ICP_BIND=127.0.0.1:3130 \
+./target/release/proxy
 
-# Test ICP protocol
-cargo test --lib icp
+# Terminal 2: child (parent = localhost:1488)
+HIERARCHY_ENABLED=true \
+MITM_ENABLED=false \
+HTTP_PORT=1489 \
+CACHE_PARENTS=127.0.0.1:1488:1.0 \
+ICP_BIND=127.0.0.1:3131 \
+./target/release/proxy
 
-# All tests
-cargo test
+# Запрос через child
+curl -x http://127.0.0.1:1489 http://httpbin.org/get
 ```
 
-### Multi-Instance Test Setup (Coming Soon)
+## Тесты
 
 ```bash
-# Start 3-tier hierarchy
-docker-compose -f docker-compose.hierarchy.yml up -d
-
-# Test flow:
-# Client → Edge Cache → Regional Cache → Central Cache → Origin
+cargo test -p bsdm-proxy --lib peers
+cargo test -p bsdm-proxy --lib icp
+cargo test -p bsdm-proxy --lib hierarchy
+cargo test -p bsdm-proxy --lib peer_fetch
+cargo test -p bsdm-proxy --lib hierarchy_config
 ```
 
-## 📊 Metrics (Planned)
+## Roadmap (оставшееся)
 
-```promql
-# Hierarchy request flow
-bsdm_proxy_hierarchy_requests_total{peer, result}
+### Phase 3 — доработки M1
+- [ ] `docker-compose.hierarchy.yml` — 3-tier demo
+- [ ] E2E тест hierarchy peer fetch
+- [ ] Prometheus metrics `bsdm_proxy_hierarchy_*`
 
-# ICP queries
-bsdm_proxy_hierarchy_icp_queries_total{peer, response}
+### Phase 4 — M2
+- [ ] Peer auto-discovery (multicast)
+- [ ] Cache digest (Bloom filters)
+- [ ] HTCP protocol
+- [ ] mTLS между peers
 
-# Peer health
-bsdm_proxy_hierarchy_peer_health{peer, type}
-
-# Selection latency
-bsdm_proxy_hierarchy_selection_duration_seconds
-
-# Cache hierarchy hit rate
-sum(rate(bsdm_proxy_hierarchy_requests_total{result="hit"}[5m])) /
-sum(rate(bsdm_proxy_hierarchy_requests_total[5m]))
-```
-
-## 🤝 Contributing
-
-Next steps for contributors:
-
-1. **Selection Strategies**: Implement `proxy/src/selection.rs`
-2. **Hierarchy Manager**: Implement `proxy/src/hierarchy.rs`
-3. **Integration Tests**: Create multi-instance docker-compose setup
-4. **Documentation**: Add usage examples and tutorials
-
-## 📚 References
+## Ссылки
 
 - [Squid Cache Hierarchy](http://www.squid-cache.org/Doc/config/cache_peer/)
 - [RFC 2186: ICP v2](https://datatracker.ietf.org/doc/html/rfc2186)
-- [RFC 2756: HTCP](https://datatracker.ietf.org/doc/html/rfc2756)
-- [Cache Hierarchy Best Practices](https://wiki.squid-cache.org/SquidFaq/CacheHierarchy)
-
-## 🎉 Quick Demo (Coming Soon)
-
-```bash
-# Terminal 1: Central cache
-CACHE_LEVEL=central cargo run --bin proxy
-
-# Terminal 2: Regional cache
-CACHE_LEVEL=regional \
-CACHE_PARENTS=localhost:1488:1.0 \
-cargo run --bin proxy -- --http-port 1489
-
-# Terminal 3: Edge cache
-CACHE_LEVEL=edge \
-CACHE_PARENTS=localhost:1489:1.0 \
-CACHE_SIBLINGS=localhost:1490:1.0 \
-cargo run --bin proxy -- --http-port 1490
-
-# Terminal 4: Test request
-curl -x http://localhost:1490 https://httpbin.org/get
-
-# Check hierarchy traversal in logs!
-```
-
----
-
-**Status**: 🚧 Work in Progress - Phase 1 Complete
-
-**ETA for MVP**: Q1 2026
+- [roadmap.md](roadmap.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,3 +50,5 @@
 ## Версии
 
 Текущая beta-версия: **0.2.2b** — [GitHub Releases](https://github.com/onixus/bsdm-proxy/releases)
+
+**Новое в 0.2.2b:** иерархический кеш (ICP + peer fetch), optional MITM CA, pre-push hook.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,17 +21,19 @@ flowchart TB
     AUTH[auth.rs]
     POL[policy: categorize + ACL]
     CACHE[L1 quick_cache]
+    HIER[hierarchy.rs]
+    PEER[peer_fetch.rs]
+    ICP[icp.rs server :3130]
     UP[Hyper upstream client]
     TLS[tls.rs MITM]
     MET[metrics :9090]
     KPROD[Kafka producer]
   end
 
-  subgraph orphan [Код вне бинарника]
+  subgraph lib_modules [Library modules]
     PEERS[peers.rs]
-    ICP[icp.rs]
-    HIER[hierarchy.rs]
     SEL[selection.rs]
+    HCFG[hierarchy_config.rs]
   end
 
   subgraph pipeline [Analytics pipeline]
@@ -49,6 +51,10 @@ flowchart TB
   MAIN --> AUTH --> POL --> CACHE
   POL --> CAT[categorization.rs]
   POL --> ACL[acl.rs]
+  CACHE --> HIER
+  HIER --> ICP
+  HIER --> PEER
+  PEER --> UP
   CACHE --> UP
   MAIN --> TLS
   MAIN --> KPROD --> KAFKA --> IDX --> OS
@@ -60,7 +66,7 @@ flowchart TB
 | Proxy binary | `proxy/src/main.rs` | ✅ |
 | Policy library | `proxy/src/lib.rs` — `acl`, `auth`, `categorization` | ✅ |
 | MITM | `proxy/src/tls.rs` | ✅ |
-| Hierarchy / ICP | `peers.rs`, `icp.rs`, `hierarchy.rs`, `selection.rs` | ❌ не подключены |
+| Hierarchy / ICP | `hierarchy.rs`, `peer_fetch.rs`, `icp.rs`, `hierarchy_config.rs` | ✅ opt-in (`HIERARCHY_ENABLED`) |
 | Event indexer | `cache-indexer/src/main.rs` | ✅ |
 | ML / analytics worker | — | ❌ не существует |
 
@@ -77,7 +83,11 @@ TCP accept
        → categorization.categorize()   # Shallalist / URLhaus / PhishTank
        → acl_engine.check_access()     # Mutex lock
   → L1 cache lookup (GET/HEAD)
-  → upstream HTTP request
+  → [if HIERARCHY_ENABLED] resolve_source()
+       → ICP query siblings (parallel UDP)
+       → select parent (round-robin / weighted / closest / hash)
+       → fetch_via_peer() on SiblingHit / ParentHit
+  → upstream HTTP request (origin fallback)
   → cache insert + response
   → send_to_kafka_async()         # fire-and-forget
 ```
@@ -89,16 +99,20 @@ TCP accept
 | Entry | `main.rs` | `handle_connection`, `handle_request` |
 | Auth | `auth.rs` | `AuthManager::authenticate` |
 | Policy | `main.rs` | `ProxyService::check_policy` |
-| Cache | `main.rs` | `http_cache`, `generate_cache_key` |
+| Cache | `main.rs`, `cache_key.rs` | `http_cache`, `http_cache_key` |
+| Hierarchy | `hierarchy.rs`, `hierarchy_config.rs` | `resolve_source`, env loading |
+| Peer fetch | `peer_fetch.rs` | `fetch_via_peer` |
+| ICP | `icp.rs`, `main.rs` | `IcpServer::serve`, `IcpClient::query_peers` |
 | Upstream | `main.rs` | `build_upstream_https_connector`, `http_client` |
 | MITM | `tls.rs`, `main.rs` | `handle_connect_mitm`, `CertCache` |
 
 ### Ограничения request path
 
-- Вся логика в **binary crate** (`main.rs` ~1300 строк) — `ProxyService` не в `lib.rs`
+- Вся логика в **binary crate** (`main.rs` ~1300 строк) — `ProxyService` не в `lib.rs` (B7)
 - Categorization с online API на **критическом пути** каждого запроса
 - ACL под глобальным `Mutex` — serializes concurrent ACL checks
-- Hierarchy **не участвует** в выборе источника ответа
+- Hierarchy metrics (`bsdm_proxy_hierarchy_*`) ещё не экспортируются в Prometheus
+- Нет `docker-compose.hierarchy.yml` для multi-instance E2E
 
 ---
 
@@ -137,30 +151,35 @@ sequenceDiagram
 ```
 proxy/
 ├── src/
-│   ├── main.rs          ← монолит: ProxyService, cache, Kafka, HTTP server
-│   ├── lib.rs           ← acl, auth, categorization (exported)
+│   ├── main.rs          ← монолит: ProxyService, cache, Kafka, HTTP server, ICP spawn
+│   ├── lib.rs           ← acl, auth, categorization, hierarchy, icp, peers, selection
+│   ├── hierarchy.rs     ← resolve_source, sibling ICP, parent selection
+│   ├── hierarchy_config.rs ← env: HIERARCHY_ENABLED, CACHE_PARENTS, …
+│   ├── peer_fetch.rs    ← HTTP forward-proxy к parent/sibling
+│   ├── cache_key.rs     ← shared cache key (proxy + ICP handler)
+│   ├── peers.rs         ← peer registry, health, stats
+│   ├── icp.rs           ← ICP v2 UDP client/server
+│   ├── selection.rs     ← round-robin, weighted, closest, hash
 │   ├── tls.rs           ← MITM cert cache
 │   ├── metrics.rs       ← Prometheus
 │   ├── policy_config.rs ← env loading
-│   ├── auth_config.rs
-│   ├── peers.rs         ← ORPHAN (not mod)
-│   ├── icp.rs           ← ORPHAN
-│   ├── hierarchy.rs     ← ORPHAN
-│   └── selection.rs     ← ORPHAN (uses rand, not in Cargo.toml)
+│   └── auth_config.rs
 cache-indexer/
 └── src/main.rs          ← Kafka → OpenSearch
 e2e/                     ← smoke + E2E harness
 ```
 
-### Hierarchy (не интегрирована)
+### Hierarchy (интегрирована, opt-in)
 
-Задуманный flow (`hierarchy.rs`):
+Flow при `HIERARCHY_ENABLED=true`:
 
 ```
-Local L1 miss → ICP query siblings → select parent → ??? → origin
+Local L1 miss → ICP query siblings → select parent → fetch_via_peer → origin fallback
 ```
 
-**Пробел:** `resolve_source()` возвращает `SiblingHit` / `ParentHit`, но **нет HTTP fetch** с выбранного peer. `IcpServer` не стартует в `main.rs`.
+Локальный ICP-сервер отвечает HIT/MISS по наличию URL в `http_cache` (ключ `GET:<url>`).
+
+**Ограничения Phase 3:** нет peer discovery, cache digest, HTCP, hierarchy Prometheus metrics, docker-compose demo.
 
 ---
 
@@ -172,14 +191,14 @@ Local L1 miss → ICP query siblings → select parent → ??? → origin
 
 ### 🔴 Critical — M1 Foundation
 
-| ID | Блокер | Файлы | Решение |
-|----|--------|-------|---------|
-| **B1** | Hierarchy modules не в бинарнике | `lib.rs`, `peers.rs`, `icp.rs`, `hierarchy.rs`, `selection.rs` | Добавить `mod`, экспорт, тесты в CI |
-| **B2** | `rand` отсутствует в Cargo.toml | `selection.rs:84`, `Cargo.toml` | Добавить `rand = "0.8"` |
-| **B3** | Hierarchy без HTTP fetch к peer | `hierarchy.rs` | После `ParentHit` — proxy HTTP GET к peer |
-| **B4** | ICP server не запускается | `icp.rs`, `main.rs` | Spawn `IcpServer` при `HIERARCHY_ENABLED` |
-| **B5** | `ca.key` обязателен при старте | `main.rs:858` | Optional при `MITM_ENABLED=false` |
-| **B6** | Rate limiting отсутствует | `main.rs` | Token bucket per IP/user |
+| ID | Блокер | Статус | Файлы |
+|----|--------|--------|-------|
+| **B1** | Hierarchy modules не в бинарнике | ✅ Done | `lib.rs` |
+| **B2** | `rand` отсутствует в Cargo.toml | ✅ Done | `Cargo.toml` |
+| **B3** | Hierarchy без HTTP fetch к peer | ✅ Done | `peer_fetch.rs`, `main.rs` |
+| **B4** | ICP server не запускается | ✅ Done | `icp.rs`, `main.rs` |
+| **B5** | `ca.key` обязателен при старте | ✅ Done | `tls.rs` |
+| **B6** | Rate limiting отсутствует | ❌ Open | `main.rs` |
 
 ### 🟠 High — M2 Squid parity / M3 Retro-search
 
@@ -220,8 +239,8 @@ Local L1 miss → ICP query siblings → select parent → ??? → origin
 ## Блокеры по milestones
 
 ```
-M1  ████████████░░  B1 B2 B3 B4 B5 B6 B7
-M2  ██████████████  B7 B8 B9 B13 B14 B21 B22 B23 B25 + B1–B4
+M1  █████████████░  B6 B7 (B1–B5 ✅)
+M2  ██████████████  B7 B8 B9 B13 B14 B21 B22 B23 B25
 M3  ████████████░░  B10 B11 B12 B17 B20
 M4  ██████████████  B15 B16 B18 B19 + M3
 M5  ██████████████  B15 B16 B18 + M4
@@ -231,11 +250,11 @@ M5  ██████████████  B15 B16 B18 + M4
 
 ## Приоритет разблокировки
 
-### Волна 1 — разблокировать M1
+### Волна 1 — завершить M1
 
-1. **B5** — optional CA при `MITM_ENABLED=false` (quick win)
-2. **B1 + B2** — подключить hierarchy modules + `rand`
-3. **B3 + B4** — HTTP fetch к peer + ICP server
+1. ~~**B5** — optional CA при `MITM_ENABLED=false`~~ ✅
+2. ~~**B1 + B2** — подключить hierarchy modules + `rand`~~ ✅
+3. ~~**B3 + B4** — HTTP fetch к peer + ICP server~~ ✅
 4. **B6** — rate limiting
 5. **B7** — начать вынос `ProxyService` в `lib.rs`
 
@@ -263,8 +282,8 @@ flowchart LR
   B16 --> B15[B15 analytics worker]
   B1[B1 wire hierarchy] --> B3[B3 HTTP fetch]
   B3 --> B4[B4 ICP server]
-  B7[B7 refactor main] --> B6[B6 rate limit]
-  B7 --> B3
+  B4 -.done.-> B6[B6 rate limit]
+  B7[B7 refactor main] --> B6
   B10[B10 reliable Kafka] --> B17[B17 dashboards]
 ```
 
@@ -274,7 +293,7 @@ flowchart LR
 
 | Milestone | Архитектурный критерий |
 |-----------|------------------------|
-| **M1** | Hierarchy в request path, rate limit, proxy стартует без CA при MITM=off |
+| **M1** | Hierarchy в request path ✅, rate limit, proxy стартует без CA при MITM=off ✅ |
 | **M2** | `ProxyService` в lib, L2 Redis, ACL complete |
 | **M3** | Единая event schema, indexer parity, Dashboards, Kafka acks≥1 |
 | **M4** | Analytics worker, alerting, extended schema |
@@ -282,4 +301,4 @@ flowchart LR
 
 ---
 
-*Версия документа: 0.2.2b · блокеры B1–B25*
+*Версия документа: 0.2.2b · B1–B5 resolved, B6–B25 open*

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,11 +22,16 @@ sudo apt-get install -y \
 ```
 bsdm-proxy/
 ├── proxy/              # Основной прокси (bin: proxy)
+│   └── src/
+│       ├── main.rs     # ProxyService, HTTP server, cache, Kafka
+│       ├── lib.rs      # acl, auth, categorization, hierarchy, icp, peers
+│       ├── peer_fetch.rs, hierarchy_config.rs, cache_key.rs
+│       └── tls.rs, metrics.rs, policy_config.rs
 ├── cache-indexer/      # Kafka → OpenSearch indexer
 ├── e2e/                # Smoke и E2E тесты
 ├── config/             # Примеры ACL-правил
 ├── packaging/          # Release-пакет (systemd, install.sh)
-├── scripts/            # build-package, run-*-tests
+├── scripts/            # build-package, run-*-tests, pre-push-check
 └── docs/               # Документация
 ```
 
@@ -189,5 +194,13 @@ AUTH_ENABLED=true
 ACL_ENABLED=true
 ACL_RULES_PATH=./config/acl-rules.test.json
 CATEGORIZATION_ENABLED=false
-UPSTREAM_CA_CERT=./certs/ca.crt   # для lab MITM с самоподписанным upstream
+MITM_ENABLED=false                    # старт без CA
+UPSTREAM_CA_CERT=./certs/ca.crt       # для lab MITM с самоподписанным upstream
+
+# Иерархический кеш (локальный тест с mock peer)
+HIERARCHY_ENABLED=true
+CACHE_PARENTS=127.0.0.1:18080
+ICP_BIND=127.0.0.1:3130
 ```
+
+Подробнее: [hierarchical-caching.md](hierarchical-caching.md)

--- a/docs/hierarchical-caching.md
+++ b/docs/hierarchical-caching.md
@@ -105,139 +105,78 @@ Enum CacheSelectionStrategy {
 
 ## Configuration
 
-### Environment Variables
+### Environment Variables (implemented)
 
 ```bash
-# Enable hierarchical caching
+# Enable hierarchical caching (default: false)
 HIERARCHY_ENABLED=true
 
-# Parent caches (comma-separated)
+# Parent caches (comma-separated: host:port[:weight])
 CACHE_PARENTS=parent1.example.com:1488:1.0,parent2.example.com:1488:0.5
-# Format: host:port:weight
 
-# Sibling caches
-CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488
+# Sibling caches (host:port[:weight][:icp_port])
+CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488:1.0:3130
 
-# ICP settings
-ICP_PORT=3130
+# ICP server bind (UDP, default 0.0.0.0:3130)
+ICP_BIND=0.0.0.0:3130
+
+# ICP client bind (default 0.0.0.0:0)
+ICP_CLIENT_BIND=0.0.0.0:0
+
+# Default ICP port for siblings without explicit icp_port
+ICP_PEER_PORT=3130
+
 ICP_TIMEOUT_MS=100
-ICP_ENABLED=true
+ICP_SERVER_ENABLED=true          # set false to disable local ICP listener
+PARENT_TIMEOUT_SECONDS=5
+ICP_MAX_SIBLING_QUERIES=10
 
-# Selection strategy
-CACHE_SELECTION_STRATEGY=weighted  # round-robin, weighted, closest, hash
+# Selection strategy: round-robin, weighted, closest, hash
+CACHE_SELECTION_STRATEGY=weighted
+```
 
-# Peer discovery
+### Not yet implemented
+
+```bash
+# Planned for Phase 4 (M2)
 PEER_DISCOVERY_ENABLED=true
 PEER_DISCOVERY_MULTICAST=239.255.255.1:3131
-PEER_DISCOVERY_INTERVAL_SEC=60
-
-# Cache hierarchy rules
-HIERARCHY_DIRECT_DOMAINS=localhost,127.0.0.1  # Bypass hierarchy
-HIERARCHY_NEVER_DIRECT=false  # Always use hierarchy
+HIERARCHY_DIRECT_DOMAINS=localhost,127.0.0.1
 ```
 
 ### Configuration File (TOML)
 
-```toml
-[hierarchy]
-enabled = true
-selection_strategy = "weighted"
-never_direct = false
+TOML config is **planned** for M2. Currently only environment variables are supported via `hierarchy_config.rs`.
 
-[[hierarchy.parents]]
-host = "parent1.example.com"
-port = 1488
-weight = 1.0
-max_connections = 100
-icp_port = 3130
+## Implementation Status
 
-[[hierarchy.parents]]
-host = "parent2.example.com"
-port = 1488
-weight = 0.5
-max_connections = 50
-icp_port = 3130
+### Phase 1: Core Infrastructure ✅
 
-[[hierarchy.siblings]]
-host = "sibling1.example.com"
-port = 1488
-icp_port = 3130
+1. **Peer Management** (`proxy/src/peers.rs`) — done
+2. **ICP Protocol** (`proxy/src/icp.rs`) — done
+3. **Selection Strategy** (`proxy/src/selection.rs`) — done
 
-[hierarchy.icp]
-enabled = true
-port = 3130
-timeout_ms = 100
-max_retries = 2
+### Phase 2: Request Routing ✅
 
-[hierarchy.discovery]
-enabled = true
-multicast_address = "239.255.255.1:3131"
-announce_interval_sec = 60
-ttl = 3
+4. **Hierarchy Manager** (`proxy/src/hierarchy.rs`) — done
+5. **Cache Fetcher** (`proxy/src/peer_fetch.rs`) — done (HTTP/1 forward proxy)
 
-[hierarchy.rules]
-# Domains to fetch directly (bypass hierarchy)
-direct_domains = ["localhost", "127.0.0.1"]
+### Phase 3: Integration ✅ (v0.2.2b)
 
-# Domains to never cache
-no_cache_domains = ["accounts.google.com"]
+6. **Configuration** (`proxy/src/hierarchy_config.rs`) — env vars
+7. **Runtime wiring** (`proxy/src/main.rs`) — request path + ICP server spawn
+8. **Cache key** (`proxy/src/cache_key.rs`) — shared L1 + ICP lookup
 
-# Force parent for specific domains
-[[hierarchy.rules.domain_routing]]
-pattern = "*.cdn.example.com"
-parent = "cdn-parent.example.com:1488"
-```
+**Remaining in Phase 3:**
+- Docker-compose multi-instance demo
+- Hierarchy Prometheus metrics
+- E2E tests for peer fetch
 
-## Implementation Plan
+### Phase 4: Discovery & Optimization 📅 M2
 
-### Phase 1: Core Infrastructure
-
-1. **Peer Management Module** (`proxy/src/peers.rs`)
-   - Peer registry
-   - Health checking (active/passive)
-   - Connection pooling per peer
-   - RTT tracking
-
-2. **ICP Protocol** (`proxy/src/icp.rs`)
-   - UDP server/client
-   - ICP message encoding/decoding
-   - Query/response handling
-   - Timeout management
-
-3. **Selection Strategy** (`proxy/src/selection.rs`)
-   - Strategy trait
-   - Implementations (round-robin, weighted, etc.)
-   - Peer scoring
-
-### Phase 2: Request Routing
-
-4. **Hierarchy Manager** (`proxy/src/hierarchy.rs`)
-   - Request flow coordination
-   - Sibling queries (parallel ICP)
-   - Parent fallback
-   - Origin fallback
-
-5. **Cache Fetcher** (`proxy/src/fetcher.rs`)
-   - HTTP client for peer communication
-   - Streaming responses
-   - Error handling and retries
-
-### Phase 3: Discovery & Optimization
-
-6. **Peer Discovery** (`proxy/src/discovery.rs`)
-   - Multicast announcements
-   - Peer registration
-   - Auto-configuration
-
-7. **Cache Digest** (`proxy/src/digest.rs`)
-   - Bloom filter for cached URLs
-   - Periodic digest exchange
-   - Digest-based pre-filtering
-
-8. **Metrics** (extend `proxy/src/metrics.rs`)
-   - Hierarchy metrics
-   - Peer performance stats
-   - ICP query stats
+9. **Peer Discovery** — not started
+10. **Cache Digest** — not started
+11. **Metrics** (`bsdm_proxy_hierarchy_*`) — not started
 
 ## Data Structures
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,8 +20,8 @@
 
 | Milestone | Версия | Фокус | Готовность |
 |-----------|--------|-------|------------|
-| [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ~90% |
-| [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | Иерархия, L2, rate limit, полный ACL | ~0% |
+| [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability, иерархия | ~95% |
+| [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, rate limit, полный ACL, hierarchy Phase 4 | ~10% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~15% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C beacon detection | ~0% |
@@ -61,14 +61,18 @@ gantt
 - [x] URL categorization: Shallalist, URLhaus, PhishTank, custom DB
 - [x] E2E / smoke test harness
 - [x] Release packaging (`0.2.2b`) + systemd
+- [x] Hierarchical caching Phase 3 — modules in lib, ICP server, peer HTTP fetch, env config
+- [x] Optional MITM CA (`MITM_ENABLED=false` без `ca.key`)
+- [x] Pre-push hook (`fmt` + `clippy`)
 
 ### В работе / осталось в M1
 
-- [ ] Rate limiting per user/IP — [#TBD]
-- [ ] Hierarchical caching Phase 3 — интеграция `peers.rs`, `icp.rs`, `hierarchy.rs` в `main.rs` — [#TBD]
+- [ ] Rate limiting per user/IP — [#37](https://github.com/onixus/bsdm-proxy/issues/37)
+- [ ] Рефакторинг `main.rs` — вынос `ProxyService` в lib — [#38](https://github.com/onixus/bsdm-proxy/issues/38)
+- [ ] Hierarchy E2E / `docker-compose.hierarchy.yml`
 - [ ] Исправить README: NTLM помечен как done, но не реализован (`auth.rs`)
 
-**Критерий завершения M1:** rate limit + hierarchy в production path, все E2E зелёные.
+**Критерий завершения M1:** rate limit + рефакторинг main, hierarchy E2E, все CI зелёные.
 
 ---
 
@@ -94,7 +98,7 @@ gantt
 
 **Критерий завершения M2:** 3-tier cache hierarchy в docker-compose, hit rate sibling/parent измеряется, Redis L2 работает.
 
-**Зависимости:** M1 (hierarchy Phase 3).
+**Зависимости:** M1 (B6 rate limit, B7 refactor).
 
 ---
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -44,6 +44,7 @@ set +a
 | Service | Default port |
 |---------|--------------|
 | Proxy HTTP/HTTPS | 1488 |
+| ICP (UDP, if `HIERARCHY_ENABLED=true`) | 3130 |
 | Metrics / health | 9090 |
 
 ## Verify

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -4,7 +4,7 @@
 HTTP_PORT=1488
 METRICS_PORT=9090
 
-# MITM (requires /certs/ca.key and /certs/ca.crt)
+# MITM (requires /certs/ca.key and /certs/ca.crt when enabled)
 MITM_ENABLED=true
 
 # Cache
@@ -34,6 +34,19 @@ ACL_AUTO_RELOAD=false
 
 CATEGORIZATION_ENABLED=false
 # CUSTOM_DB_PATH=/etc/bsdm-proxy/custom-categories.json
+
+# Hierarchical caching (optional, disabled by default)
+HIERARCHY_ENABLED=false
+# CACHE_PARENTS=parent.example.com:1488:1.0
+# CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488
+# CACHE_SELECTION_STRATEGY=round-robin
+# ICP_BIND=0.0.0.0:3130
+# ICP_CLIENT_BIND=0.0.0.0:0
+# ICP_PEER_PORT=3130
+# ICP_TIMEOUT_MS=100
+# ICP_SERVER_ENABLED=true
+# PARENT_TIMEOUT_SECONDS=5
+# ICP_MAX_SIBLING_QUERIES=10
 
 # Upstream TLS (for self-signed upstream CA in tests/lab)
 # UPSTREAM_CA_CERT=/etc/bsdm-proxy/upstream-ca.crt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates project documentation to reflect v0.2.2b state: hierarchical caching Phase 3 integration, resolved M1 blockers B1–B5, and current roadmap.

### Updated files

| Document | Changes |
|----------|---------|
| `README.md` | Hierarchy in features/architecture, env vars table, M1 ~95% |
| `docs/architecture.md` | Integrated hierarchy flow, B1–B5 ✅, module map |
| `docs/roadmap.md` | Phase 3 hierarchy done, remaining M1 items |
| `docs/BLOCKERS.md` | Status column, B1–B5 marked resolved |
| `docs/HIERARCHICAL_CACHING_README.md` | Rewritten: current status, config, quick start |
| `docs/hierarchical-caching.md` | Actual env vars, implementation status |
| `docs/development.md` | Workspace layout, hierarchy dev env |
| `docs/README.md` | 0.2.2b changelog note |
| `packaging/` | Hierarchy env example, ICP port in README |

### Note

This branch includes M1 blocker implementation commits (B1–B5, hierarchy runtime) from `cursor/fix-m1-blockers-046a` plus this documentation commit.

## Test plan

- [x] Documentation review — env vars match `hierarchy_config.rs`
- [x] Links between docs verified
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

