### PR TITLE
Fix macOS MITM proxy and add native browser setup scripts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,10 +187,13 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -198,6 +201,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,57 +3,40 @@
 # ============================================================
 # Unified builder stage - собирает оба бинарника
 # ============================================================
-FROM rust:1.85-alpine AS builder
+FROM rust:1-bookworm AS builder
 WORKDIR /build
 
-# Установка зависимостей для сборки (включая bash для rdkafka)
-RUN apk add --no-cache \
-    musl-dev \
-    protoc \
-    g++ \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libssl-dev \
+    pkg-config \
     cmake \
-    make \
-    bash \
-    perl \
-    git \
-    openssl-dev \
-    openssl-libs-static \
-    pkgconfig \
     librdkafka-dev \
-    cyrus-sasl-dev \
-    lz4-dev \
-    zlib-dev \
-    zlib-static \
-    zstd-dev
+    libclang-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
-# Добавляем musl target
-RUN rustup target add x86_64-unknown-linux-musl
-
-# Копируем весь workspace
+# Копируем workspace (e2e нужен как member в корневом Cargo.toml)
 COPY Cargo.toml Cargo.lock ./
 COPY proxy ./proxy
 COPY cache-indexer ./cache-indexer
+COPY e2e ./e2e
 
-# Настройка окружения для статической линковки
-ENV OPENSSL_STATIC=1 \
-    OPENSSL_LIB_DIR=/usr/lib \
-    OPENSSL_INCLUDE_DIR=/usr/include \
-    RUSTFLAGS="-C target-feature=+crt-static"
-
-# Собираем оба бинарника в release режиме
-RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN cargo build --release \
+    -p bsdm-proxy --bin proxy \
+    -p cache-indexer --bin cache-indexer
 
 # ============================================================
 # Proxy runtime
 # ============================================================
-FROM alpine:3.21 AS proxy
-RUN apk add --no-cache \
+FROM debian:bookworm-slim AS proxy
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    libgcc \
-    wget
+    libssl3 \
+    curl \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 
-# Копируем скомпилированный бинарник
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/proxy /usr/local/bin/proxy
+COPY --from=builder /build/target/release/proxy /usr/local/bin/proxy
 
 EXPOSE 1488
 CMD ["proxy"]
@@ -61,13 +44,13 @@ CMD ["proxy"]
 # ============================================================
 # Cache-indexer runtime
 # ============================================================
-FROM alpine:3.21 AS cache-indexer
-RUN apk add --no-cache \
+FROM debian:bookworm-slim AS cache-indexer
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    libgcc
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
 
-# Копируем скомпилированный бинарник
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/cache-indexer /usr/local/bin/cache-indexer
+COPY --from=builder /build/target/release/cache-indexer /usr/local/bin/cache-indexer
 
 EXPOSE 8080
 CMD ["cache-indexer"]

--- a/config/proxy.pac
+++ b/config/proxy.pac
@@ -1,0 +1,15 @@
+function FindProxyForURL(url, host) {
+  if (host === "localhost" ||
+      host === "127.0.0.1" ||
+      shExpMatch(host, "*.local") ||
+      shExpMatch(host, "*.localhost")) {
+    return "DIRECT";
+  }
+  if (isInNet(dnsResolve(host), "127.0.0.0", "255.0.0.0") ||
+      isInNet(dnsResolve(host), "10.0.0.0", "255.0.0.0") ||
+      isInNet(dnsResolve(host), "172.16.0.0", "255.240.0.0") ||
+      isInNet(dnsResolve(host), "192.168.0.0", "255.255.0.0")) {
+    return "DIRECT";
+  }
+  return "PROXY 127.0.0.1:8080";
+}

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -149,6 +149,7 @@ impl ProxyHarness {
             .with_context(|| format!("spawn proxy binary at {}", proxy_bin.display()))?;
 
         wait_for_health(metrics_port, Duration::from_secs(20)).await?;
+        wait_for_tcp(proxy_port).await?;
 
         Ok(Self {
             proxy_port,

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -22,6 +22,10 @@ prometheus = { version = "0.14", features = ["process"] }
 tokio-rustls = { version = "0.26", features = ["ring"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2.2"
+rustls-platform-verifier = "0.7"
+rustls-native-certs = "0.8"
+webpki-roots = "1.0"
+time = "0.3"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "ring", "tls12", "webpki-roots"] }
 sha2 = "0.11"
 base64 = "0.22"

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -17,13 +17,13 @@ use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
-use rustls_platform_verifier::BuilderVerifierExt;
 use hyper_util::rt::TokioIo;
 use metrics::{Metrics, RequestMetricsGuard};
 use policy_config::{load_policy_config, reload_acl_engine, PolicyConfig};
 use quick_cache::sync::Cache;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
+use rustls_platform_verifier::BuilderVerifierExt;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -91,10 +91,7 @@ fn normalize_response_headers(
     out
 }
 
-fn apply_response_headers(
-    response: &mut Response<Body>,
-    headers: &HashMap<String, String>,
-) {
+fn apply_response_headers(response: &mut Response<Body>, headers: &HashMap<String, String>) {
     for (key, value) in headers {
         if let (Ok(name), Ok(val)) = (
             HeaderName::from_bytes(key.as_bytes()),
@@ -718,9 +715,7 @@ fn build_upstream_tls_with_combined_roots() -> rustls::ClientConfig {
             native += 1;
         }
     }
-    info!(
-        "Upstream TLS: webpki-roots + {native} native CA certificate(s)"
-    );
+    info!("Upstream TLS: webpki-roots + {native} native CA certificate(s)");
     rustls::ClientConfig::builder()
         .with_root_certificates(roots)
         .with_no_client_auth()

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -48,6 +48,63 @@ type Body = http_body_util::Full<Bytes>;
 const CACHEABLE_METHODS: &[&str] = &["GET", "HEAD"];
 const CACHEABLE_STATUS_CODES: &[u16] = &[200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501];
 
+/// Hop-by-hop and framing headers that must not be forwarded after the body is buffered.
+const STRIP_RESPONSE_HEADERS: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
+
+fn normalize_response_headers(
+    headers: HashMap<String, String>,
+    body_len: usize,
+    method: &str,
+) -> HashMap<String, String> {
+    let is_head = method.eq_ignore_ascii_case("HEAD");
+    let upstream_content_length = headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        .map(|(_, v)| v.clone());
+
+    let mut out: HashMap<String, String> = headers
+        .into_iter()
+        .filter(|(k, _)| {
+            let lower = k.to_ascii_lowercase();
+            !STRIP_RESPONSE_HEADERS.contains(&lower.as_str())
+                && !(lower == "content-length" && !is_head)
+        })
+        .collect();
+
+    if is_head {
+        if let Some(cl) = upstream_content_length {
+            out.insert("content-length".to_string(), cl);
+        }
+    } else if body_len > 0 || !matches!(method, "GET" | "HEAD") {
+        out.insert("content-length".to_string(), body_len.to_string());
+    }
+
+    out
+}
+
+fn apply_response_headers(
+    response: &mut Response<Body>,
+    headers: &HashMap<String, String>,
+) {
+    for (key, value) in headers {
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::from_bytes(key.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            response.headers_mut().insert(name, val);
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct CachedResponse {
     status: u16,
@@ -69,17 +126,15 @@ impl CachedResponse {
         let mut response = Response::new(Body::new(self.body.clone()));
         *response.status_mut() = StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK);
 
-        let headers_mut = response.headers_mut();
-        for (key, value) in self.headers.iter() {
-            if let (Ok(name), Ok(val)) = (
-                HeaderName::from_bytes(key.as_bytes()),
-                HeaderValue::from_str(value),
-            ) {
-                headers_mut.insert(name, val);
-            }
-        }
-
-        headers_mut.insert("x-cache-status", HeaderValue::from_static("HIT"));
+        let headers_map: HashMap<String, String> = self
+            .headers
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        apply_response_headers(&mut response, &headers_map);
+        response
+            .headers_mut()
+            .insert("x-cache-status", HeaderValue::from_static("HIT"));
         response
     }
 }
@@ -550,7 +605,7 @@ impl ProxyService {
                     .with_label_values(&[&domain])
                     .observe(upstream_duration);
 
-                let headers_map: HashMap<String, String> = response
+                let raw_headers: HashMap<String, String> = response
                     .headers()
                     .iter()
                     .filter_map(|(k, v)| {
@@ -577,6 +632,7 @@ impl ProxyService {
                     }
                 };
                 let body_size = body_bytes.len();
+                let headers_map = normalize_response_headers(raw_headers, body_size, &method);
 
                 if let (Some(hierarchy), Some(peer)) =
                     (self.hierarchy.as_ref(), hierarchy_peer.as_ref())
@@ -630,14 +686,7 @@ impl ProxyService {
 
                 let mut resp = Response::new(Body::new(body_bytes));
                 *resp.status_mut() = status;
-                for (key, value) in headers_map {
-                    if let (Ok(name), Ok(val)) = (
-                        HeaderName::from_bytes(key.as_bytes()),
-                        HeaderValue::from_str(&value),
-                    ) {
-                        resp.headers_mut().insert(name, val);
-                    }
-                }
+                apply_response_headers(&mut resp, &headers_map);
                 guard.finish(status.as_u16(), request_body_size, body_size);
                 resp
             }

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -17,7 +17,7 @@ use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
-use hyper_rustls::ConfigBuilderExt;
+use rustls_platform_verifier::BuilderVerifierExt;
 use hyper_util::rt::TokioIo;
 use metrics::{Metrics, RequestMetricsGuard};
 use policy_config::{load_policy_config, reload_acl_engine, PolicyConfig};
@@ -656,6 +656,27 @@ impl ProxyService {
     }
 }
 
+fn build_upstream_tls_with_combined_roots() -> rustls::ClientConfig {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let native_certs = rustls_native_certs::load_native_certs();
+    for err in &native_certs.errors {
+        warn!("Failed to load native CA certificate: {err}");
+    }
+    let mut native = 0usize;
+    for cert in native_certs.certs {
+        if roots.add(cert).is_ok() {
+            native += 1;
+        }
+    }
+    info!(
+        "Upstream TLS: webpki-roots + {native} native CA certificate(s)"
+    );
+    rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth()
+}
+
 fn build_upstream_https_connector() -> Result<
     hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
     Box<dyn std::error::Error>,
@@ -675,10 +696,27 @@ fn build_upstream_https_connector() -> Result<
         rustls::ClientConfig::builder()
             .with_root_certificates(roots)
             .with_no_client_auth()
+    } else if std::env::var("UPSTREAM_TLS_PLATFORM")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        match rustls::ClientConfig::builder()
+            .with_platform_verifier()
+            .map(|builder| builder.with_no_client_auth())
+        {
+            Ok(config) => {
+                info!("Upstream TLS: using platform certificate verifier");
+                config
+            }
+            Err(e) => {
+                warn!(
+                    "Platform TLS verifier unavailable ({e}); falling back to webpki + native roots"
+                );
+                build_upstream_tls_with_combined_roots()
+            }
+        }
     } else {
-        rustls::ClientConfig::builder()
-            .with_webpki_roots()
-            .with_no_client_auth()
+        build_upstream_tls_with_combined_roots()
     };
 
     Ok(hyper_rustls::HttpsConnectorBuilder::new()

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -28,9 +28,7 @@ fn leaf_cert_params(domain: &str) -> Result<CertificateParams, rcgen::Error> {
     let mut params = CertificateParams::new(vec![domain.to_string()])?;
     apply_leaf_cert_validity(&mut params);
     params.distinguished_name = DistinguishedName::new();
-    params
-        .distinguished_name
-        .push(DnType::CommonName, domain);
+    params.distinguished_name.push(DnType::CommonName, domain);
     params
         .distinguished_name
         .push(DnType::OrganizationName, "BSDM Proxy");
@@ -310,11 +308,9 @@ mod tests {
         let now = time::OffsetDateTime::now_utc();
         assert!(params.not_before <= now);
         assert!(params.not_after > now + time::Duration::days(30));
-        assert!(
-            params
-                .extended_key_usages
-                .contains(&ExtendedKeyUsagePurpose::ServerAuth)
-        );
+        assert!(params
+            .extended_key_usages
+            .contains(&ExtendedKeyUsagePurpose::ServerAuth));
     }
 
     #[test]

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::Request;
 use rcgen::{
-    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
-    KeyUsagePurpose,
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
+    Issuer, KeyPair, KeyUsagePurpose,
 };
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::ServerConfig;
@@ -15,6 +15,32 @@ use std::io::Cursor;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
+
+const LEAF_CERT_VALIDITY_DAYS: i64 = 825;
+
+fn apply_leaf_cert_validity(params: &mut CertificateParams) {
+    let now = time::OffsetDateTime::now_utc();
+    params.not_before = now - time::Duration::days(1);
+    params.not_after = now + time::Duration::days(LEAF_CERT_VALIDITY_DAYS);
+}
+
+fn leaf_cert_params(domain: &str) -> Result<CertificateParams, rcgen::Error> {
+    let mut params = CertificateParams::new(vec![domain.to_string()])?;
+    apply_leaf_cert_validity(&mut params);
+    params.distinguished_name = DistinguishedName::new();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, domain);
+    params
+        .distinguished_name
+        .push(DnType::OrganizationName, "BSDM Proxy");
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyEncipherment,
+    ];
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    Ok(params)
+}
 
 pub type CertPair = (Bytes, Bytes);
 type CertMap = Arc<RwLock<HashMap<Arc<str>, CertPair>>>;
@@ -95,6 +121,7 @@ impl CertCache {
 
     fn in_memory_ca_params() -> Result<CertificateParams, rcgen::Error> {
         let mut ca_params = CertificateParams::new(vec!["BSDM Proxy CA".to_string()])?;
+        apply_leaf_cert_validity(&mut ca_params);
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         ca_params.key_usages = vec![
             KeyUsagePurpose::KeyCertSign,
@@ -130,7 +157,7 @@ impl CertCache {
         }
 
         let (cert_pem, key_pem) = self.get_or_generate(domain).await?;
-        let config = Arc::new(build_server_config(&cert_pem, &key_pem, &self.ca_cert_pem)?);
+        let config = Arc::new(build_server_config(&cert_pem, &key_pem)?);
 
         let mut cache = self.server_configs.write().await;
         cache.insert(domain_arc, config.clone());
@@ -153,16 +180,7 @@ impl CertCache {
 
         debug!("Certificate cache MISS for {}, generating...", domain);
         let key_pair = KeyPair::generate()?;
-        let mut params = CertificateParams::new(vec![domain.to_string()])?;
-        params.distinguished_name = DistinguishedName::new();
-        params.distinguished_name.push(DnType::CommonName, domain);
-        params
-            .distinguished_name
-            .push(DnType::OrganizationName, "BSDM Proxy");
-        params.key_usages = vec![
-            KeyUsagePurpose::DigitalSignature,
-            KeyUsagePurpose::KeyEncipherment,
-        ];
+        let params = leaf_cert_params(domain)?;
 
         let issuer = self.issuer()?;
         let cert = params.signed_by(&key_pair, &issuer)?;
@@ -179,11 +197,10 @@ impl CertCache {
 fn build_server_config(
     cert_pem: &[u8],
     key_pem: &[u8],
-    ca_cert_pem: &[u8],
 ) -> Result<ServerConfig, Box<dyn std::error::Error + Send + Sync>> {
-    let mut chain = parse_certs(cert_pem)?;
-    chain.extend(parse_certs(ca_cert_pem)?);
-
+    // Send leaf only — clients already trust the CA from their trust store.
+    // Including the self-signed root in the chain triggers UnknownCA in Safari/Chrome.
+    let chain = parse_certs(cert_pem)?;
     let key = parse_private_key(key_pem)?;
 
     ServerConfig::builder()
@@ -285,6 +302,19 @@ mod tests {
         assert!(should_mitm_port(8443));
         assert!(!should_mitm_port(22));
         assert!(!should_mitm_port(8080));
+    }
+
+    #[test]
+    fn leaf_cert_params_use_sane_validity() {
+        let params = leaf_cert_params("example.com").unwrap();
+        let now = time::OffsetDateTime::now_utc();
+        assert!(params.not_before <= now);
+        assert!(params.not_after > now + time::Duration::days(30));
+        assert!(
+            params
+                .extended_key_usages
+                .contains(&ExtendedKeyUsagePurpose::ServerAuth)
+        );
     }
 
     #[test]

--- a/scripts/configure-macos-proxy.sh
+++ b/scripts/configure-macos-proxy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Configure macOS system HTTP/HTTPS proxy for BSDM (Wi‑Fi).
+set -euo pipefail
+
+SERVICE="${1:-Wi-Fi}"
+HOST="${PROXY_HOST:-127.0.0.1}"
+PORT="${PROXY_PORT:-8080}"
+
+# macOS expects host only — NOT http://127.0.0.1
+HOST="${HOST#http://}"
+HOST="${HOST#https://}"
+HOST="${HOST%%/*}"
+
+networksetup -setwebproxy "$SERVICE" "$HOST" "$PORT"
+networksetup -setsecurewebproxy "$SERVICE" "$HOST" "$PORT"
+networksetup -setproxybypassdomains "$SERVICE" \
+  localhost 127.0.0.1 "*.local" "*.localhost" \
+  10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 169.254.0.0/16
+
+echo "Proxy enabled on '$SERVICE': $HOST:$PORT"
+networksetup -getwebproxy "$SERVICE"
+networksetup -getsecurewebproxy "$SERVICE"
+
+echo
+echo "IMPORTANT: use port 8080 for native proxy (not 1488)."
+echo "Docker Desktop can exhaust localhost:1488 with stale TCP connections."
+echo
+echo "Quick setup:"
+echo "  ./scripts/setup-macos-browser-proxy.sh"
+echo
+echo "Also trust MITM CA: ./scripts/trust-mitm-ca-macos.sh"

--- a/scripts/diagnose-macos-proxy.sh
+++ b/scripts/diagnose-macos-proxy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Diagnose why BSDM proxy / browser MITM fails on macOS.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${HTTP_PORT:-8080}"
+
+echo "=== TCP connections to :1488 (Docker leak indicator) ==="
+STALE_1488=$(netstat -an 2>/dev/null | grep -c '\.1488 ' || true)
+echo "Count: $STALE_1488"
+if (( STALE_1488 > 1000 )); then
+  echo "WARNING: Docker Desktop leaked connections to port 1488."
+  echo "  Quit Docker Desktop completely, then retry:"
+  echo "    osascript -e 'quit app \"Docker\"'"
+  echo "  Or reboot macOS."
+fi
+
+echo
+echo "=== Proxy process / port ${PORT} ==="
+if lsof -i ":${PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  lsof -i ":${PORT}" -sTCP:LISTEN
+else
+  echo "No listener on ${PORT}. Run: ./scripts/setup-macos-browser-proxy.sh"
+fi
+
+echo
+echo "=== Loopback connect test ==="
+if python3 -c "import socket; s=socket.create_connection(('127.0.0.1',${PORT}),2); s.close()"; then
+  echo "OK: can connect to 127.0.0.1:${PORT}"
+else
+  echo "FAIL: cannot connect to 127.0.0.1:${PORT} (often stale Docker TCP on 1488)"
+fi
+
+echo
+echo "=== System proxy (Wi-Fi) ==="
+networksetup -getwebproxy Wi-Fi 2>/dev/null || true
+networksetup -getsecurewebproxy Wi-Fi 2>/dev/null || true
+
+echo
+echo "=== CA trust ==="
+if security find-certificate -c "BSDM Root CA" /Library/Keychains/System.keychain >/dev/null 2>&1; then
+  echo "BSDM Root CA found in System keychain"
+else
+  echo "CA NOT trusted. Run: ./scripts/trust-mitm-ca-macos.sh"
+fi
+
+echo
+echo "=== MITM smoke test (explicit proxy, no system settings changed) ==="
+if curl -sf -o /dev/null -w "example.com -> HTTP %{http_code}\n" \
+  -x "http://127.0.0.1:${PORT}" --cacert "$ROOT/certs/ca.crt" https://example.com/; then
+  :
+else
+  echo "MITM test failed"
+fi

--- a/scripts/disable-macos-proxy.sh
+++ b/scripts/disable-macos-proxy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Disable macOS system HTTP/HTTPS proxy (Wi‑Fi).
+set -euo pipefail
+
+SERVICE="${1:-Wi-Fi}"
+
+networksetup -setwebproxystate "$SERVICE" off
+networksetup -setsecurewebproxystate "$SERVICE" off
+
+echo "System proxy disabled on '$SERVICE'"

--- a/scripts/generate-mitm-ca.sh
+++ b/scripts/generate-mitm-ca.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Generate a self-signed Root CA for BSDM-Proxy MITM TLS interception.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CERT_DIR="${CERT_DIR:-$ROOT/certs}"
+DAYS="${MITM_CA_DAYS:-3650}"
+
+mkdir -p "$CERT_DIR"
+
+if [[ -f "$CERT_DIR/ca.key" || -f "$CERT_DIR/ca.crt" ]]; then
+  echo "Backing up existing CA to ${CERT_DIR}/backup-$(date +%Y%m%d-%H%M%S)/"
+  backup_dir="$CERT_DIR/backup-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$backup_dir"
+  [[ -f "$CERT_DIR/ca.key" ]] && mv "$CERT_DIR/ca.key" "$backup_dir/"
+  [[ -f "$CERT_DIR/ca.crt" ]] && mv "$CERT_DIR/ca.crt" "$backup_dir/"
+fi
+
+conf="$(mktemp)"
+trap 'rm -f "$conf"' EXIT
+
+cat >"$conf" <<EOF
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+prompt = no
+
+[req_distinguished_name]
+C = RU
+ST = Moscow
+L = Moscow
+O = BSDM
+CN = BSDM Root CA
+
+[v3_ca]
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+EOF
+
+openssl genrsa -out "$CERT_DIR/ca.key" 4096
+chmod 600 "$CERT_DIR/ca.key"
+openssl req -new -x509 -days "$DAYS" -key "$CERT_DIR/ca.key" -out "$CERT_DIR/ca.crt" \
+  -config "$conf" -extensions v3_ca
+
+echo "MITM CA created:"
+echo "  key:  $CERT_DIR/ca.key"
+echo "  cert: $CERT_DIR/ca.crt"
+openssl x509 -in "$CERT_DIR/ca.crt" -noout -subject -issuer -dates
+
+echo
+echo "Trust on macOS:"
+echo "  sudo security add-trusted-cert -d -r trustRoot \\"
+echo "    -k /Library/Keychains/System.keychain $CERT_DIR/ca.crt"
+echo
+echo "Test via proxy:"
+echo "  curl --cacert $CERT_DIR/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get"

--- a/scripts/run-proxy-native.sh
+++ b/scripts/run-proxy-native.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run BSDM proxy natively on macOS (recommended with system-wide proxy enabled).
+#
+# Docker Desktop forwards container outbound traffic through the macOS system
+# proxy. When the system proxy points at 127.0.0.1:1488, the container loops
+# back into itself and upstream requests fail with 502.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f certs/ca.key ]]; then
+  echo "CA not found. Run: ./scripts/generate-mitm-ca.sh" >&2
+  exit 1
+fi
+
+echo "Stopping Docker proxy container (if running)..."
+docker compose stop proxy 2>/dev/null || true
+
+# Port 8080 avoids Docker Desktop leaking tens of thousands of stale TCP
+# connections to 1488 (docstor), which breaks localhost on macOS.
+export HTTP_PORT="${HTTP_PORT:-8080}"
+export METRICS_PORT="${METRICS_PORT:-9090}"
+export MITM_ENABLED=true
+export AUTH_ENABLED=false
+export ACL_ENABLED=false
+export CATEGORIZATION_ENABLED=false
+export SHALLALIST_ENABLED=false
+export RUST_LOG="${RUST_LOG:-info,bsdm_proxy=debug}"
+
+echo "Starting native proxy on 0.0.0.0:${HTTP_PORT} (metrics :${METRICS_PORT})"
+echo "Trust CA: ./scripts/trust-mitm-ca-macos.sh"
+echo "Press Ctrl+C to stop."
+exec cargo run -p bsdm-proxy --bin proxy

--- a/scripts/setup-macos-browser-proxy.sh
+++ b/scripts/setup-macos-browser-proxy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Start native BSDM proxy and configure macOS system proxy (port 8080).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PROXY_PORT="${PROXY_PORT:-8080}"
+SERVICE="${1:-Wi-Fi}"
+
+chmod +x "$ROOT/scripts/"*.sh
+
+if [[ ! -f certs/ca.key ]]; then
+  echo "CA not found. Run: ./scripts/generate-mitm-ca.sh" >&2
+  exit 1
+fi
+
+STALE_1488=$(netstat -an 2>/dev/null | grep -c '\.1488 ' || true)
+if (( STALE_1488 > 1000 )); then
+  echo "ERROR: $STALE_1488 stale TCP connections on port 1488 (Docker Desktop leak)." >&2
+  echo "Quit Docker Desktop first: osascript -e 'quit app \"Docker\"'" >&2
+  echo "Then wait 5 seconds and re-run this script." >&2
+  exit 1
+fi
+
+if [[ ! -x target/debug/proxy ]]; then
+  echo "Building proxy..."
+  CARGO_TARGET_DIR=target cargo build -p bsdm-proxy --bin proxy
+fi
+
+echo "=== Stop Docker proxy and any old native instance ==="
+docker compose stop proxy 2>/dev/null || true
+pkill -f 'target/debug/proxy' 2>/dev/null || true
+pkill -f 'target/release/proxy' 2>/dev/null || true
+sleep 1
+
+echo "=== Start native proxy on 0.0.0.0:${PROXY_PORT} ==="
+nohup env HTTP_PORT="$PROXY_PORT" METRICS_PORT=9090 MITM_ENABLED=true \
+  AUTH_ENABLED=false ACL_ENABLED=false CATEGORIZATION_ENABLED=false \
+  SHALLALIST_ENABLED=false RUST_LOG=info,bsdm_proxy=info \
+  NO_PROXY='*' HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= \
+  CARGO_TARGET_DIR=target "$ROOT/target/debug/proxy" \
+  >>"$ROOT/proxy-native.log" 2>&1 &
+echo $! >"$ROOT/proxy-native.pid"
+
+for _ in $(seq 1 40); do
+  if curl -sf "http://127.0.0.1:9090/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+
+if ! curl -sf "http://127.0.0.1:9090/health" >/dev/null 2>&1; then
+  echo "Proxy failed to start. See $ROOT/proxy-native.log" >&2
+  exit 1
+fi
+
+echo "=== Configure system proxy (after proxy is up) ==="
+PROXY_PORT="$PROXY_PORT" "$ROOT/scripts/configure-macos-proxy.sh" "$SERVICE"
+
+echo
+echo "=== Smoke test ==="
+curl -sS -o /dev/null -w "example.com via system proxy: HTTP %{http_code}\n" \
+  --cacert "$ROOT/certs/ca.crt" https://example.com/
+
+echo
+echo "Done."
+echo "  Proxy PID: $(cat "$ROOT/proxy-native.pid")"
+echo "  Log:       $ROOT/proxy-native.log"
+echo "  Port:      ${PROXY_PORT}"
+echo
+echo "If browser shows certificate errors:"
+echo "  ./scripts/trust-mitm-ca-macos.sh"
+echo "  Keychain Access -> System -> BSDM Root CA -> Trust -> Always Trust"
+echo "  Fully quit and reopen Safari/Chrome."

--- a/scripts/test-100-https-sites.sh
+++ b/scripts/test-100-https-sites.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# Test 100 HTTPS sites through BSDM proxy (single pass / MISS).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CA="${CA:-$ROOT/certs/ca.crt}"
+PROXY="${PROXY:-http://127.0.0.1:1488}"
+CONCURRENCY="${CONCURRENCY:-10}"
+MAX_TIME="${MAX_TIME:-25}"
+
+if [[ ! -f "$CA" ]]; then
+  echo "CA not found: $CA (run ./scripts/generate-mitm-ca.sh)" >&2
+  exit 1
+fi
+
+SITES=(
+  https://httpbin.org/get
+  https://example.com/
+  https://www.iana.org/
+  https://www.wikipedia.org/
+  https://en.wikipedia.org/wiki/Main_Page
+  https://www.rust-lang.org/
+  https://doc.rust-lang.org/
+  https://crates.io/
+  https://docs.rs/
+  https://github.com/
+  https://gitlab.com/
+  https://stackoverflow.com/
+  https://serverfault.com/
+  https://superuser.com/
+  https://news.ycombinator.com/
+  https://www.mozilla.org/
+  https://www.cloudflare.com/
+  https://www.nginx.com/
+  https://www.apache.org/
+  https://www.gnu.org/
+  https://www.kernel.org/
+  https://www.python.org/
+  https://docs.python.org/3/
+  https://nodejs.org/
+  https://www.php.net/
+  https://go.dev/
+  https://www.ruby-lang.org/
+  https://www.perl.org/
+  https://www.postgresql.org/
+  https://redis.io/
+  https://www.mongodb.com/
+  https://www.elastic.co/
+  https://kafka.apache.org/
+  https://prometheus.io/
+  https://grafana.com/
+  https://www.docker.com/
+  https://kubernetes.io/
+  https://www.digitalocean.com/
+  https://aws.amazon.com/
+  https://azure.microsoft.com/
+  https://cloud.google.com/
+  https://www.apple.com/
+  https://www.microsoft.com/
+  https://www.ibm.com/
+  https://www.intel.com/
+  https://www.amd.com/
+  https://www.debian.org/
+  https://ubuntu.com/
+  https://archlinux.org/
+  https://www.freebsd.org/
+  https://www.openbsd.org/
+  https://www.eff.org/
+  https://www.w3.org/
+  https://www.ietf.org/
+  https://letsencrypt.org/
+  https://www.openssl.org/
+  https://www.bbc.com/
+  https://apnews.com/
+  https://www.npr.org/
+  https://arxiv.org/
+  https://www.imdb.com/
+  https://www.archive.org/
+  https://www.khanacademy.org/
+  https://www.coursera.org/
+  https://www.edx.org/
+  https://www.mit.edu/
+  https://www.stanford.edu/
+  https://www.harvard.edu/
+  https://www.berkeley.edu/
+  https://www.nasa.gov/
+  https://www.noaa.gov/
+  https://www.usgs.gov/
+  https://www.cdc.gov/
+  https://www.nih.gov/
+  https://www.who.int/
+  https://www.un.org/
+  https://european-union.europa.eu/
+  https://www.gov.uk/
+  https://www.canada.ca/
+  https://www.data.gov/
+  https://jsonplaceholder.typicode.com/todos/1
+  https://api.github.com/zen
+  https://httpbingo.org/get
+  https://1.1.1.1/cdn-cgi/trace
+  https://ifconfig.me/
+  https://ipinfo.io/json
+  https://duckduckgo.com/
+  https://www.bing.com/
+  https://www.yahoo.com/
+  https://www.ebay.com/
+  https://www.etsy.com/
+  https://www.spotify.com/
+  https://vimeo.com/
+  https://www.flickr.com/
+  https://medium.com/
+  https://dev.to/
+  https://bitbucket.org/
+  https://sourceforge.net/
+  https://www.npmjs.com/
+  https://pypi.org/
+  https://packagist.org/
+  https://hub.docker.com/
+  https://lobste.rs/
+  https://status.github.com/
+  https://www.atlassian.com/
+  https://slack.com/
+  https://zoom.us/
+  https://www.dropbox.com/
+  https://www.wikimedia.org/
+  https://commons.wikimedia.org/
+  https://www.openstreetmap.org/
+  https://react.dev/
+  https://vuejs.org/
+  https://angular.io/
+  https://svelte.dev/
+  https://tailwindcss.com/
+  https://getbootstrap.com/
+  https://www.typescriptlang.org/
+  https://graphql.org/
+  https://grpc.io/
+  https://www.rabbitmq.com/
+  https://nats.io/
+  https://opensearch.org/
+  https://www.sqlite.org/
+  https://www.mariadb.org/
+  https://www.djangoproject.com/
+  https://fastapi.tiangolo.com/
+  https://spring.io/
+  https://laravel.com/
+  https://wordpress.org/
+  https://www.drupal.org/
+  https://caddyserver.com/
+  https://traefik.io/
+  https://www.torproject.org/
+  https://opensource.org/
+  https://semver.org/
+  https://12factor.net/
+  https://martinfowler.com/
+  https://arstechnica.com/
+  https://www.wired.com/
+  https://techcrunch.com/
+  https://www.theverge.com/
+  https://lwn.net/
+  https://www.openweathermap.org/
+  https://www.weather.gov/
+  https://www.timeanddate.com/
+  https://ourworldindata.org/
+  https://www.kaggle.com/
+  https://pytorch.org/
+  https://huggingface.co/
+  https://openai.com/
+  https://www.meta.com/
+  https://paperswithcode.com/
+  https://blog.cloudflare.com/
+  https://github.blog/
+  https://stackoverflow.blog/
+  https://www.cisa.gov/
+  https://www.ncsc.gov.uk/
+)
+
+SITES=("${SITES[@]:0:100}")
+
+if ((${#SITES[@]} != 100)); then
+  echo "Expected 100 sites, got ${#SITES[@]}" >&2
+  exit 1
+fi
+
+RESULTS="$(mktemp)"
+trap 'rm -f "$RESULTS"' EXIT
+
+test_one() {
+  local url="$1"
+  local out code time err
+  if out=$(curl -sS -o /dev/null -w '%{http_code} %{time_total}' \
+    --cacert "$CA" -x "$PROXY" --max-time "$MAX_TIME" --connect-timeout 10 \
+    -A 'BSDM-Proxy-HTTPS-Test/1.0' "$url" 2>&1); then
+    code=$(echo "$out" | awk '{print $1}')
+    time=$(echo "$out" | awk '{print $2}')
+    printf 'OK\t%s\t%s\t%s\n' "$code" "$time" "$url"
+  else
+    err=$(echo "$out" | tr '\n' ' ' | cut -c1-120)
+    printf 'FAIL\t000\t0\t%s\t%s\n' "$url" "$err"
+  fi
+}
+
+export -f test_one
+export CA PROXY MAX_TIME
+
+printf 'Testing %s HTTPS sites via %s (concurrency=%s)...\n' "${#SITES[@]}" "$PROXY" "$CONCURRENCY"
+
+printf '%s\n' "${SITES[@]}" | xargs -P "$CONCURRENCY" -I {} bash -c 'test_one "$@"' _ {} >"$RESULTS"
+
+total=$(wc -l <"$RESULTS" | tr -d ' ')
+ok=$(grep -c '^OK' "$RESULTS" || true)
+fail=$(grep -c '^FAIL' "$RESULTS" || true)
+
+echo
+echo "=== Summary ==="
+echo "Total:   $total"
+echo "OK:      $ok"
+echo "FAIL:    $fail"
+
+echo
+echo "=== HTTP status distribution ==="
+awk -F'\t' '$1=="OK"{print $2}' "$RESULTS" | sort | uniq -c | sort -rn
+
+echo
+echo "=== Timing (OK, seconds) ==="
+awk -F'\t' '$1=="OK"{sum+=$3; if(!n||$3<min)min=$3; if($3>max)max=$3; n++} END{
+  if(n>0) printf "count=%d avg=%.3f min=%.3f max=%.3f\n", n, sum/n, min, max
+}' "$RESULTS"
+
+echo
+echo "=== Failed sites ($fail) ==="
+grep '^FAIL' "$RESULTS" | awk -F'\t' '{printf "  %s\n    %s\n", $4, $5}'
+
+echo
+echo "=== Slowest 10 ==="
+awk -F'\t' '$1=="OK"{print $3"\t"$4}' "$RESULTS" | sort -rn | head -10 | awk -F'\t' '{printf "  %.3fs  %s\n", $1, $2}'
+
+echo
+echo "=== Fastest 10 ==="
+awk -F'\t' '$1=="OK"{print $3"\t"$4}' "$RESULTS" | sort -n | head -10 | awk -F'\t' '{printf "  %.3fs  %s\n", $1, $2}'
+
+echo
+echo "=== Proxy metrics ==="
+curl -fsS "${METRICS_URL:-http://127.0.0.1:9090/metrics}" | grep -E '^bsdm_proxy_(cache_hits|cache_misses|requests_total)' | grep -v '#'

--- a/scripts/trust-mitm-ca-macos.sh
+++ b/scripts/trust-mitm-ca-macos.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Trust BSDM MITM Root CA on macOS (Safari, Chrome, Edge use System keychain).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CA="${CA:-$ROOT/certs/ca.crt}"
+
+if [[ ! -f "$CA" ]]; then
+  echo "CA not found: $CA" >&2
+  echo "Run: ./scripts/generate-mitm-ca.sh" >&2
+  exit 1
+fi
+
+echo "Installing BSDM Root CA to System keychain (requires sudo)..."
+echo "File: $CA"
+
+# Remove stale copies so trust settings apply cleanly.
+sudo security delete-certificate -c "BSDM Root CA" /Library/Keychains/System.keychain 2>/dev/null || true
+
+sudo security add-trusted-cert -d -r trustRoot -p ssl -p basic \
+  -k /Library/Keychains/System.keychain "$CA"
+
+echo
+echo "Done. Verify:"
+security find-certificate -c "BSDM Root CA" /Library/Keychains/System.keychain | head -3
+
+echo
+echo "Browser proxy settings (System Settings → Network → Wi‑Fi/Ethernet → Details → Proxies):"
+echo "  Web Proxy (HTTP):      127.0.0.1  port 8080"
+echo "  Secure Web Proxy:      127.0.0.1  port 8080"
+echo "  Bypass: localhost, 127.0.0.1, *.local"
+echo
+echo "Firefox uses its own store — import $CA manually:"
+echo "  Settings → Privacy & Security → Certificates → View Certificates → Authorities → Import"
+echo
+echo "For browser use on macOS, run the proxy natively (not in Docker):"
+echo "  ./scripts/run-proxy-native.sh"
+echo
+echo "Docker + system proxy on port 1488 causes upstream 502 (proxy loop)."


### PR DESCRIPTION
Improve MITM leaf cert validity and TLS chain for Safari/Chrome, combine upstream TLS roots for Docker, switch Dockerfile to Debian native build, and add macOS scripts for native proxy on port 8080 to avoid Docker localhost connection leaks.