### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+BSDM-Proxy is a single Rust/Cargo product: a caching HTTPS forward proxy with MITM
+TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → OpenSearch
+analytics pipeline. The Cargo workspace has three crates: `proxy/` (bin `proxy`),
+`cache-indexer/` (bin `cache-indexer`), and `e2e/` (test harness). Standard build,
+lint, test, and run commands live in `README.md` and `docs/development.md` — use those
+as the source of truth.
+
+Environment notes (the update script already runs `cargo fetch`; system packages and the
+Rust toolchain are baked into the VM image):
+
+- Requires Rust 1.85+. The image ships a newer stable toolchain (`rustup default stable`);
+  the previously preinstalled 1.83 is too old and will fail to compile some deps.
+- Native build needs system packages `libssl-dev pkg-config cmake librdkafka-dev libclang-dev`
+  (see `docs/development.md`). `rdkafka` (Kafka client) links against `librdkafka-dev`.
+
+Running and testing:
+
+- `cargo test --workspace` (plus the `smoke`/`e2e` suites) needs **no** Docker, Kafka, or
+  OpenSearch — the e2e harness spawns `proxy` as a subprocess with an in-process mock
+  upstream (`e2e/src/lib.rs`). The test suites do require outbound localhost networking.
+- To run the proxy with `MITM_ENABLED=true` (the default), a CA keypair must exist at
+  `./certs/ca.key` and `./certs/ca.crt`. These are git-ignored and NOT in the repo, so
+  generate them first (see "Быстрый старт" in `README.md`), otherwise MITM startup fails.
+  For plain forward-proxy testing you can set `MITM_ENABLED=false` and skip the certs.
+- Run locally: `HTTP_PORT=1488 METRICS_PORT=9090 cargo run -p bsdm-proxy --bin proxy`
+  (or the built `./target/debug/proxy`). Verify with `curl http://127.0.0.1:9090/health`
+  and `curl -x http://127.0.0.1:1488 http://httpbin.org/get`. HTTPS through MITM:
+  `curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/uuid`.
+- The full Docker stack (`docker-compose.yml`: Kafka, OpenSearch, Prometheus, Grafana) is
+  optional and only needed to exercise the analytics pipeline / dashboards end to end.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-proxy"
-version = "0.2.2-b"
+version = "0.2.3-test"
 dependencies = [
  "base64",
  "bytes",
@@ -233,7 +233,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cache-indexer"
-version = "0.2.2-b"
+version = "0.2.3-test"
 dependencies = [
  "bytes",
  "opensearch",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the BSDM-Proxy development environment for Cursor Cloud agents and verifies it end to end. Adds `AGENTS.md` with durable, non-obvious setup/run notes. No application code changed.

## Environment setup

- System packages: `libssl-dev pkg-config cmake librdkafka-dev libclang-dev` (baked into VM image).
- Rust toolchain upgraded to stable (1.96) — the project requires 1.85+ and the preinstalled 1.83 was too old.
- Update script (runs on startup): `cargo fetch`.

## Verification

All checks run against the Rust workspace (core product). The full Docker stack is optional and out of scope for basic dev readiness.

| Check | Command | Result |
|-------|---------|--------|
| Build | `cargo build --workspace --all-targets` | pass |
| Format | `cargo fmt --all -- --check` | pass |
| Lint | `cargo clippy --workspace --all-targets -- -D warnings` | pass |
| Tests | `cargo test --workspace --all-targets` | 21 passed (8 e2e, 4 smoke, 9 integration) |
| Run | `./target/debug/proxy` + curl | health/ready OK, HTTP forward OK, HTTPS MITM OK, cache HIT recorded |

Hello-world: started the proxy, forwarded an HTTP request, performed an HTTPS request through MITM (trusting the generated CA), and confirmed a cache HIT plus request metrics.

[bsdm_proxy_demo.log](https://cursor.com/agents/bc-85f622ab-f82e-4be6-a6df-b565cc0f8c48/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbsdm_proxy_demo.log)

Please merge the `AGENTS.md` updates so future agents remember the MITM cert and Rust-version caveats.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85f622ab-f82e-4be6-a6df-b565cc0f8c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85f622ab-f82e-4be6-a6df-b565cc0f8c48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

