### PR TITLE
feat(proxy): rate limiting per user/IP (B6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 | Область | Возможности |
 |---------|-------------|
 | **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (порты 443/8443), HTTP CONNECT, кеш L1, **иерархический кеш** (ICP + parent/sibling peers) |
-| **Безопасность** | Proxy-аутентификация (Basic / LDAP / NTLM), ACL, категоризация URL |
+| **Безопасность** | Proxy-аутентификация (Basic / LDAP), ACL, категоризация URL, rate limiting |
 | **Наблюдаемость** | Prometheus (20+ метрик), Grafana, `/health`, `/ready`, `/metrics` |
 | **Аналитика** | Kafka → cache-indexer → OpenSearch |
 | **Эксплуатация** | Graceful shutdown, настраиваемые порты, release-пакет + systemd |
@@ -186,6 +186,19 @@ CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallbac
 
 → [docs/acl.md](docs/acl.md) · [docs/categorization.md](docs/categorization.md)
 
+### Rate limiting (опционально)
+
+Token-bucket лимиты на IP и аутентифицированного пользователя. Метрика: `bsdm_proxy_rate_limit_rejected_total{limit_type="ip|user"}`.
+
+| Переменная | По умолчанию | Описание |
+|-----------|-------------|----------|
+| `RATE_LIMIT_ENABLED` | `false` | Включить rate limiting |
+| `RATE_LIMIT_IP_RPS` | `100` | Запросов/сек на IP |
+| `RATE_LIMIT_IP_BURST` | `200` | Burst на IP |
+| `RATE_LIMIT_USER_RPS` | `50` | Запросов/сек на пользователя |
+| `RATE_LIMIT_USER_BURST` | `100` | Burst на пользователя |
+| `RATE_LIMIT_MAX_KEYS` | `10000` | Макс. отслеживаемых ключей |
+
 ### Иерархический кеш (опционально)
 
 Включается через `HIERARCHY_ENABLED=true`. После промаха L1: ICP-запрос к siblings → выбор parent → HTTP fetch через peer → fallback на origin.
@@ -301,7 +314,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] E2E / smoke test harness
 - [x] Release packaging (`0.2.2b`)
 - [x] Hierarchical caching Phase 3 — ICP server, peer fetch, env config
-- [ ] Rate limiting per user/IP
+- [x] Rate limiting per user/IP
 - [ ] Рефакторинг `main.rs` (вынос `ProxyService` в lib)
 
 ### M2 — Squid parity (v0.3.x)

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -17,7 +17,7 @@
 | B3 | [#34](https://github.com/onixus/bsdm-proxy/issues/34) | Implement HTTP fetch from hierarchy peer | ✅ |
 | B4 | [#35](https://github.com/onixus/bsdm-proxy/issues/35) | Start ICP server in proxy runtime | ✅ |
 | B5 | [#36](https://github.com/onixus/bsdm-proxy/issues/36) | Make `ca.key` optional when MITM disabled | ✅ |
-| B6 | [#37](https://github.com/onixus/bsdm-proxy/issues/37) | Implement rate limiting per user/IP | ❌ |
+| B6 | [#37](https://github.com/onixus/bsdm-proxy/issues/37) | Implement rate limiting per user/IP | ✅ |
 
 ## High — M2 / M3
 
@@ -57,6 +57,6 @@
 
 ## Волны разблокировки
 
-1. **Волна 1 (M1):** ~~B5~~ → ~~B1+B2~~ → ~~B3+B4~~ → **B6** → **B7**
+1. **Волна 1 (M1):** ~~B5~~ → ~~B1+B2~~ → ~~B3+B4~~ → ~~**B6**~~ → **B7**
 2. **Волна 2 (M3):** B12 → B11 → B10 → B17
 3. **Волна 3 (M4/M5):** B16 → B15 → B8

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,12 +67,12 @@ gantt
 
 ### В работе / осталось в M1
 
-- [ ] Rate limiting per user/IP — [#37](https://github.com/onixus/bsdm-proxy/issues/37)
+- [x] Rate limiting per user/IP — [#37](https://github.com/onixus/bsdm-proxy/issues/37)
 - [ ] Рефакторинг `main.rs` — вынос `ProxyService` в lib — [#38](https://github.com/onixus/bsdm-proxy/issues/38)
 - [ ] Hierarchy E2E / `docker-compose.hierarchy.yml`
 - [ ] Исправить README: NTLM помечен как done, но не реализован (`auth.rs`)
 
-**Критерий завершения M1:** rate limit + рефакторинг main, hierarchy E2E, все CI зелёные.
+**Критерий завершения M1:** рефакторинг main, hierarchy E2E, все CI зелёные.
 
 ---
 

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -52,5 +52,13 @@ HIERARCHY_ENABLED=false
 # Upstream TLS (for self-signed upstream CA in tests/lab)
 # UPSTREAM_CA_CERT=/etc/bsdm-proxy/upstream-ca.crt
 
+# Rate limiting (disabled by default)
+# RATE_LIMIT_ENABLED=true
+# RATE_LIMIT_IP_RPS=100
+# RATE_LIMIT_IP_BURST=200
+# RATE_LIMIT_USER_RPS=50
+# RATE_LIMIT_USER_BURST=100
+# RATE_LIMIT_MAX_KEYS=10000
+
 RUST_LOG=info,bsdm_proxy=info
 RUST_BACKTRACE=0

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hierarchy_config;
 pub mod icp;
 pub mod peer_fetch;
 pub mod peers;
+pub mod rate_limit;
 pub mod selection;
 
 // Re-export commonly used types
@@ -23,6 +24,7 @@ pub use hierarchy_config::{
 pub use icp::{IcpClient, IcpMessage, IcpOpcode, IcpServer};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
+pub use rate_limit::{RateLimitConfig, RateLimitViolation, RateLimiter};
 pub use selection::{parse_strategy, SelectionStrategy};
 
 // Conditional re-exports based on features

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,7 +9,8 @@ use base64::Engine;
 use bsdm_proxy::{
     build_hierarchy_manager, fetch_via_peer, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, should_start_icp_server, AclAction, AclDecision, AuthManager, Category,
-    HierarchyManager, HierarchyResult, IcpServer, UserInfo,
+    HierarchyManager, HierarchyResult, IcpServer, RateLimitConfig, RateLimitViolation, RateLimiter,
+    UserInfo,
 };
 use bytes::Bytes;
 use hyper::body::Incoming;
@@ -149,6 +150,7 @@ struct ProxyService {
     acl_engine: Option<Arc<Mutex<bsdm_proxy::AclEngine>>>,
     categorization: Option<Arc<bsdm_proxy::CategorizationEngine>>,
     hierarchy: Option<Arc<HierarchyManager>>,
+    rate_limiter: Arc<RateLimiter>,
 }
 
 impl ProxyService {
@@ -163,6 +165,7 @@ impl ProxyService {
         auth: Option<Arc<AuthManager>>,
         policy: &PolicyConfig,
         hierarchy: Option<Arc<HierarchyManager>>,
+        rate_limit_config: RateLimitConfig,
     ) -> Self {
         let kafka_producer = kafka_brokers.and_then(|brokers| {
             ClientConfig::new()
@@ -201,6 +204,7 @@ impl ProxyService {
             acl_engine: policy.acl_engine.clone(),
             categorization: policy.categorization.clone(),
             hierarchy,
+            rate_limiter: Arc::new(RateLimiter::new(rate_limit_config)),
         }
     }
 
@@ -328,6 +332,38 @@ impl ProxyService {
         .unwrap_or((None, None))
     }
 
+    fn check_rate_limit(&self, client_ip: &str, username: Option<&str>) -> Option<Response<Body>> {
+        let violation = self.rate_limiter.check(client_ip, username)?;
+        let limit_type = match violation {
+            RateLimitViolation::Ip => "ip",
+            RateLimitViolation::User => "user",
+        };
+        self.metrics
+            .rate_limit_rejected_total
+            .with_label_values(&[limit_type])
+            .inc();
+        warn!(
+            "Rate limit exceeded ({}) for client_ip={} user={}",
+            limit_type,
+            client_ip,
+            username.unwrap_or("-")
+        );
+        Some(Self::rate_limit_response())
+    }
+
+    fn rate_limit_response() -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::TOO_MANY_REQUESTS)
+            .header("Content-Type", "text/plain; charset=utf-8")
+            .header("Retry-After", "1")
+            .body(Body::new(Bytes::from_static(
+                b"429 Too Many Requests: rate limit exceeded",
+            )))
+            .unwrap_or_else(|_| {
+                Response::new(Body::new(Bytes::from_static(b"429 Too Many Requests")))
+            })
+    }
+
     #[inline]
     fn generate_cache_key(&self, method: &str, url: &str) -> Arc<str> {
         http_cache_key(method, url)
@@ -453,6 +489,12 @@ impl ProxyService {
         } else {
             Self::extract_user_info(&req)
         };
+
+        if let Some(resp) = self.check_rate_limit(&client_ip, username.as_deref()) {
+            guard.finish(429, 0, 0);
+            return resp;
+        }
+
         let domain = Self::extract_domain(&url);
 
         let (policy_decision, categories) = self
@@ -964,6 +1006,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await
         .map_err(|e| -> Box<dyn std::error::Error> { e })?;
 
+    let rate_limit_config = RateLimitConfig::from_env();
+
     let service = Arc::new(ProxyService::new(
         cert_cache,
         cache_config.clone(),
@@ -974,6 +1018,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         auth,
         &policy_config,
         hierarchy.clone(),
+        rate_limit_config.clone(),
     ));
 
     if should_start_icp_server(&hierarchy_config) {
@@ -1061,6 +1106,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
     } else {
         info!("👤 Proxy auth: disabled");
+    }
+    if rate_limit_config.enabled {
+        info!(
+            "⏱️  Rate limit: enabled (ip={}/{} rps/burst, user={}/{} rps/burst)",
+            rate_limit_config.ip_rps,
+            rate_limit_config.ip_burst,
+            rate_limit_config.user_rps,
+            rate_limit_config.user_burst
+        );
+    } else {
+        info!("⏱️  Rate limit: disabled");
     }
     info!(
         "📦 Cache: {} entries, TTL: {:?}, max body: {}MB",
@@ -1342,9 +1398,13 @@ async fn handle_connection(
                     Err(resp) => return Ok(resp),
                 };
 
+                let policy_username = proxy_user.as_deref().map(|u| u.username.as_str());
+                if let Some(resp) = service.check_rate_limit(&client_ip, policy_username) {
+                    return Ok::<_, Infallible>(resp);
+                }
+
                 let connect_url = format!("https://{}", authority);
                 let connect_domain = parse_authority(&authority).0;
-                let policy_username = proxy_user.as_deref().map(|u| u.username.as_str());
                 let (policy_decision, _) = service
                     .check_policy(&connect_url, &connect_domain, policy_username, &client_ip)
                     .await;

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -51,6 +51,9 @@ pub struct Metrics {
     pub acl_decisions_total: CounterVec,
     pub acl_rules_matched_total: CounterVec,
     pub acl_eval_duration_seconds: Histogram,
+
+    // Rate limit metrics
+    pub rate_limit_rejected_total: CounterVec,
 }
 
 impl Metrics {
@@ -225,6 +228,15 @@ impl Metrics {
         )?;
         registry.register(Box::new(acl_eval_duration_seconds.clone()))?;
 
+        let rate_limit_rejected_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_rate_limit_rejected_total",
+                "Total requests rejected by rate limiting",
+            ),
+            &["limit_type"],
+        )?;
+        registry.register(Box::new(rate_limit_rejected_total.clone()))?;
+
         Ok(Metrics {
             registry,
             requests_total,
@@ -250,6 +262,7 @@ impl Metrics {
             acl_decisions_total,
             acl_rules_matched_total,
             acl_eval_duration_seconds,
+            rate_limit_rejected_total,
         })
     }
 

--- a/proxy/src/rate_limit.rs
+++ b/proxy/src/rate_limit.rs
@@ -1,0 +1,267 @@
+//! Token-bucket rate limiting per client IP and authenticated user.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Which limit was exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateLimitViolation {
+    Ip,
+    User,
+}
+
+/// Per-key token bucket.
+#[derive(Debug)]
+struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(burst: f64) -> Self {
+        Self {
+            tokens: burst,
+            last_refill: Instant::now(),
+        }
+    }
+
+    fn try_acquire(&mut self, rate: f64, burst: f64) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * rate).min(burst);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Rate limit configuration loaded from environment.
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    pub enabled: bool,
+    pub ip_rps: f64,
+    pub ip_burst: f64,
+    pub user_rps: f64,
+    pub user_burst: f64,
+    pub max_keys: usize,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            ip_rps: 100.0,
+            ip_burst: 200.0,
+            user_rps: 50.0,
+            user_burst: 100.0,
+            max_keys: 10_000,
+        }
+    }
+}
+
+impl RateLimitConfig {
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("RATE_LIMIT_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let ip_rps = parse_positive_f64("RATE_LIMIT_IP_RPS", 100.0);
+        let ip_burst = parse_positive_f64("RATE_LIMIT_IP_BURST", ip_rps * 2.0);
+        let user_rps = parse_positive_f64("RATE_LIMIT_USER_RPS", 50.0);
+        let user_burst = parse_positive_f64("RATE_LIMIT_USER_BURST", user_rps * 2.0);
+        let max_keys = std::env::var("RATE_LIMIT_MAX_KEYS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10_000)
+            .max(1);
+
+        Self {
+            enabled,
+            ip_rps,
+            ip_burst,
+            user_rps,
+            user_burst,
+            max_keys,
+        }
+    }
+}
+
+fn parse_positive_f64(name: &str, default: f64) -> f64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .filter(|v| *v > 0.0)
+        .unwrap_or(default)
+}
+
+/// Token-bucket rate limiter with separate buckets per IP and per user.
+pub struct RateLimiter {
+    config: RateLimitConfig,
+    ip_buckets: Mutex<HashMap<String, TokenBucket>>,
+    user_buckets: Mutex<HashMap<String, TokenBucket>>,
+}
+
+impl RateLimiter {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            ip_buckets: Mutex::new(HashMap::new()),
+            user_buckets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn config(&self) -> &RateLimitConfig {
+        &self.config
+    }
+
+    /// Returns `Some(violation)` when the request must be rejected.
+    pub fn check(&self, client_ip: &str, username: Option<&str>) -> Option<RateLimitViolation> {
+        if !self.config.enabled {
+            return None;
+        }
+
+        if !self.try_acquire(
+            &self.ip_buckets,
+            client_ip,
+            self.config.ip_rps,
+            self.config.ip_burst,
+        ) {
+            return Some(RateLimitViolation::Ip);
+        }
+
+        if let Some(user) = username.filter(|u| !u.is_empty()) {
+            if !self.try_acquire(
+                &self.user_buckets,
+                user,
+                self.config.user_rps,
+                self.config.user_burst,
+            ) {
+                return Some(RateLimitViolation::User);
+            }
+        }
+
+        None
+    }
+
+    fn try_acquire(
+        &self,
+        buckets: &Mutex<HashMap<String, TokenBucket>>,
+        key: &str,
+        rate: f64,
+        burst: f64,
+    ) -> bool {
+        let mut guard = buckets
+            .lock()
+            .expect("rate limit bucket map mutex poisoned");
+
+        if guard.len() >= self.config.max_keys && !guard.contains_key(key) {
+            if let Some(evict_key) = guard.keys().next().cloned() {
+                guard.remove(&evict_key);
+            }
+        }
+
+        guard
+            .entry(key.to_string())
+            .or_insert_with(|| TokenBucket::new(burst))
+            .try_acquire(rate, burst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    fn enabled_config(ip_rps: f64, ip_burst: f64) -> RateLimitConfig {
+        RateLimitConfig {
+            enabled: true,
+            ip_rps,
+            ip_burst,
+            user_rps: 10.0,
+            user_burst: 10.0,
+            max_keys: 100,
+        }
+    }
+
+    #[test]
+    fn disabled_allows_all() {
+        let limiter = RateLimiter::new(RateLimitConfig::default());
+        assert!(limiter.check("10.0.0.1", None).is_none());
+    }
+
+    #[test]
+    fn burst_then_reject() {
+        let limiter = RateLimiter::new(enabled_config(1.0, 2.0));
+        assert!(limiter.check("10.0.0.1", None).is_none());
+        assert!(limiter.check("10.0.0.1", None).is_none());
+        assert_eq!(
+            limiter.check("10.0.0.1", None),
+            Some(RateLimitViolation::Ip)
+        );
+    }
+
+    #[test]
+    fn separate_ips_have_separate_buckets() {
+        let limiter = RateLimiter::new(enabled_config(1.0, 1.0));
+        assert!(limiter.check("10.0.0.1", None).is_none());
+        assert_eq!(
+            limiter.check("10.0.0.1", None),
+            Some(RateLimitViolation::Ip)
+        );
+        assert!(limiter.check("10.0.0.2", None).is_none());
+    }
+
+    #[test]
+    fn user_limit_applies_when_authenticated() {
+        let config = RateLimitConfig {
+            enabled: true,
+            ip_rps: 1000.0,
+            ip_burst: 1000.0,
+            user_rps: 1.0,
+            user_burst: 1.0,
+            max_keys: 100,
+        };
+        let limiter = RateLimiter::new(config);
+        assert!(limiter.check("10.0.0.1", Some("alice")).is_none());
+        assert_eq!(
+            limiter.check("10.0.0.1", Some("alice")),
+            Some(RateLimitViolation::User)
+        );
+        assert!(limiter.check("10.0.0.1", Some("bob")).is_none());
+    }
+
+    #[test]
+    fn tokens_refill_over_time() {
+        let limiter = RateLimiter::new(enabled_config(10.0, 1.0));
+        assert!(limiter.check("10.0.0.1", None).is_none());
+        assert_eq!(
+            limiter.check("10.0.0.1", None),
+            Some(RateLimitViolation::Ip)
+        );
+        thread::sleep(Duration::from_millis(150));
+        assert!(limiter.check("10.0.0.1", None).is_none());
+    }
+
+    #[test]
+    fn evicts_oldest_key_when_at_capacity() {
+        let config = RateLimitConfig {
+            enabled: true,
+            ip_rps: 1.0,
+            ip_burst: 1.0,
+            user_rps: 1.0,
+            user_burst: 1.0,
+            max_keys: 2,
+        };
+        let limiter = RateLimiter::new(config);
+        assert!(limiter.check("10.0.0.1", None).is_none());
+        assert!(limiter.check("10.0.0.2", None).is_none());
+        assert!(limiter.check("10.0.0.3", None).is_none());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements blocker **B6** — token-bucket rate limiting per client IP and authenticated user.

## Changes

- New `proxy/src/rate_limit.rs` module with `RateLimiter`, `RateLimitConfig`, and unit tests
- Rate limit checks wired into CONNECT (before tunnel) and `handle_request` (covers MITM inner requests)
- Returns `429 Too Many Requests` with `Retry-After: 1`
- Prometheus metric: `bsdm_proxy_rate_limit_rejected_total{limit_type="ip|user"}`
- Disabled by default (`RATE_LIMIT_ENABLED=false`)

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `RATE_LIMIT_ENABLED` | `false` | Enable rate limiting |
| `RATE_LIMIT_IP_RPS` | `100` | Requests/sec per IP |
| `RATE_LIMIT_IP_BURST` | `200` | Burst per IP |
| `RATE_LIMIT_USER_RPS` | `50` | Requests/sec per user |
| `RATE_LIMIT_USER_BURST` | `100` | Burst per user |
| `RATE_LIMIT_MAX_KEYS` | `10000` | Max tracked keys |

## Testing

- `cargo test -p bsdm-proxy` — 57 tests pass
- `cargo clippy -p bsdm-proxy -- -D warnings` — clean

## Next in M1 sequence

After merge: **B7** — refactor `ProxyService` out of `main.rs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

