### PR TITLE
docs: logging guide + cache-indexer RUST_LOG fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Таймаут graceful shutdown |
 | `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab) |
-| `RUST_LOG` | `info` | Уровень логов |
+| `RUST_LOG` | `info,bsdm_proxy=debug`¹ | Фильтр логов ([docs/logging.md](docs/logging.md)) |
 
 CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallback: `./certs/`).
+
+¹ Если `RUST_LOG` не задана — fallback в коде; для production задайте `RUST_LOG=info,bsdm_proxy=info` (см. [docs/logging.md](docs/logging.md)).
 
 ### Аутентификация
 
@@ -282,6 +284,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 |----------|------------|
 | [docs/README.md](docs/README.md) | Оглавление документации |
 | [docs/authentication.md](docs/authentication.md) | LDAP, Basic Auth (NTLM — M2) |
+| [docs/logging.md](docs/logging.md) | Логирование (`RUST_LOG`, уровни, просмотр) |
 | [docs/acl.md](docs/acl.md) | Правила доступа, приоритеты |
 | [docs/categorization.md](docs/categorization.md) | Shallalist, URLhaus, PhishTank |
 | [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш, ICP, peers |
@@ -299,7 +302,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 
 | Milestone | Версия | Фокус | Статус |
 |-----------|--------|-------|--------|
-| **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability, иерархия | ~95% |
+| **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability, иерархия | ✅ Done |
 | **M2** Squid parity | v0.3.x | L2 Redis, rate limit, полный ACL, hierarchy Phase 4 | Planned |
 | **M3** Retro-search | v0.4.x | OpenSearch dashboards, поиск по истории | Planned |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | Planned |

--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -309,7 +309,12 @@ impl Indexer {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,cache_indexer=info".into()),
+        )
+        .init();
 
     let kafka_brokers = std::env::var("KAFKA_BROKERS").unwrap_or_else(|_| "kafka:9092".to_string());
     let opensearch_url =

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 | Документ | Описание |
 |----------|----------|
 | [authentication.md](authentication.md) | Аутентификация прокси (Basic, LDAP; NTLM — M2) |
+| [logging.md](logging.md) | Логирование (`RUST_LOG`, уровни, troubleshooting) |
 | [acl.md](acl.md) | Списки контроля доступа (ACL) |
 | [categorization.md](categorization.md) | Категоризация URL и threat intelligence |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -185,7 +185,7 @@ cargo test -p bsdm-proxy-e2e --test e2e e2e_mitm_https_with_self_signed_ca -- --
 export HTTP_PORT=1488
 export METRICS_PORT=9090
 export MITM_ENABLED=true
-export RUST_LOG=info,bsdm_proxy=debug
+export RUST_LOG=info,bsdm_proxy=debug   # см. docs/logging.md
 
 # CA для MITM (обязательно)
 mkdir -p certs
@@ -193,6 +193,8 @@ mkdir -p certs
 
 cargo run -p bsdm-proxy --bin proxy
 ```
+
+Подробнее о уровнях и модулях: [logging.md](logging.md).
 
 Проверка:
 ```bash

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,121 @@
+# Логирование
+
+BSDM-Proxy и cache-indexer используют [tracing](https://docs.rs/tracing) + [tracing-subscriber](https://docs.rs/tracing-subscriber). Уровень и область логов задаются переменной окружения **`RUST_LOG`** ([`EnvFilter`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html)).
+
+## Переменные
+
+| Переменная | Компонент | Описание |
+|------------|-----------|----------|
+| `RUST_LOG` | proxy, cache-indexer | Фильтр уровней (`error`, `warn`, `info`, `debug`, `trace`) и модулей |
+| `RUST_BACKTRACE` | оба | `1` — полный backtrace при panic (для отладки) |
+
+## Значения по умолчанию
+
+Если `RUST_LOG` **не задана**:
+
+| Бинарник | Fallback | Примечание |
+|----------|----------|------------|
+| `proxy` | `info,bsdm_proxy=debug` | Удобно для локальной разработки (`cargo run`) |
+| `cache-indexer` | `info,cache_indexer=info` | Сообщения indexer на уровне `info` |
+
+В production задавайте `RUST_LOG` явно через env-файл или systemd — см. [packaging/config/bsdm-proxy.env.example](../packaging/config/bsdm-proxy.env.example).
+
+### Рекомендуемые профили
+
+**Production (proxy):**
+```bash
+RUST_LOG=info,bsdm_proxy=info
+```
+
+**Production (cache-indexer):**
+```bash
+RUST_LOG=info,cache_indexer=info
+```
+
+**Отладка прокси (MITM, ACL, hierarchy, rate limit):**
+```bash
+RUST_LOG=info,bsdm_proxy=debug
+```
+
+**Минимальный шум (только предупреждения и ошибки):**
+```bash
+RUST_LOG=warn
+```
+
+**Трассировка одного модуля:**
+```bash
+RUST_LOG=info,bsdm_proxy::icp=debug,bsdm_proxy::hierarchy=debug
+```
+
+## Имена модулей (targets)
+
+Используйте имя крейта с подчёркиванием:
+
+| Крейт | Префикс в `RUST_LOG` |
+|-------|----------------------|
+| `bsdm-proxy` | `bsdm_proxy` |
+| `cache-indexer` | `cache_indexer` |
+
+Подмодули: `bsdm_proxy::proxy_service`, `bsdm_proxy::icp`, `bsdm_proxy::acl`, `bsdm_proxy::auth` и т.д.
+
+## Где настраивается в репозитории
+
+| Файл | `RUST_LOG` |
+|------|------------|
+| [packaging/config/bsdm-proxy.env.example](../packaging/config/bsdm-proxy.env.example) | `info,bsdm_proxy=info` |
+| [packaging/config/cache-indexer.env.example](../packaging/config/cache-indexer.env.example) | `info,cache_indexer=info` |
+| [docker-compose.yml](../docker-compose.yml) | `info,bsdm_proxy=debug` / `info,cache_indexer=debug` |
+| [docker-compose.hierarchy.yml](../docker-compose.hierarchy.yml) | `info,bsdm_proxy=info` |
+| [docker-compose.test.yml](../docker-compose.test.yml) | `warn` |
+| [proxy/src/main.rs](../proxy/src/main.rs) | init + fallback |
+| [cache-indexer/src/main.rs](../cache-indexer/src/main.rs) | init + fallback |
+
+systemd подхватывает env из `/etc/bsdm-proxy/bsdm-proxy.env` и `cache-indexer.env` ([packaging/systemd/](../packaging/systemd/)).
+
+## Что логируется
+
+### Proxy (`bsdm_proxy`)
+
+| Уровень | Примеры |
+|---------|---------|
+| `info` | Старт, порты, включённые подсистемы (ACL, hierarchy, rate limit), graceful shutdown |
+| `warn` | Неизвестная стратегия peer selection, ошибки ICP, fallback auth backend |
+| `debug` | MITM-соединения, cache hit/miss, ACL decisions, peer fetch |
+| `error` | Ошибки upstream, Kafka flush, критические сбои обработки |
+
+### cache-indexer
+
+| Уровень | Примеры |
+|---------|---------|
+| `info` | Старт, Kafka/OpenSearch endpoints, bulk index stats |
+| `warn` | Пропуск событий, retryable ошибки |
+| `error` | Сбой consumer, OpenSearch bulk errors |
+
+Метрики и health **не** дублируются в логах — используйте `/metrics` и `/health` на `METRICS_PORT` (по умолчанию `9090`).
+
+## Просмотр логов
+
+**Docker Compose:**
+```bash
+docker compose logs -f proxy
+docker compose logs -f cache-indexer
+docker compose logs -f proxy 2>&1 | grep -iE 'acl|ldap|icp|rate.?limit'
+```
+
+**systemd:**
+```bash
+journalctl -u bsdm-proxy -f
+journalctl -u bsdm-cache-indexer -f
+```
+
+**Локальный запуск:**
+```bash
+RUST_LOG=info,bsdm_proxy=debug cargo run -p bsdm-proxy --bin proxy
+```
+
+## Связанные документы
+
+- [development.md](development.md) — локальный запуск и отладка
+- [authentication.md](authentication.md) — логи LDAP/auth
+- [acl.md](acl.md) — логи ACL
+- [packaging/README.md](../packaging/README.md) — установка и env-файлы

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@
 
 | Milestone | Версия | Фокус | Готовность |
 |-----------|--------|-------|------------|
-| [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability, иерархия | ~95% |
+| [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability, иерархия | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, rate limit, полный ACL, hierarchy Phase 4 | ~10% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~15% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
@@ -71,8 +71,9 @@ gantt
 - [x] Рефакторинг `main.rs` — вынос `ProxyService` в lib — [#38](https://github.com/onixus/bsdm-proxy/issues/38)
 - [x] Hierarchy E2E / `docker-compose.hierarchy.yml`
 - [x] Документация NTLM: помечен как M2 / не реализован — [#44](https://github.com/onixus/bsdm-proxy/issues/44)
+- [x] Документация логирования (`RUST_LOG`, профили production/dev)
 
-**Критерий завершения M1:** все CI зелёные.
+**Критерий завершения M1:** все CI зелёные — **выполнен** (v0.2.3-test).
 
 ---
 
@@ -93,7 +94,6 @@ gantt
 - [ ] **NTLM auth** — реализация или снятие с roadmap
 - [ ] **Negative caching** coordination
 - [ ] **Cache refresh / revalidate** — Squid-style freshness
-- [ ] **docker-compose.hierarchy.yml** — 3-tier demo stack
 - [ ] Hierarchy Prometheus metrics (`bsdm_proxy_hierarchy_*`)
 
 **Критерий завершения M2:** 3-tier cache hierarchy в docker-compose, hit rate sibling/parent измеряется, Redis L2 работает.
@@ -217,10 +217,11 @@ Issues привязывайте к milestones:
 
 - [architecture.md](architecture.md) — архитектура и блокеры B1–B25
 - [hierarchical-caching.md](hierarchical-caching.md) — дизайн ICP/HTCP (M2)
+- [logging.md](logging.md) — `RUST_LOG` и профили логирования
 - [categorization.md](categorization.md) — threat intel feeds (M1/M4)
 - [acl.md](acl.md) — политики доступа (M1/M2)
 - [development.md](development.md) — сборка и тесты
 
 ---
 
-*Последнее обновление: v0.2.2b*
+*Последнее обновление: M1 завершён (v0.2.3-test)*

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -55,6 +55,8 @@ curl http://127.0.0.1:9090/ready
 curl http://127.0.0.1:9090/metrics | head
 ```
 
+Логи: `journalctl -u bsdm-proxy -f` или см. [docs/logging.md](../docs/logging.md) (`RUST_LOG` в `config/*.env.example`).
+
 ## Build package from source
 
 ```bash

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -62,5 +62,6 @@ HIERARCHY_ENABLED=false
 # RATE_LIMIT_USER_BURST=100
 # RATE_LIMIT_MAX_KEYS=10000
 
+# Logging — see docs/logging.md
 RUST_LOG=info,bsdm_proxy=info
 RUST_BACKTRACE=0

--- a/packaging/config/cache-indexer.env.example
+++ b/packaging/config/cache-indexer.env.example
@@ -11,5 +11,6 @@ OPENSEARCH_INDEX=http-cache
 # OPENSEARCH_PASSWORD=
 OPENSEARCH_SSL_VERIFY=true
 
+# Logging — see docs/logging.md
 RUST_LOG=info,cache_indexer=info
 RUST_BACKTRACE=0

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tracing_subscriber::fmt()
         .with_env_filter(
+            // Fallback when RUST_LOG is unset — see docs/logging.md
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| "info,bsdm_proxy=debug".into()),
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds logging documentation and fixes inconsistent `RUST_LOG` handling in cache-indexer. Marks M1 as complete in roadmap/README.

## Changes

### Code
- **cache-indexer:** replace `tracing_subscriber::fmt::init()` with `EnvFilter::try_from_default_env()` + fallback `info,cache_indexer=info` (same pattern as proxy). Previously, without `RUST_LOG` set, only error-level logs were emitted.
- **proxy:** comment pointing to `docs/logging.md` for fallback behavior.

### Documentation
- New **[docs/logging.md](docs/logging.md)** — `RUST_LOG` syntax, production/dev profiles, module targets, docker/systemd/journalctl examples.
- Updated README (correct default `info,bsdm_proxy=debug`), roadmap (M1 ✅), development.md, packaging README, env examples.

## Logging audit findings

| Location | `RUST_LOG` |
|----------|------------|
| proxy (no env) | `info,bsdm_proxy=debug` |
| cache-indexer (no env, **after fix**) | `info,cache_indexer=info` |
| packaging env examples | `info,bsdm_proxy=info` / `info,cache_indexer=info` |
| docker-compose.yml | `debug` (dev stack) |
| docker-compose.hierarchy.yml | `info` |
| docker-compose.test.yml | `warn` |

## Testing

- `cargo clippy -p bsdm-proxy -p cache-indexer -- -D warnings` ✅
- `cargo test -p bsdm-proxy -p cache-indexer` ✅ (69 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

