### PR TITLE
ci: auto-close blocker issues on PR merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- Кратко: что меняется и зачем -->
+
+## Связанные issue
+
+<!-- Обязательно для блокеров B1–B25: укажите Closes #NN или оставьте (Bn) в заголовке PR — issue закроется автоматически при merge (см. .github/workflows/close-blockers.yml). -->
+
+- [ ] `Closes #NN` добавлено в описание **или** блокер указан в заголовке: `(B6)`
+- Milestone / блокер: <!-- M1, B6, … -->
+
+**Маппинг:** B*n* → issue #*(31+n)* (B6 → #37, B13 → #44).  
+**B13 (NTLM):** auto-close только при `Closes #44` (полная реализация); docs-only PR не закрывают #44.
+
+## Testing
+
+<!-- cargo test, e2e, clippy — что запускали -->
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+## Checklist
+
+- [ ] CI зелёный
+- [ ] Документация обновлена (если менялось поведение / env)
+- [ ] `docs/BLOCKERS.md` / `docs/roadmap.md` (если закрывается блокер)

--- a/.github/workflows/close-blockers.yml
+++ b/.github/workflows/close-blockers.yml
@@ -1,0 +1,164 @@
+# Auto-close architecture blocker issues when a merged PR references B1–B25.
+# Mapping: issue_number = 31 + blocker_id (B6 → #37).
+# B13 (#44) is skipped unless the PR body contains "Closes #44" / "Fixes #44"
+# (docs-only NTLM work must not close the implementation issue).
+
+name: Close blocker issues
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      blocker_id:
+        description: "Blocker id (1–25), e.g. 6 for B6 → #37"
+        required: true
+        type: string
+      pr_number:
+        description: "Related merged PR number (optional, for comment text)"
+        required: false
+        type: string
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  manual-close:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const base = 31;
+            const n = parseInt(core.getInput('blocker_id'), 10);
+            if (Number.isNaN(n) || n < 1 || n > 25) {
+              core.setFailed(`Invalid blocker_id: ${core.getInput('blocker_id')}`);
+              return;
+            }
+            const issue_number = base + n;
+            const prNum = core.getInput('pr_number');
+            const prRef = prNum ? `PR #${prNum}` : 'manual workflow_dispatch';
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            });
+
+            if (issue.state === 'closed') {
+              core.info(`Issue #${issue_number} (B${n}) already closed`);
+              return;
+            }
+
+            const body = [
+              `Closed via **${prRef}** (workflow: close-blockers).`,
+              '',
+              `Blocker **B${n}** marked completed.`,
+              '',
+              'See [docs/BLOCKERS.md](https://github.com/' + context.repo.owner + '/' + context.repo.repo + '/blob/main/docs/BLOCKERS.md).',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body,
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+
+            core.info(`Closed #${issue_number} (B${n})`);
+
+  on-pr-merge:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n${pr.body || ''}`;
+            const base = 31;
+            const skipUnlessExplicit = new Set([13]); // B13: NTLM impl vs docs-only
+
+            const blockers = new Set();
+            for (const m of text.matchAll(/\bB(\d{1,2})\b/gi)) {
+              const n = parseInt(m[1], 10);
+              if (n >= 1 && n <= 25) blockers.add(n);
+            }
+
+            const explicitIssues = new Set();
+            for (const m of (pr.body || '').matchAll(
+              /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi
+            )) {
+              explicitIssues.add(parseInt(m[1], 10));
+            }
+
+            const toClose = new Set();
+
+            for (const n of blockers) {
+              const issue_number = base + n;
+              if (skipUnlessExplicit.has(n) && !explicitIssues.has(issue_number)) {
+                core.info(
+                  `Skip B${n} (#${issue_number}): partial blocker — needs "Closes #${issue_number}" in PR body`
+                );
+                continue;
+              }
+              toClose.add(issue_number);
+            }
+
+            for (const issue_number of explicitIssues) {
+              if (issue_number >= 32 && issue_number <= 56) {
+                toClose.add(issue_number);
+              }
+            }
+
+            for (const issue_number of [...toClose].sort((a, b) => a - b)) {
+              const n = issue_number - base;
+
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+              });
+
+              if (issue.state === 'closed') {
+                core.info(`Issue #${issue_number} already closed`);
+                continue;
+              }
+
+              const comment = [
+                `Auto-closed by merge of PR #${pr.number}: ${pr.title}`,
+                '',
+                n >= 1 && n <= 25
+                  ? `Blocker **B${n}** referenced in PR (title/body) or \`Closes #${issue_number}\`.`
+                  : `Referenced via \`Closes #${issue_number}\` in PR body.`,
+                '',
+                `PR: ${pr.html_url}`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body: comment,
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+
+              core.info(`Closed #${issue_number} (B${n})`);
+            }

--- a/.github/workflows/pr-blocker-hint.yml
+++ b/.github/workflows/pr-blocker-hint.yml
@@ -1,0 +1,97 @@
+# Remind authors to link blocker issues when PR title references B1–B25.
+
+name: PR blocker link hint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  hint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || '';
+            const body = pr.body || '';
+            const base = 31;
+
+            const blockers = [];
+            for (const m of title.matchAll(/\bB(\d{1,2})\b/gi)) {
+              const n = parseInt(m[1], 10);
+              if (n >= 1 && n <= 25) blockers.push(n);
+            }
+
+            if (blockers.length === 0) {
+              core.info('No blockers in PR title');
+              return;
+            }
+
+            const hasCloses = /(?:close|closes|fix|fixes|resolve|resolves)\s+#\d+/i.test(body);
+            const marker = '<!-- blocker-link-hint -->';
+            if (hasCloses) {
+              core.info('PR body already has Closes/Fixes #NN');
+              return;
+            }
+
+            const lines = blockers.map((n) => {
+              const issue = base + n;
+              const note =
+                n === 13
+                  ? ' *(B13: auto-close только с `Closes #44` в теле PR)*'
+                  : ' *(закроется автоматически при merge)*';
+              return `- **B${n}** → [#${issue}](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${issue})${note}`;
+            });
+
+            const comment = [
+              marker,
+              '### 🔗 Blocker issues',
+              '',
+              'В заголовке PR указаны блокеры:',
+              ...lines,
+              '',
+              'При **merge** связанные issue закроются workflow [close-blockers](https://github.com/' +
+                context.repo.owner +
+                '/' +
+                context.repo.repo +
+                '/actions/workflows/close-blockers.yml).',
+              'Можно явно добавить в описание PR: `Closes #37`.',
+              '',
+              'См. [docs/development.md](https://github.com/' +
+                context.repo.owner +
+                '/' +
+                context.repo.repo +
+                '/blob/main/docs/development.md#issue-automation).',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: comment,
+              });
+              core.info('Updated blocker hint comment');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: comment,
+              });
+              core.info('Posted blocker hint comment');
+            }

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -5,6 +5,8 @@
 | GitHub | Скрипт |
 |--------|--------|
 | Issues [#32–#56](https://github.com/onixus/bsdm-proxy/issues?q=is%3Aissue+in%3Atitle+B) | `./scripts/create-blocker-issues.sh` |
+| Закрыть блокер вручную | `./scripts/close-blocker-issue.sh <id> [pr]` |
+| Auto-close при merge PR | [.github/workflows/close-blockers.yml](../.github/workflows/close-blockers.yml) |
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -172,12 +172,43 @@ cargo test -p bsdm-proxy-e2e --test e2e e2e_mitm_https_with_self_signed_ca -- --
 
 См. [architecture.md](architecture.md).
 
+## Issue automation
+
+При merge PR связанные GitHub issue закрываются автоматически:
+
+| Способ | Пример | Поведение |
+|--------|--------|-----------|
+| Блокер в **заголовке** PR | `feat(proxy): rate limit (B6)` | Закрывает #37 |
+| **`Closes #NN`** в теле PR | `Closes #37` | Закрывает #37 (стандарт GitHub + workflow) |
+| **workflow_dispatch** | Actions → Close blocker issues | Ручное закрытие / backfill |
+| **Скрипт** | `./scripts/close-blocker-issue.sh 6 65` | Локально через `gh` |
+
+**Маппинг:** B*n* → issue #*(31+n)* (B1→#32 … B25→#56).
+
+**Исключение B13 (#44):** auto-close только при `Closes #44` в теле PR (полная реализация NTLM). PR с docs-only и `(B13)` в заголовке **не** закрывают #44.
+
+Шаблон PR: [.github/pull_request_template.md](../.github/pull_request_template.md).
+
+### Backfill (уже смерженные PR без Closes)
+
+```bash
+# Через GitHub Actions UI: Close blocker issues → Run workflow
+#   blocker_id: 6, pr_number: 65
+#   blocker_id: 7, pr_number: 67
+
+# Или локально:
+./scripts/close-blocker-issue.sh 6 65   # B6 → #37
+./scripts/close-blocker-issue.sh 7 67   # B7 → #38
+```
+
 ## CI
 
 | Workflow | Триггер | Шаги |
 |----------|---------|------|
 | [rust.yml](../.github/workflows/rust.yml) | push/PR → main | fmt, clippy, build, test, cargo-audit |
 | [e2e.yml](../.github/workflows/e2e.yml) | push/PR → main | smoke + e2e |
+| [close-blockers.yml](../.github/workflows/close-blockers.yml) | PR merged / manual | auto-close B1–B25 issues |
+| [pr-blocker-hint.yml](../.github/workflows/pr-blocker-hint.yml) | PR opened/edited | комментарий со ссылками на issue |
 
 ## Локальный запуск proxy
 

--- a/scripts/close-blocker-issue.sh
+++ b/scripts/close-blocker-issue.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Close a single architecture blocker issue B1–B25 (GitHub #32–#56).
+# Requires: gh auth with issues write scope
+#
+# Usage:
+#   ./scripts/close-blocker-issue.sh 6              # close B6 → #37
+#   ./scripts/close-blocker-issue.sh 6 65           # with PR reference
+#   ./scripts/close-blocker-issue.sh --dry-run 6
+set -euo pipefail
+
+REPO="${GITHUB_REPO:-onixus/bsdm-proxy}"
+DRY_RUN=false
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *)
+      if [[ -z "${BLOCKER_ID:-}" ]]; then
+        BLOCKER_ID="$1"
+      elif [[ -z "$PR_NUM" ]]; then
+        PR_NUM="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${BLOCKER_ID:-}" ]]; then
+  echo "Usage: $0 [--dry-run] <blocker_id 1-25> [pr_number]" >&2
+  exit 1
+fi
+
+if ! [[ "$BLOCKER_ID" =~ ^[0-9]+$ ]] || (( BLOCKER_ID < 1 || BLOCKER_ID > 25 )); then
+  echo "blocker_id must be 1–25 (got: $BLOCKER_ID)" >&2
+  exit 1
+fi
+
+ISSUE_NUM=$((31 + BLOCKER_ID))
+PR_REF=""
+if [[ -n "$PR_NUM" ]]; then
+  PR_REF="Implemented in PR #${PR_NUM} (merged)."
+fi
+
+COMMENT="$(cat <<EOF
+${PR_REF}
+Blocker **B${BLOCKER_ID}** marked completed.
+
+Closed via \`scripts/close-blocker-issue.sh\`.
+See [docs/BLOCKERS.md](docs/BLOCKERS.md).
+EOF
+)"
+
+if $DRY_RUN; then
+  echo "[dry-run] Would close #${ISSUE_NUM} (B${BLOCKER_ID})"
+  echo "$COMMENT"
+  exit 0
+fi
+
+STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
+if [[ "$STATE" == "CLOSED" ]]; then
+  echo "Issue #${ISSUE_NUM} (B${BLOCKER_ID}) already closed"
+  exit 0
+fi
+
+gh issue close "$ISSUE_NUM" --repo "$REPO" --comment "$COMMENT"
+echo "Closed #${ISSUE_NUM} (B${BLOCKER_ID})"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Automates linking and closing architecture blocker issues (B1–B25 / #32–#56) when PRs merge.

## What's added

| Component | Purpose |
|-----------|---------|
| `.github/pull_request_template.md` | Checklist: `Closes #NN` or `(Bn)` in title |
| `close-blockers.yml` | On PR merge → close matching issues + comment |
| `close-blockers.yml` (`workflow_dispatch`) | Manual backfill (e.g. close #37 after PR #65) |
| `pr-blocker-hint.yml` | Bot comment on PR with issue links when title has `(B6)` |
| `scripts/close-blocker-issue.sh` | Local `gh` helper |

## Rules

- **B*n*** in PR title/body → closes issue **#(31+n)** on merge (B6 → #37)
- **`Closes #NN`** in PR body → also handled (GitHub native + workflow comment)
- **B13 (#44)** — skipped unless `Closes #44` (docs-only PRs must not close NTLM impl issue)

## After merge — backfill open issues

Run **Actions → Close blocker issues → Run workflow**:

| blocker_id | pr_number | Issue |
|------------|-----------|-------|
| `6` | `65` | #37 B6 rate limiting |
| `7` | `67` | #38 B7 refactor |

Or locally: `./scripts/close-blocker-issue.sh 6 65`

Docs: [docs/development.md#issue-automation](docs/development.md#issue-automation)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

