### PR TITLE
feat(metrics): hierarchy Prometheus metrics (M2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 # Proxy runtime
 # ============================================================
 FROM alpine:3.21 AS proxy
+# wget: used by docker-compose healthchecks (Alpine has no curl by default)
 RUN apk add --no-cache \
     ca-certificates \
     libgcc \

--- a/docker-compose.hierarchy.yml
+++ b/docker-compose.hierarchy.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -73,7 +73,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -114,7 +114,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     stdin_open: true
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -52,7 +52,7 @@
 | B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
 | B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ❌ |
 | B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ❌ |
-| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ❌ |
+| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |
 | B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,7 +231,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | **B21** | Feature flags не в main | `Cargo.toml` features |
 | **B22** | Нет negative caching / refresh | `main.rs` |
 | **B23** | HTTP/1 only upstream | `build_upstream_https_connector` |
-| **B24** | Healthcheck curl vs wget | `docker-compose.yml`, `Dockerfile` |
+| **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
 | **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,7 @@ TCP accept
 - Вся логика в **binary crate** (`main.rs` ~1300 строк) — `ProxyService` не в `lib.rs` (B7)
 - Categorization с online API на **критическом пути** каждого запроса
 - ACL под глобальным `Mutex` — serializes concurrent ACL checks
-- Hierarchy metrics (`bsdm_proxy_hierarchy_*`) ещё не экспортируются в Prometheus
+- Hierarchy metrics (`bsdm_proxy_hierarchy_*`) экспортируются в Prometheus при `HIERARCHY_ENABLED=true`
 - Нет `docker-compose.hierarchy.yml` для multi-instance E2E
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,9 @@ docker compose -f docker-compose.test.yml up -d --build
 ./scripts/run-smoke-tests.sh --external
 ```
 
+> Proxy Alpine image includes **wget** (not curl). Healthchecks in compose files use  
+> `wget -q -O- http://127.0.0.1:9090/health | grep -q ok`.
+
 Покрытие: `/health`, `/ready`, `/metrics`, HTTP forward через прокси.
 
 ### E2E-тесты

--- a/docs/hierarchical-caching.md
+++ b/docs/hierarchical-caching.md
@@ -256,15 +256,21 @@ pub enum IcpOpcode {
 
 ## Metrics
 
-New Prometheus metrics:
+Prometheus metrics (v0.2.x / M2):
 
 ```
-bsdm_proxy_hierarchy_requests_total{peer, result}
-bsdm_proxy_hierarchy_icp_queries_total{peer, result}
-bsdm_proxy_hierarchy_peer_health{peer, type}
-bsdm_proxy_hierarchy_peer_rtt_ms{peer}
-bsdm_proxy_hierarchy_selection_duration_seconds
-bsdm_proxy_hierarchy_fetch_duration_seconds{peer, cache_status}
+bsdm_proxy_hierarchy_resolutions_total{result}   # sibling_hit, parent_hit, origin_required
+bsdm_proxy_hierarchy_peer_requests_total{peer_type, outcome}  # parent|sibling × hit|miss|error
+bsdm_proxy_hierarchy_icp_queries_total{outcome}  # hit, miss, timeout, error
+bsdm_proxy_hierarchy_lookup_duration_seconds
+```
+
+Example queries:
+
+```promql
+rate(bsdm_proxy_hierarchy_resolutions_total[5m])
+rate(bsdm_proxy_hierarchy_peer_requests_total{outcome="hit"}[5m])
+  / rate(bsdm_proxy_hierarchy_peer_requests_total[5m])
 ```
 
 ## Testing Strategy

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,7 +94,7 @@ gantt
 - [ ] **NTLM auth** — реализация или снятие с roadmap
 - [ ] **Negative caching** coordination
 - [ ] **Cache refresh / revalidate** — Squid-style freshness
-- [ ] Hierarchy Prometheus metrics (`bsdm_proxy_hierarchy_*`)
+- [x] Hierarchy Prometheus metrics (`bsdm_proxy_hierarchy_*`)
 
 **Критерий завершения M2:** 3-tier cache hierarchy в docker-compose, hit rate sibling/parent измеряется, Redis L2 работает.
 

--- a/proxy/src/hierarchy.rs
+++ b/proxy/src/hierarchy.rs
@@ -4,6 +4,7 @@
 //! Local cache → Siblings (ICP) → Parents → Origin
 
 use crate::icp::{IcpClient, IcpOpcode};
+use crate::metrics::Metrics;
 use crate::peers::{CachePeer, PeerRegistry};
 use crate::selection::SelectionStrategy;
 use std::sync::Arc;
@@ -56,6 +57,7 @@ pub struct HierarchyManager {
     peer_registry: PeerRegistry,
     selection_strategy: Box<dyn SelectionStrategy>,
     icp_client: Option<Arc<IcpClient>>,
+    metrics: Option<Arc<Metrics>>,
 }
 
 impl HierarchyManager {
@@ -69,7 +71,13 @@ impl HierarchyManager {
             peer_registry,
             selection_strategy,
             icp_client: None,
+            metrics: None,
         }
+    }
+
+    pub fn with_metrics(mut self, metrics: Arc<Metrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
     }
 
     /// Initialize ICP client
@@ -106,6 +114,7 @@ impl HierarchyManager {
                 sibling.id,
                 start.elapsed().as_millis()
             );
+            self.record_resolution("sibling_hit", start);
             return HierarchyResult::SiblingHit(sibling);
         }
 
@@ -117,6 +126,7 @@ impl HierarchyManager {
                 parent.id,
                 start.elapsed().as_millis()
             );
+            self.record_resolution("parent_hit", start);
             return HierarchyResult::ParentHit(parent);
         }
 
@@ -126,7 +136,15 @@ impl HierarchyManager {
             url,
             start.elapsed().as_millis()
         );
+        self.record_resolution("origin_required", start);
         HierarchyResult::OriginRequired
+    }
+
+    fn record_resolution(&self, result: &str, start: Instant) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_hierarchy_resolution(result);
+            metrics.observe_hierarchy_lookup(start.elapsed().as_secs_f64());
+        }
     }
 
     /// Query sibling caches via ICP
@@ -165,6 +183,25 @@ impl HierarchyManager {
             .query_peers(&sibling_addrs, url, self.config.icp_timeout)
             .await;
 
+        let responded = results.len();
+        for result in &results {
+            if let Some(metrics) = &self.metrics {
+                let outcome = match result.response {
+                    IcpOpcode::Hit => "hit",
+                    IcpOpcode::Miss => "miss",
+                    IcpOpcode::Error | IcpOpcode::Denied => "error",
+                    _ => "error",
+                };
+                metrics.record_hierarchy_icp_query(outcome);
+            }
+        }
+        let unanswered = sibling_addrs.len().saturating_sub(responded);
+        if let Some(metrics) = &self.metrics {
+            for _ in 0..unanswered {
+                metrics.record_hierarchy_icp_query("timeout");
+            }
+        }
+
         // Find first HIT
         for result in results {
             if result.response == IcpOpcode::Hit {
@@ -198,18 +235,27 @@ impl HierarchyManager {
 
     /// Record successful fetch from peer
     pub async fn record_peer_hit(&self, peer: &CachePeer, bytes: u64) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_hierarchy_peer_request(&peer.config.peer_type.to_string(), "hit");
+        }
         peer.stats.record_request().await;
         peer.stats.record_hit(bytes).await;
     }
 
     /// Record miss from peer
     pub async fn record_peer_miss(&self, peer: &CachePeer) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_hierarchy_peer_request(&peer.config.peer_type.to_string(), "miss");
+        }
         peer.stats.record_request().await;
         peer.stats.record_miss().await;
     }
 
     /// Record error from peer
     pub async fn record_peer_error(&self, peer: &CachePeer) {
+        if let Some(metrics) = &self.metrics {
+            metrics.record_hierarchy_peer_request(&peer.config.peer_type.to_string(), "error");
+        }
         peer.stats.record_request().await;
         peer.stats.record_error().await;
 

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -94,7 +94,8 @@ pub async fn build_hierarchy_manager(
         std::env::var("CACHE_SELECTION_STRATEGY").unwrap_or_else(|_| "round-robin".to_string());
     let strategy = parse_strategy(&strategy_name);
 
-    let mut manager = HierarchyManager::new(config.clone(), registry, strategy).with_metrics(metrics);
+    let mut manager =
+        HierarchyManager::new(config.clone(), registry, strategy).with_metrics(metrics);
 
     let client_bind = std::env::var("ICP_CLIENT_BIND").unwrap_or_else(|_| "0.0.0.0:0".to_string());
     manager.init_icp(&client_bind).await?;

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -1,6 +1,7 @@
 //! Load hierarchical caching configuration from environment variables.
 
 use crate::hierarchy::{HierarchyConfig, HierarchyManager};
+use crate::metrics::Metrics;
 use crate::peers::{PeerConfig, PeerRegistry, PeerType};
 use crate::selection::parse_strategy;
 use std::sync::Arc;
@@ -65,6 +66,7 @@ pub fn load_hierarchy_config() -> HierarchyConfig {
 /// Build hierarchy manager from environment. Returns `None` when disabled.
 pub async fn build_hierarchy_manager(
     config: &HierarchyConfig,
+    metrics: Arc<Metrics>,
 ) -> Result<Option<Arc<HierarchyManager>>, Box<dyn std::error::Error + Send + Sync>> {
     if !config.enabled {
         return Ok(None);
@@ -92,7 +94,7 @@ pub async fn build_hierarchy_manager(
         std::env::var("CACHE_SELECTION_STRATEGY").unwrap_or_else(|_| "round-robin".to_string());
     let strategy = parse_strategy(&strategy_name);
 
-    let mut manager = HierarchyManager::new(config.clone(), registry, strategy);
+    let mut manager = HierarchyManager::new(config.clone(), registry, strategy).with_metrics(metrics);
 
     let client_bind = std::env::var("ICP_CLIENT_BIND").unwrap_or_else(|_| "0.0.0.0:0".to_string());
     manager.init_icp(&client_bind).await?;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let hierarchy_config = load_hierarchy_config();
-    let hierarchy = build_hierarchy_manager(&hierarchy_config)
+    let hierarchy = build_hierarchy_manager(&hierarchy_config, metrics.clone())
         .await
         .map_err(|e| -> Box<dyn std::error::Error> { e })?;
 

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -54,6 +54,12 @@ pub struct Metrics {
 
     // Rate limit metrics
     pub rate_limit_rejected_total: CounterVec,
+
+    // Hierarchy metrics (M2)
+    pub hierarchy_resolutions_total: CounterVec,
+    pub hierarchy_peer_requests_total: CounterVec,
+    pub hierarchy_icp_queries_total: CounterVec,
+    pub hierarchy_lookup_duration_seconds: Histogram,
 }
 
 impl Metrics {
@@ -237,6 +243,42 @@ impl Metrics {
         )?;
         registry.register(Box::new(rate_limit_rejected_total.clone()))?;
 
+        let hierarchy_resolutions_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_hierarchy_resolutions_total",
+                "Hierarchy source resolution outcomes",
+            ),
+            &["result"],
+        )?;
+        registry.register(Box::new(hierarchy_resolutions_total.clone()))?;
+
+        let hierarchy_peer_requests_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_hierarchy_peer_requests_total",
+                "HTTP fetches to parent/sibling cache peers",
+            ),
+            &["peer_type", "outcome"],
+        )?;
+        registry.register(Box::new(hierarchy_peer_requests_total.clone()))?;
+
+        let hierarchy_icp_queries_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_hierarchy_icp_queries_total",
+                "ICP UDP queries to sibling caches",
+            ),
+            &["outcome"],
+        )?;
+        registry.register(Box::new(hierarchy_icp_queries_total.clone()))?;
+
+        let hierarchy_lookup_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "bsdm_proxy_hierarchy_lookup_duration_seconds",
+                "Time to resolve hierarchy source (ICP + parent selection)",
+            )
+            .buckets(vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0]),
+        )?;
+        registry.register(Box::new(hierarchy_lookup_duration_seconds.clone()))?;
+
         Ok(Metrics {
             registry,
             requests_total,
@@ -263,7 +305,34 @@ impl Metrics {
             acl_rules_matched_total,
             acl_eval_duration_seconds,
             rate_limit_rejected_total,
+            hierarchy_resolutions_total,
+            hierarchy_peer_requests_total,
+            hierarchy_icp_queries_total,
+            hierarchy_lookup_duration_seconds,
         })
+    }
+
+    pub fn record_hierarchy_resolution(&self, result: &str) {
+        self.hierarchy_resolutions_total
+            .with_label_values(&[result])
+            .inc();
+    }
+
+    pub fn record_hierarchy_peer_request(&self, peer_type: &str, outcome: &str) {
+        self.hierarchy_peer_requests_total
+            .with_label_values(&[peer_type, outcome])
+            .inc();
+    }
+
+    pub fn record_hierarchy_icp_query(&self, outcome: &str) {
+        self.hierarchy_icp_queries_total
+            .with_label_values(&[outcome])
+            .inc();
+    }
+
+    pub fn observe_hierarchy_lookup(&self, duration_secs: f64) {
+        self.hierarchy_lookup_duration_seconds
+            .observe(duration_secs);
     }
 
     /// Export metrics in Prometheus text format
@@ -292,6 +361,24 @@ impl Metrics {
 impl Default for Metrics {
     fn default() -> Self {
         Self::new().expect("Failed to create metrics")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hierarchy_metrics_exported() {
+        let m = Metrics::new().unwrap();
+        m.record_hierarchy_resolution("parent_hit");
+        m.record_hierarchy_icp_query("hit");
+        m.record_hierarchy_peer_request("parent", "hit");
+        let out = String::from_utf8(m.export().unwrap()).unwrap();
+        assert!(out.contains("bsdm_proxy_hierarchy_resolutions_total"));
+        assert!(out.contains("bsdm_proxy_hierarchy_icp_queries_total"));
+        assert!(out.contains("bsdm_proxy_hierarchy_peer_requests_total"));
+        assert!(out.contains("parent_hit"));
     }
 }
 

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -364,24 +364,6 @@ impl Default for Metrics {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn hierarchy_metrics_exported() {
-        let m = Metrics::new().unwrap();
-        m.record_hierarchy_resolution("parent_hit");
-        m.record_hierarchy_icp_query("hit");
-        m.record_hierarchy_peer_request("parent", "hit");
-        let out = String::from_utf8(m.export().unwrap()).unwrap();
-        assert!(out.contains("bsdm_proxy_hierarchy_resolutions_total"));
-        assert!(out.contains("bsdm_proxy_hierarchy_icp_queries_total"));
-        assert!(out.contains("bsdm_proxy_hierarchy_peer_requests_total"));
-        assert!(out.contains("parent_hit"));
-    }
-}
-
 /// Helper to record request metrics with RAII pattern
 pub struct RequestMetricsGuard {
     metrics: Arc<Metrics>,
@@ -420,5 +402,23 @@ impl RequestMetricsGuard {
         self.metrics
             .response_size_bytes
             .observe(response_size as f64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hierarchy_metrics_exported() {
+        let m = Metrics::new().unwrap();
+        m.record_hierarchy_resolution("parent_hit");
+        m.record_hierarchy_icp_query("hit");
+        m.record_hierarchy_peer_request("parent", "hit");
+        let out = String::from_utf8(m.export().unwrap()).unwrap();
+        assert!(out.contains("bsdm_proxy_hierarchy_resolutions_total"));
+        assert!(out.contains("bsdm_proxy_hierarchy_icp_queries_total"));
+        assert!(out.contains("bsdm_proxy_hierarchy_peer_requests_total"));
+        assert!(out.contains("parent_hit"));
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First M2 deliverable: Prometheus metrics for cache hierarchy (parent/sibling/ICP).

## Metrics

| Metric | Labels | When incremented |
|--------|--------|------------------|
| `bsdm_proxy_hierarchy_resolutions_total` | `result` | `resolve_source`: sibling_hit, parent_hit, origin_required |
| `bsdm_proxy_hierarchy_peer_requests_total` | `peer_type`, `outcome` | HTTP fetch to peer: hit, miss, error |
| `bsdm_proxy_hierarchy_icp_queries_total` | `outcome` | ICP UDP: hit, miss, timeout, error |
| `bsdm_proxy_hierarchy_lookup_duration_seconds` | — | ICP + parent selection latency |

Active when `HIERARCHY_ENABLED=true`.

## Testing

- `cargo test -p bsdm-proxy` — 58 tests
- `cargo clippy -p bsdm-proxy -- -D warnings` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

