### PR TITLE
fix(docker): proxy healthcheck wget instead of curl (B24)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 # Proxy runtime
 # ============================================================
 FROM alpine:3.21 AS proxy
+# wget: used by docker-compose healthchecks (Alpine has no curl by default)
 RUN apk add --no-cache \
     ca-certificates \
     libgcc \

--- a/docker-compose.hierarchy.yml
+++ b/docker-compose.hierarchy.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -73,7 +73,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -114,7 +114,7 @@ services:
     networks:
       - hierarchy-net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
     stdin_open: true
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9090/health || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -52,7 +52,7 @@
 | B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
 | B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ❌ |
 | B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ❌ |
-| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ❌ |
+| B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |
 | B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,7 +231,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | **B21** | Feature flags не в main | `Cargo.toml` features |
 | **B22** | Нет negative caching / refresh | `main.rs` |
 | **B23** | HTTP/1 only upstream | `build_upstream_https_connector` |
-| **B24** | Healthcheck curl vs wget | `docker-compose.yml`, `Dockerfile` |
+| **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
 | **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,6 +98,9 @@ docker compose -f docker-compose.test.yml up -d --build
 ./scripts/run-smoke-tests.sh --external
 ```
 
+> Proxy Alpine image includes **wget** (not curl). Healthchecks in compose files use  
+> `wget -q -O- http://127.0.0.1:9090/health | grep -q ok`.
+
 Покрытие: `/health`, `/ready`, `/metrics`, HTTP forward через прокси.
 
 ### E2E-тесты


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **B24** — proxy Docker healthchecks failed because Alpine runtime image has `wget` only, but compose files used `curl`.

## Changes

- `docker-compose.yml` — proxy healthcheck → `wget` (same as `docker-compose.test.yml`)
- `docker-compose.hierarchy.yml` — all 3 proxy tiers updated
- `Dockerfile` — comment documenting wget for healthchecks
- Docs updated

Closes #55
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

