### PR TITLE
feat(acl): TimeWindow and group rules (B14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ version = "0.2.3-test"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "hex",
  "http-body-util",
  "hyper",

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -32,7 +32,7 @@
 | B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ❌ |
 | B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ❌ |
 | B13 | [#44](https://github.com/onixus/bsdm-proxy/issues/44) | Implement NTLM or remove from docs | ✅ docs |
-| B14 | [#45](https://github.com/onixus/bsdm-proxy/issues/45) | ACL TimeWindow + group rules | ❌ |
+| B14 | [#45](https://github.com/onixus/bsdm-proxy/issues/45) | ACL TimeWindow + group rules | ✅ |
 
 ## Medium — M3 / M4 / M5
 

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -106,6 +106,8 @@ Flexible access control system for BSDM-Proxy with multiple rule types and prior
 }
 ```
 
+**Time format:** `HH:MM` (24-hour, local server time via `chrono::Local`). Overnight windows supported (e.g. `22:00`–`06:00`). Combine with domain/category rules via separate rule entries and priority.
+
 ### 6. User/Group Rules
 
 ```json
@@ -123,6 +125,8 @@ Flexible access control system for BSDM-Proxy with multiple rule types and prior
   }
 }
 ```
+
+**Groups:** LDAP `memberOf` DNs are matched by full DN or `cn=` value (e.g. rule `"admins"` matches `cn=admins,ou=groups,dc=corp,dc=local`). User and group in the same rule use OR logic.
 
 ### 7. IP Range Rules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,7 +211,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | **B11** | Schema drift: `categories` не в indexer | `cache-indexer/src/main.rs` | M3 |
 | **B12** | Нет shared event crate | `proxy`, `cache-indexer` | M3 |
 | **B13** | NTLM — не реализован (документация исправлена) | `auth.rs` | M2 impl |
-| **B14** | ACL: TimeWindow TODO, groups ignored | `acl.rs:224-236` | M2 |
+| **B14** | ACL TimeWindow + group rules — реализовано | `acl.rs` | M2 ✅ |
 
 ### 🟡 Medium — M4 Threat / M5 ML
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,8 +88,8 @@ gantt
 - [ ] **HTTP/2 upstream client**
 - [ ] **Compression** — Brotli/Zstd для cacheable responses
 - [ ] **ACL completeness**
-  - [ ] TimeWindow rules (сейчас TODO в `acl.rs`)
-  - [ ] Group-based rules (сейчас игнорируются)
+  - [x] TimeWindow rules (`HH:MM`, local time, overnight windows)
+  - [x] Group-based Principal rules (LDAP `memberOf` cn matching)
   - [ ] REST API управления ACL (`/api/acl/*` из docs)
 - [ ] **NTLM auth** — реализация или снятие с roadmap
 - [ ] **Negative caching** coordination

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -38,6 +38,7 @@ hex = "0.4"
 
 # ACL and Categorization
 regex = "1.12"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 reqwest = { version = "0.13", features = ["json", "form"] }
 
 [features]

--- a/proxy/src/acl.rs
+++ b/proxy/src/acl.rs
@@ -8,11 +8,70 @@
 //! - Time-based access control
 //! - User/group-based rules
 
+use chrono::Timelike;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use tracing::{debug, info, warn};
+
+/// Minutes since midnight for time-window matching (0–1439).
+pub(crate) fn minutes_since_midnight(hour: u32, minute: u32) -> u32 {
+    hour * 60 + minute
+}
+
+/// Parse `HH:MM` (24h) into minutes since midnight.
+pub(crate) fn parse_hhmm(value: &str) -> Option<u32> {
+    let (hour, minute) = value.split_once(':')?;
+    let hour: u32 = hour.trim().parse().ok()?;
+    let minute: u32 = minute.trim().parse().ok()?;
+    if hour > 23 || minute > 59 {
+        return None;
+    }
+    Some(minutes_since_midnight(hour, minute))
+}
+
+/// Whether `now` (minutes since midnight) falls in `[start, end]` (supports overnight windows).
+pub(crate) fn time_in_window(start: &str, end: &str, now: u32) -> bool {
+    let Some(start_min) = parse_hhmm(start) else {
+        warn!("Invalid TimeWindow start: {}", start);
+        return false;
+    };
+    let Some(end_min) = parse_hhmm(end) else {
+        warn!("Invalid TimeWindow end: {}", end);
+        return false;
+    };
+
+    if start_min <= end_min {
+        now >= start_min && now <= end_min
+    } else {
+        now >= start_min || now <= end_min
+    }
+}
+
+fn local_minutes_now() -> u32 {
+    let now = chrono::Local::now();
+    minutes_since_midnight(now.hour(), now.minute())
+}
+
+/// Match LDAP `memberOf` DN or plain group name against rule group.
+pub(crate) fn group_matches(member_group: &str, rule_group: &str) -> bool {
+    if member_group.eq_ignore_ascii_case(rule_group) {
+        return true;
+    }
+    for part in member_group.split(',') {
+        let part = part.trim();
+        if let Some(cn) = part
+            .strip_prefix("cn=")
+            .or_else(|| part.strip_prefix("CN="))
+        {
+            if cn.eq_ignore_ascii_case(rule_group) {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 /// ACL action to take
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -153,11 +212,12 @@ impl AclEngine {
         domain: &str,
         categories: &[&str],
         user: Option<&str>,
+        groups: &[&str],
         client_ip: Option<IpAddr>,
     ) -> AclDecision {
         debug!(
-            "ACL check: url={}, domain={}, categories={:?}, user={:?}",
-            url, domain, categories, user
+            "ACL check: url={}, domain={}, categories={:?}, user={:?}, groups={:?}",
+            url, domain, categories, user, groups
         );
 
         // Check each rule in priority order
@@ -169,7 +229,7 @@ impl AclEngine {
             .collect();
 
         for rule in rules {
-            if self.matches_rule(&rule, url, domain, categories, user, client_ip) {
+            if self.matches_rule(&rule, url, domain, categories, user, groups, client_ip) {
                 debug!("Matched ACL rule: {} ({})", rule.name, rule.id);
 
                 return match rule.action {
@@ -200,6 +260,7 @@ impl AclEngine {
     }
 
     /// Check if rule matches
+    #[allow(clippy::too_many_arguments)]
     fn matches_rule(
         &mut self,
         rule: &AclRule,
@@ -207,6 +268,7 @@ impl AclEngine {
         domain: &str,
         categories: &[&str],
         user: Option<&str>,
+        groups: &[&str],
         client_ip: Option<IpAddr>,
     ) -> bool {
         match &rule.rule_type {
@@ -221,20 +283,33 @@ impl AclEngine {
                     false
                 }
             }
-            AclRuleType::TimeWindow { start: _, end: _ } => {
-                // TODO: Implement time-based matching
-                true
+            AclRuleType::TimeWindow { start, end } => {
+                time_in_window(start, end, local_minutes_now())
             }
             AclRuleType::Principal {
                 user: rule_user,
-                group: _,
-            } => {
-                if let Some(u) = user {
-                    rule_user.as_ref().map(|ru| ru == u).unwrap_or(false)
-                } else {
-                    false
-                }
-            }
+                group: rule_group,
+            } => Self::match_principal(rule_user, rule_group, user, groups),
+        }
+    }
+
+    fn match_principal(
+        rule_user: &Option<String>,
+        rule_group: &Option<String>,
+        user: Option<&str>,
+        groups: &[&str],
+    ) -> bool {
+        let user_match = rule_user.as_ref().zip(user).is_some_and(|(ru, u)| ru == u);
+
+        let group_match = rule_group
+            .as_ref()
+            .is_some_and(|rg| groups.iter().any(|g| group_matches(g, rg)));
+
+        match (rule_user.is_some(), rule_group.is_some()) {
+            (true, true) => user_match || group_match,
+            (true, false) => user_match,
+            (false, true) => group_match,
+            (false, false) => false,
         }
     }
 
@@ -327,6 +402,7 @@ mod tests {
             "example.com",
             &[],
             None,
+            &[],
             None,
         );
 
@@ -348,8 +424,14 @@ mod tests {
             comment: None,
         });
 
-        let decision =
-            engine.check_access("https://example.com", "example.com", &["adult"], None, None);
+        let decision = engine.check_access(
+            "https://example.com",
+            "example.com",
+            &["adult"],
+            None,
+            &[],
+            None,
+        );
 
         assert_eq!(decision.action, AclAction::Deny);
     }
@@ -388,10 +470,126 @@ mod tests {
             "admin.example.com",
             &[],
             None,
+            &[],
             None,
         );
 
         assert_eq!(decision.action, AclAction::Deny);
         assert_eq!(decision.rule_id.unwrap(), "high");
+    }
+
+    #[test]
+    fn test_time_window_matching() {
+        assert!(time_in_window(
+            "09:00",
+            "17:00",
+            minutes_since_midnight(12, 0)
+        ));
+        assert!(!time_in_window(
+            "09:00",
+            "17:00",
+            minutes_since_midnight(8, 59)
+        ));
+        assert!(time_in_window(
+            "09:00",
+            "17:00",
+            minutes_since_midnight(17, 0)
+        ));
+        assert!(time_in_window(
+            "22:00",
+            "06:00",
+            minutes_since_midnight(23, 0)
+        ));
+        assert!(time_in_window(
+            "22:00",
+            "06:00",
+            minutes_since_midnight(5, 30)
+        ));
+        assert!(!time_in_window(
+            "22:00",
+            "06:00",
+            minutes_since_midnight(12, 0)
+        ));
+    }
+
+    #[test]
+    fn test_group_matching_ldap_cn() {
+        assert!(group_matches(
+            "cn=admins,ou=groups,dc=example,dc=com",
+            "admins"
+        ));
+        assert!(group_matches("admins", "admins"));
+        assert!(!group_matches(
+            "cn=users,ou=groups,dc=example,dc=com",
+            "admins"
+        ));
+    }
+
+    #[test]
+    fn test_principal_group_rule() {
+        let mut engine = AclEngine::new(AclAction::Deny);
+
+        engine.add_rule(AclRule {
+            id: "admins-allow".to_string(),
+            name: "Allow admins".to_string(),
+            enabled: true,
+            priority: 200,
+            action: AclAction::Allow,
+            rule_type: AclRuleType::Principal {
+                user: None,
+                group: Some("admins".to_string()),
+            },
+            redirect_url: None,
+            comment: None,
+        });
+
+        let decision = engine.check_access(
+            "https://example.com",
+            "example.com",
+            &[],
+            Some("alice"),
+            &["cn=admins,ou=groups,dc=corp,dc=local"],
+            None,
+        );
+        assert_eq!(decision.action, AclAction::Allow);
+
+        let decision = engine.check_access(
+            "https://example.com",
+            "example.com",
+            &[],
+            Some("bob"),
+            &["cn=users,ou=groups,dc=corp,dc=local"],
+            None,
+        );
+        assert_eq!(decision.action, AclAction::Deny);
+    }
+
+    #[test]
+    fn test_principal_user_rule() {
+        let mut engine = AclEngine::new(AclAction::Deny);
+
+        engine.add_rule(AclRule {
+            id: "alice-allow".to_string(),
+            name: "Allow alice".to_string(),
+            enabled: true,
+            priority: 100,
+            action: AclAction::Allow,
+            rule_type: AclRuleType::Principal {
+                user: Some("alice".to_string()),
+                group: None,
+            },
+            redirect_url: None,
+            comment: None,
+        });
+
+        let decision = engine.check_access(
+            "https://example.com",
+            "example.com",
+            &[],
+            Some("alice"),
+            &[],
+            None,
+        );
+        assert_eq!(decision.action, AclAction::Allow);
     }
 }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -121,6 +121,7 @@ impl ProxyService {
         url: &str,
         domain: &str,
         username: Option<&str>,
+        groups: &[&str],
         client_ip: &str,
     ) -> (Option<AclDecision>, Vec<String>) {
         let eval_start = Instant::now();
@@ -148,6 +149,7 @@ impl ProxyService {
                 domain,
                 &category_refs,
                 username,
+                groups,
                 Self::parse_client_ip(client_ip),
             )
         };
@@ -377,8 +379,13 @@ impl ProxyService {
 
         let domain = Self::extract_domain(&url);
 
+        let user_groups: Vec<&str> = proxy_user
+            .as_deref()
+            .map(|u| u.groups.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+
         let (policy_decision, categories) = self
-            .check_policy(&url, &domain, username.as_deref(), &client_ip)
+            .check_policy(&url, &domain, username.as_deref(), &user_groups, &client_ip)
             .await;
         if let Some(decision) = policy_decision {
             let response = Self::policy_response(&decision);

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -384,6 +384,10 @@ pub async fn handle_connection(
                 };
 
                 let policy_username = proxy_user.as_deref().map(|u| u.username.as_str());
+                let policy_groups: Vec<&str> = proxy_user
+                    .as_deref()
+                    .map(|u| u.groups.iter().map(String::as_str).collect())
+                    .unwrap_or_default();
                 if let Some(resp) = service.check_rate_limit(&client_ip, policy_username) {
                     return Ok::<_, Infallible>(resp);
                 }
@@ -391,7 +395,13 @@ pub async fn handle_connection(
                 let connect_url = format!("https://{}", authority);
                 let connect_domain = parse_authority(&authority).0;
                 let (policy_decision, _) = service
-                    .check_policy(&connect_url, &connect_domain, policy_username, &client_ip)
+                    .check_policy(
+                        &connect_url,
+                        &connect_domain,
+                        policy_username,
+                        &policy_groups,
+                        &client_ip,
+                    )
                     .await;
                 if let Some(decision) = policy_decision {
                     return Ok::<_, Infallible>(ProxyService::policy_response(&decision));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **B14** — ACL `TimeWindow` and group-based `Principal` rules.

## Changes

### TimeWindow
- Format `HH:MM` (24h), server local time (`chrono::Local`)
- Inclusive range; overnight windows (`22:00`–`06:00`)
- Invalid times → rule does not match (warn in logs)

### Principal / groups
- `group` field now matches LDAP `memberOf` (full DN or `cn=` value)
- `user` + `group` in same rule → OR logic
- Groups passed from `UserInfo` in `handle_request` and CONNECT path

### Tests
- `test_time_window_matching`, `test_group_matching_ldap_cn`
- `test_principal_group_rule`, `test_principal_user_rule`

## Testing

- `cargo test -p bsdm-proxy` — 62 tests ✅
- `cargo test -p bsdm-proxy-e2e` — 15 tests ✅
- `cargo clippy -p bsdm-proxy -- -D warnings` ✅

Closes #45
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

