### PR TITLE
feat(cache): Redis L2 shared HTTP cache (M2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +203,7 @@ dependencies = [
  "rand",
  "rcgen",
  "rdkafka",
+ "redis",
  "regex",
  "reqwest",
  "rustls",
@@ -298,7 +317,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -473,6 +496,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -851,7 +880,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -1021,6 +1050,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1589,7 +1627,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1627,7 +1665,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1724,6 +1762,32 @@ dependencies = [
  "libz-sys",
  "num_enum",
  "pkg-config",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "backon",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itertools",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2155,6 +2219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2293,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2433,7 +2513,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/README.md
+++ b/README.md
@@ -201,6 +201,21 @@ Token-bucket лимиты на IP и аутентифицированного п
 | `RATE_LIMIT_USER_BURST` | `100` | Burst на пользователя |
 | `RATE_LIMIT_MAX_KEYS` | `10000` | Макс. отслеживаемых ключей |
 
+### Redis L2 cache (опционально)
+
+Распределённый кеш между инстансами прокси. Порядок: **L1 → Redis L2 → hierarchy → origin**.
+
+| Переменная | По умолчанию | Описание |
+|-----------|-------------|----------|
+| `REDIS_L2_ENABLED` | `false` | Включить Redis L2 |
+| `REDIS_URL` | `redis://127.0.0.1:6379` | URL Redis |
+| `REDIS_KEY_PREFIX` | `bsdm:http:` | Префикс ключей (тот же `SHA256(method:url)`) |
+
+Метрики: `bsdm_proxy_cache_l2_hits_total`, `bsdm_proxy_cache_l2_misses_total`, `bsdm_proxy_cache_l2_errors_total`.  
+Ответ при L2 hit: заголовок `x-cache-status: L2-HIT`.
+
+Демо: `docker compose -f docker-compose.redis-l2.yml up -d --build`
+
 ### Иерархический кеш (опционально)
 
 Включается через `HIERARCHY_ENABLED=true`. После промаха L1: ICP-запрос к siblings → выбор parent → HTTP fetch через peer → fallback на origin.
@@ -324,7 +339,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 
 ### M2 — Squid parity (v0.3.x)
 
-- [ ] Redis L2 cache
+- [x] Redis L2 cache
 - [ ] HTTP/2 upstream client
 - [ ] Compression (Brotli/Zstd)
 - [ ] ACL TimeWindow + group rules

--- a/docker-compose.redis-l2.yml
+++ b/docker-compose.redis-l2.yml
@@ -1,0 +1,89 @@
+# Redis L2 cache demo — shared cache between proxy instances
+#
+# Usage:
+#   docker compose -f docker-compose.redis-l2.yml up -d --build
+#   curl -x http://127.0.0.1:1488 http://upstream/get   # MISS
+#   docker compose -f docker-compose.redis-l2.yml restart proxy-a
+#   curl -x http://127.0.0.1:1488 http://upstream/get   # L2-HIT (x-cache-status)
+#
+# Requires two proxies (proxy-a / proxy-b) sharing Redis; only proxy-a is exposed on 1488.
+
+services:
+  redis:
+    image: redis:7.4-alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - l2-net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  upstream:
+    image: kennethreitz/httpbin:latest
+    networks:
+      - l2-net
+
+  proxy-a:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    ports:
+      - "1488:1488"
+      - "9090:9090"
+    environment:
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - CACHE_CAPACITY=100
+      - CACHE_TTL_SECONDS=3600
+      - REDIS_L2_ENABLED=true
+      - REDIS_URL=redis://redis:6379
+      - REDIS_KEY_PREFIX=bsdm:http:
+      - RUST_LOG=info,bsdm_proxy=info
+    depends_on:
+      redis:
+        condition: service_healthy
+      upstream:
+        condition: service_started
+    networks:
+      - l2-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  proxy-b:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    environment:
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - CACHE_CAPACITY=100
+      - CACHE_TTL_SECONDS=3600
+      - REDIS_L2_ENABLED=true
+      - REDIS_URL=redis://redis:6379
+      - REDIS_KEY_PREFIX=bsdm:http:
+      - RUST_LOG=info,bsdm_proxy=info
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - l2-net
+
+networks:
+  l2-net:
+    driver: bridge

--- a/docs/development.md
+++ b/docs/development.md
@@ -133,6 +133,16 @@ docker compose -f docker-compose.hierarchy.yml down
 
 3-tier stack: **child** (1488) → **sibling** (ICP, 1490) / **parent** (1489) → **upstream**.
 
+### Redis L2 demo (Docker)
+
+```bash
+docker compose -f docker-compose.redis-l2.yml up -d --build
+curl -x http://127.0.0.1:1488 http://upstream/get          # MISS
+docker compose -f docker-compose.redis-l2.yml restart proxy-a  # clears L1 only
+curl -x http://127.0.0.1:1488 http://upstream/get          # L2-HIT (x-cache-status)
+docker compose -f docker-compose.redis-l2.yml down
+```
+
 Переменные для тестов MITM:
 - `UPSTREAM_CA_CERT` — proxy доверяет самоподписанному CA upstream
 - `MITM_ENABLED=true`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,7 +84,7 @@ gantt
 ### Задачи
 
 - [ ] **Hierarchy Phase 4** — peer discovery, cache digest, HTCP (опционально mTLS)
-- [ ] **Redis L2 cache** — распределённый кеш между инстансами
+- [x] **Redis L2 cache** — распределённый кеш между инстансами (`docker-compose.redis-l2.yml`)
 - [ ] **HTTP/2 upstream client**
 - [ ] **Compression** — Brotli/Zstd для cacheable responses
 - [ ] **ACL completeness**

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -62,6 +62,11 @@ HIERARCHY_ENABLED=false
 # RATE_LIMIT_USER_BURST=100
 # RATE_LIMIT_MAX_KEYS=10000
 
+# Redis L2 cache (disabled by default)
+# REDIS_L2_ENABLED=true
+# REDIS_URL=redis://127.0.0.1:6379
+# REDIS_KEY_PREFIX=bsdm:http:
+
 # Logging — see docs/logging.md
 RUST_LOG=info,bsdm_proxy=info
 RUST_BACKTRACE=0

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 http-body-util = "0.1"
 quick_cache = "0.7"
+redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 rand = "0.9"
 rcgen = { version = "0.14", features = ["x509-parser"] }
 rdkafka = "0.39"

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -29,6 +29,10 @@ impl CachedResponse {
     }
 
     pub fn to_response(&self) -> Response<Body> {
+        self.to_response_with_cache_status("HIT")
+    }
+
+    pub fn to_response_with_cache_status(&self, cache_status: &str) -> Response<Body> {
         let mut response = Response::new(Body::new(self.body.clone()));
         *response.status_mut() = StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK);
 
@@ -42,7 +46,9 @@ impl CachedResponse {
             }
         }
 
-        headers_mut.insert("x-cache-status", HeaderValue::from_static("HIT"));
+        if let Ok(val) = HeaderValue::from_str(cache_status) {
+            headers_mut.insert("x-cache-status", val);
+        }
         response
     }
 }

--- a/proxy/src/l2_cache.rs
+++ b/proxy/src/l2_cache.rs
@@ -1,0 +1,219 @@
+//! Redis L2 HTTP response cache (shared across proxy instances).
+
+use crate::cache::CachedResponse;
+use crate::metrics::Metrics;
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use bytes::Bytes;
+use redis::aio::ConnectionManager;
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::{debug, warn};
+
+#[derive(Clone, Debug)]
+pub struct L2CacheConfig {
+    pub enabled: bool,
+    pub url: String,
+    pub key_prefix: String,
+}
+
+impl L2CacheConfig {
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("REDIS_L2_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        let url =
+            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+        let key_prefix =
+            std::env::var("REDIS_KEY_PREFIX").unwrap_or_else(|_| "bsdm:http:".to_string());
+
+        Self {
+            enabled,
+            url,
+            key_prefix,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CachedResponseWire {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body_b64: String,
+    cached_at_secs: u64,
+    ttl_secs: u64,
+}
+
+impl CachedResponseWire {
+    fn from_cached(value: &CachedResponse) -> Option<Self> {
+        let cached_at_secs = value.cached_at.duration_since(UNIX_EPOCH).ok()?.as_secs();
+        let headers = value
+            .headers
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Some(Self {
+            status: value.status,
+            headers,
+            body_b64: B64.encode(value.body.as_ref()),
+            cached_at_secs,
+            ttl_secs: value.ttl.as_secs(),
+        })
+    }
+
+    fn into_cached(self) -> Option<CachedResponse> {
+        let body = Bytes::from(B64.decode(self.body_b64).ok()?);
+        let headers: Arc<[(Arc<str>, Arc<str>)]> = self
+            .headers
+            .into_iter()
+            .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
+            .collect();
+        Some(CachedResponse {
+            status: self.status,
+            headers,
+            body,
+            cached_at: UNIX_EPOCH + Duration::from_secs(self.cached_at_secs),
+            ttl: Duration::from_secs(self.ttl_secs),
+        })
+    }
+}
+
+pub fn encode_cached_response(value: &CachedResponse) -> Option<String> {
+    let wire = CachedResponseWire::from_cached(value)?;
+    serde_json::to_string(&wire).ok()
+}
+
+pub fn decode_cached_response(payload: &str) -> Option<CachedResponse> {
+    let wire: CachedResponseWire = serde_json::from_str(payload).ok()?;
+    wire.into_cached()
+}
+
+/// Redis-backed L2 cache. `ConnectionManager` is cheap to clone per operation.
+#[derive(Clone)]
+pub struct RedisL2Cache {
+    conn: ConnectionManager,
+    key_prefix: String,
+    metrics: Arc<Metrics>,
+}
+
+impl RedisL2Cache {
+    pub async fn connect(
+        config: &L2CacheConfig,
+        metrics: Arc<Metrics>,
+    ) -> Result<Self, redis::RedisError> {
+        let client = redis::Client::open(config.url.as_str())?;
+        let conn = ConnectionManager::new(client).await?;
+        Ok(Self {
+            conn,
+            key_prefix: config.key_prefix.clone(),
+            metrics,
+        })
+    }
+
+    fn redis_key(&self, cache_key: &str) -> String {
+        format!("{}{}", self.key_prefix, cache_key)
+    }
+
+    fn remaining_ttl_secs(value: &CachedResponse) -> u64 {
+        value
+            .cached_at
+            .checked_add(value.ttl)
+            .and_then(|expires| expires.duration_since(SystemTime::now()).ok())
+            .map(|d| d.as_secs().max(1))
+            .unwrap_or(1)
+    }
+
+    pub async fn get(&self, cache_key: &str) -> Option<CachedResponse> {
+        let key = self.redis_key(cache_key);
+        let mut conn = self.conn.clone();
+        let payload: Option<String> = match conn.get(&key).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("Redis L2 get failed for {}: {}", key, e);
+                self.metrics.cache_l2_errors_total.inc();
+                return None;
+            }
+        };
+
+        let Some(payload) = payload else {
+            self.metrics.cache_l2_misses_total.inc();
+            return None;
+        };
+
+        let cached = match decode_cached_response(&payload) {
+            Some(v) if !v.is_expired() => v,
+            Some(_) => {
+                debug!("Redis L2 entry expired for {}", key);
+                self.metrics.cache_l2_misses_total.inc();
+                let _ = conn.del::<_, ()>(&key).await;
+                return None;
+            }
+            None => {
+                warn!("Redis L2 corrupt payload for {}", key);
+                self.metrics.cache_l2_errors_total.inc();
+                return None;
+            }
+        };
+
+        self.metrics.cache_l2_hits_total.inc();
+        Some(cached)
+    }
+
+    pub async fn set(&self, cache_key: &str, value: &CachedResponse) {
+        let Some(payload) = encode_cached_response(value) else {
+            self.metrics.cache_l2_errors_total.inc();
+            return;
+        };
+
+        let key = self.redis_key(cache_key);
+        let ttl = Self::remaining_ttl_secs(value);
+        let mut conn = self.conn.clone();
+        if let Err(e) = conn.set_ex::<_, _, ()>(&key, payload, ttl).await {
+            warn!("Redis L2 set failed for {}: {}", key, e);
+            self.metrics.cache_l2_errors_total.inc();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn wire_roundtrip() {
+        let original = CachedResponse {
+            status: 200,
+            headers: Arc::from([(Arc::from("content-type"), Arc::from("text/plain"))]),
+            body: Bytes::from_static(b"hello"),
+            cached_at: SystemTime::now(),
+            ttl: Duration::from_secs(3600),
+        };
+        let json = encode_cached_response(&original).unwrap();
+        let decoded = decode_cached_response(&json).unwrap();
+        assert_eq!(decoded.status, 200);
+        assert_eq!(decoded.body, original.body);
+        assert_eq!(decoded.headers.len(), 1);
+    }
+
+    #[test]
+    fn l2_config_defaults_disabled() {
+        std::env::remove_var("REDIS_L2_ENABLED");
+        let cfg = L2CacheConfig::from_env();
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn remaining_ttl_is_at_least_one() {
+        let cached = CachedResponse {
+            status: 200,
+            headers: Arc::from([]),
+            body: Bytes::new(),
+            cached_at: SystemTime::now(),
+            ttl: Duration::from_secs(60),
+        };
+        assert!(RedisL2Cache::remaining_ttl_secs(&cached) >= 1);
+    }
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hierarchy;
 pub mod hierarchy_config;
 pub mod http_types;
 pub mod icp;
+pub mod l2_cache;
 pub mod metrics;
 pub mod peer_fetch;
 pub mod peers;
@@ -30,6 +31,7 @@ pub use hierarchy_config::{
     build_hierarchy_manager, icp_server_bind_addr, load_hierarchy_config, should_start_icp_server,
 };
 pub use icp::{IcpClient, IcpMessage, IcpOpcode, IcpServer};
+pub use l2_cache::{L2CacheConfig, RedisL2Cache};
 pub use metrics::{Metrics, RequestMetricsGuard};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -5,8 +5,8 @@ use auth_config::load_auth_config;
 use bsdm_proxy::{
     build_hierarchy_manager, handle_connection, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, metrics_server, should_start_icp_server, wait_shutdown_signal,
-    AclAction, AuthManager, CacheConfig, CertCache, IcpServer, Metrics, ProxyPolicy, ProxyService,
-    RateLimitConfig,
+    AclAction, AuthManager, CacheConfig, CertCache, IcpServer, L2CacheConfig, Metrics, ProxyPolicy,
+    ProxyService, RateLimitConfig, RedisL2Cache,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -63,6 +63,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
     let cache_config = CacheConfig::from_env();
 
+    let l2_config = L2CacheConfig::from_env();
+    let l2_cache = if l2_config.enabled {
+        match RedisL2Cache::connect(&l2_config, metrics.clone()).await {
+            Ok(cache) => {
+                info!(
+                    "Redis L2 cache enabled (url={}, prefix={})",
+                    l2_config.url, l2_config.key_prefix
+                );
+                Some(cache)
+            }
+            Err(e) => {
+                warn!("Redis L2 cache disabled: connection failed: {}", e);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let auth_config = load_auth_config();
     let auth = if auth_config.enabled {
         Some(Arc::new(AuthManager::new(auth_config.clone())))
@@ -93,6 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = Arc::new(ProxyService::new(
         cert_cache,
         cache_config.clone(),
+        l2_cache,
         kafka_brokers,
         kafka_topic,
         metrics.clone(),

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -35,6 +35,11 @@ pub struct Metrics {
     pub cache_evictions_total: Counter,
     pub cache_lookup_duration_seconds: Histogram,
 
+    // L2 Redis cache metrics
+    pub cache_l2_hits_total: Counter,
+    pub cache_l2_misses_total: Counter,
+    pub cache_l2_errors_total: Counter,
+
     // Upstream metrics
     pub upstream_requests_total: CounterVec,
     pub upstream_duration_seconds: HistogramVec,
@@ -155,6 +160,24 @@ impl Metrics {
             .buckets(vec![0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01]),
         )?;
         registry.register(Box::new(cache_lookup_duration_seconds.clone()))?;
+
+        let cache_l2_hits_total = Counter::new(
+            "bsdm_proxy_cache_l2_hits_total",
+            "Total Redis L2 cache hits",
+        )?;
+        registry.register(Box::new(cache_l2_hits_total.clone()))?;
+
+        let cache_l2_misses_total = Counter::new(
+            "bsdm_proxy_cache_l2_misses_total",
+            "Total Redis L2 cache misses",
+        )?;
+        registry.register(Box::new(cache_l2_misses_total.clone()))?;
+
+        let cache_l2_errors_total = Counter::new(
+            "bsdm_proxy_cache_l2_errors_total",
+            "Total Redis L2 cache errors",
+        )?;
+        registry.register(Box::new(cache_l2_errors_total.clone()))?;
 
         // Upstream metrics
         let upstream_requests_total = CounterVec::new(
@@ -293,6 +316,9 @@ impl Metrics {
             cache_size_bytes,
             cache_evictions_total,
             cache_lookup_duration_seconds,
+            cache_l2_hits_total,
+            cache_l2_misses_total,
+            cache_l2_errors_total,
             upstream_requests_total,
             upstream_duration_seconds,
             upstream_errors_total,

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -26,6 +26,7 @@ use crate::cache_key::http_cache_key;
 use crate::categorization::{CategorizationEngine, Category};
 use crate::hierarchy::{HierarchyManager, HierarchyResult};
 use crate::http_types::Body;
+use crate::l2_cache::RedisL2Cache;
 use crate::metrics::{Metrics, RequestMetricsGuard};
 use crate::peer_fetch::fetch_via_peer;
 use crate::peers::CachePeer;
@@ -43,6 +44,7 @@ pub struct ProxyPolicy {
 pub struct ProxyService {
     pub(crate) cert_cache: CertCache,
     http_cache: Arc<Cache<Arc<str>, CachedResponse>>,
+    l2_cache: Option<RedisL2Cache>,
     cache_config: CacheConfig,
     kafka_producer: Option<Arc<FutureProducer>>,
     kafka_topic: String,
@@ -74,6 +76,7 @@ impl ProxyService {
     pub fn new(
         cert_cache: CertCache,
         cache_config: CacheConfig,
+        l2_cache: Option<RedisL2Cache>,
         kafka_brokers: Option<String>,
         kafka_topic: String,
         metrics: Arc<Metrics>,
@@ -98,6 +101,7 @@ impl ProxyService {
         Self {
             cert_cache,
             http_cache,
+            l2_cache,
             cache_config,
             kafka_producer,
             kafka_topic,
@@ -114,6 +118,64 @@ impl ProxyService {
 
     fn parse_client_ip(client_ip: &str) -> Option<IpAddr> {
         client_ip.parse().ok()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_cache_hit_event(
+        &self,
+        url: &str,
+        method: &str,
+        cache_key: &Arc<str>,
+        cache_status: &'static str,
+        cached: &CachedResponse,
+        user_id: &Option<String>,
+        username: &Option<String>,
+        client_ip: &str,
+        categories: &[String],
+        request_start: Instant,
+    ) {
+        if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            let event = CacheEvent {
+                url: url.to_string(),
+                method: method.to_string(),
+                status: cached.status,
+                cache_key: cache_key.to_string(),
+                cache_status,
+                timestamp: timestamp.as_secs(),
+                headers: HashMap::new(),
+                user_id: user_id.clone(),
+                username: username.clone(),
+                client_ip: client_ip.to_string(),
+                domain: Self::extract_domain(url),
+                response_size: cached.body.len() as u64,
+                request_duration_ms: request_start.elapsed().as_millis() as u64,
+                content_type: cached
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                    .map(|(_, v)| v.to_string()),
+                user_agent: None,
+                categories: categories.to_vec(),
+                event_id: new_event_id(),
+            };
+            self.send_cache_event(event);
+        }
+    }
+
+    async fn try_l2_cache_get(&self, cache_key: &Arc<str>) -> Option<CachedResponse> {
+        let l2 = self.l2_cache.as_ref()?;
+        l2.get(cache_key.as_ref()).await
+    }
+
+    fn store_in_l1_and_l2(&self, cache_key: Arc<str>, cached_response: CachedResponse) {
+        self.http_cache
+            .insert(cache_key.clone(), cached_response.clone());
+        if let Some(l2) = &self.l2_cache {
+            let l2 = l2.clone();
+            tokio::spawn(async move {
+                l2.set(cache_key.as_ref(), &cached_response).await;
+            });
+        }
     }
 
     pub(crate) async fn check_policy(
@@ -407,38 +469,49 @@ impl ProxyService {
                 self.metrics.cache_hits_total.inc();
                 guard.set_cache_status("HIT");
 
-                if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                    let event = CacheEvent {
-                        url: url.clone(),
-                        method: method.clone(),
-                        status: cached.status,
-                        cache_key: cache_key.to_string(),
-                        cache_status: "HIT",
-                        timestamp: timestamp.as_secs(),
-                        headers: HashMap::new(),
-                        user_id: user_id.clone(),
-                        username: username.clone(),
-                        client_ip: client_ip.clone(),
-                        domain: Self::extract_domain(&url),
-                        response_size: cached.body.len() as u64,
-                        request_duration_ms: request_start.elapsed().as_millis() as u64,
-                        content_type: cached
-                            .headers
-                            .iter()
-                            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-                            .map(|(_, v)| v.to_string()),
-                        user_agent: None,
-                        categories: categories.clone(),
-                        event_id: new_event_id(),
-                    };
-                    self.send_cache_event(event);
-                }
+                self.emit_cache_hit_event(
+                    &url,
+                    &method,
+                    &cache_key,
+                    "HIT",
+                    &cached,
+                    &user_id,
+                    &username,
+                    &client_ip,
+                    &categories,
+                    request_start,
+                );
                 let response = cached.to_response();
                 let body_size = cached.body.len();
                 guard.finish(cached.status, 0, body_size);
                 return response;
             }
         }
+
+        if let Some(cached) = self.try_l2_cache_get(&cache_key).await {
+            info!("Cache L2 HIT: {} {}", method, url);
+            self.http_cache.insert(cache_key.clone(), cached.clone());
+            guard.set_cache_status("L2_HIT");
+
+            self.emit_cache_hit_event(
+                &url,
+                &method,
+                &cache_key,
+                "L2_HIT",
+                &cached,
+                &user_id,
+                &username,
+                &client_ip,
+                &categories,
+                request_start,
+            );
+
+            let response = cached.to_response_with_cache_status("L2-HIT");
+            let body_size = cached.body.len();
+            guard.finish(cached.status, 0, body_size);
+            return response;
+        }
+
         self.metrics
             .cache_lookup_duration_seconds
             .observe(cache_lookup_start.elapsed().as_secs_f64());
@@ -541,7 +614,7 @@ impl ProxyService {
                         cached_at: SystemTime::now(),
                         ttl: self.cache_config.default_ttl,
                     };
-                    self.http_cache.insert(cache_key.clone(), cached_response);
+                    self.store_in_l1_and_l2(cache_key.clone(), cached_response);
                     guard.set_cache_status("MISS");
                     "MISS"
                 } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Redis L2 cache** (M2) — shared HTTP response cache across proxy instances.

## Architecture

```
L1 (quick_cache) → Redis L2 → hierarchy (ICP/parent) → origin
```

- **Read-through:** L2 hit → populate L1 → `x-cache-status: L2-HIT`
- **Write:** cacheable responses → L1 + async Redis `SET EX` (remaining TTL)
- **Keys:** same `SHA256(method:url)` as L1, prefix `REDIS_KEY_PREFIX`

## Configuration

| Variable | Default |
|----------|---------|
| `REDIS_L2_ENABLED` | `false` |
| `REDIS_URL` | `redis://127.0.0.1:6379` |
| `REDIS_KEY_PREFIX` | `bsdm:http:` |

## Metrics

- `bsdm_proxy_cache_l2_hits_total`
- `bsdm_proxy_cache_l2_misses_total`
- `bsdm_proxy_cache_l2_errors_total`

## Demo

```bash
docker compose -f docker-compose.redis-l2.yml up -d --build
curl -x http://127.0.0.1:1488 http://upstream/get
docker compose -f docker-compose.redis-l2.yml restart proxy-a
curl -x http://127.0.0.1:1488 http://upstream/get  # L2-HIT
```

## Testing

- `cargo test -p bsdm-proxy` — 65 tests (incl. L2 wire roundtrip)
- `cargo test -p bsdm-proxy-e2e` — 15 tests
- `cargo clippy -p bsdm-proxy -- -D warnings` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

