### PR TITLE
(B23) HTTP/2 upstream client via ALPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Таймаут graceful shutdown |
 | `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab) |
+| `UPSTREAM_HTTP2_ENABLED` | `false` | HTTP/2 ALPN для upstream HTTPS |
 | `RUST_LOG` | `info,bsdm_proxy=debug`¹ | Фильтр логов ([docs/logging.md](docs/logging.md)) |
 
 CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallback: `./certs/`).

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -51,7 +51,7 @@
 |----|-------|--------|--------|
 | B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
 | B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ❌ |
-| B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ❌ |
+| B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ✅ |
 | B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |
 | B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,7 +230,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 |----|--------|-------|
 | **B21** | Feature flags не в main | `Cargo.toml` features |
 | **B22** | Нет negative caching / refresh | `main.rs` |
-| **B23** | HTTP/1 only upstream | `build_upstream_https_connector` |
+| **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` |
 | **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
 | **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,7 +85,7 @@ gantt
 
 - [ ] **Hierarchy Phase 4** — peer discovery, cache digest, HTCP (опционально mTLS)
 - [x] **Redis L2 cache** — распределённый кеш между инстансами (`docker-compose.redis-l2.yml`)
-- [ ] **HTTP/2 upstream client**
+- [x] **HTTP/2 upstream client** — `UPSTREAM_HTTP2_ENABLED` + ALPN h2
 - [ ] **Compression** — Brotli/Zstd для cacheable responses
 - [ ] **ACL completeness**
   - [x] TimeWindow rules (`HH:MM`, local time, overnight windows)

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -54,6 +54,9 @@ HIERARCHY_ENABLED=false
 # Upstream TLS (for self-signed upstream CA in tests/lab)
 # UPSTREAM_CA_CERT=/etc/bsdm-proxy/upstream-ca.crt
 
+# Upstream HTTP/2 (ALPN h2 on TLS connections, disabled by default)
+# UPSTREAM_HTTP2_ENABLED=true
+
 # Rate limiting (disabled by default)
 # RATE_LIMIT_ENABLED=true
 # RATE_LIMIT_IP_RPS=100

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -23,7 +23,7 @@ prometheus = { version = "0.14", features = ["process"] }
 tokio-rustls = { version = "0.26", features = ["ring"] }
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2.2"
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "ring", "tls12", "webpki-roots"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "ring", "tls12", "webpki-roots"] }
 sha2 = "0.11"
 base64 = "0.22"
 url = "2.5"

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -19,6 +19,7 @@ pub mod rate_limit;
 pub mod selection;
 pub mod server;
 pub mod tls;
+pub mod upstream;
 
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
@@ -41,6 +42,7 @@ pub use rate_limit::{RateLimitConfig, RateLimitViolation, RateLimiter};
 pub use selection::{parse_strategy, SelectionStrategy};
 pub use server::{handle_connection, metrics_server, wait_shutdown_signal};
 pub use tls::CertCache;
+pub use upstream::{build_upstream_https_connector, UpstreamTlsConfig};
 
 // Conditional re-exports based on features
 #[cfg(feature = "auth-ldap")]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -6,7 +6,7 @@ use bsdm_proxy::{
     build_hierarchy_manager, handle_connection, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, metrics_server, should_start_icp_server, wait_shutdown_signal,
     AclAction, AuthManager, CacheConfig, CertCache, IcpServer, L2CacheConfig, Metrics, ProxyPolicy,
-    ProxyService, RateLimitConfig, RedisL2Cache,
+    ProxyService, RateLimitConfig, RedisL2Cache, UpstreamTlsConfig,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -108,6 +108,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| -> Box<dyn std::error::Error> { e })?;
 
     let rate_limit_config = RateLimitConfig::from_env();
+    let upstream_tls = UpstreamTlsConfig::from_env();
 
     let service = Arc::new(ProxyService::new(
         cert_cache,
@@ -121,6 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         &proxy_policy,
         hierarchy.clone(),
         rate_limit_config.clone(),
+        upstream_tls,
     ));
 
     if should_start_icp_server(&hierarchy_config) {

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -6,13 +6,11 @@ use bytes::Bytes;
 use hyper::body::Incoming;
 use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
 use hyper::{Request, Response, StatusCode};
-use hyper_rustls::ConfigBuilderExt;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use quick_cache::sync::Cache;
 use rdkafka::producer::FutureProducer;
 use std::collections::HashMap;
-use std::io::Cursor;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -35,6 +33,7 @@ use crate::pipeline::{
 };
 use crate::rate_limit::{RateLimitViolation, RateLimiter};
 use crate::tls::CertCache;
+use crate::upstream::{build_upstream_https_connector, UpstreamTlsConfig};
 
 pub struct ProxyPolicy {
     pub acl_engine: Option<Arc<Mutex<AclEngine>>>,
@@ -85,13 +84,14 @@ impl ProxyService {
         policy: &ProxyPolicy,
         hierarchy: Option<Arc<HierarchyManager>>,
         rate_limit_config: crate::rate_limit::RateLimitConfig,
+        upstream_tls: UpstreamTlsConfig,
     ) -> Self {
         let kafka_producer = kafka_brokers.as_deref().and_then(create_kafka_producer);
 
         let http_cache = Arc::new(Cache::new(cache_config.capacity));
 
-        let https =
-            build_upstream_https_connector().expect("failed to build upstream HTTPS connector");
+        let https = build_upstream_https_connector(&upstream_tls)
+            .expect("failed to build upstream HTTPS connector");
 
         let http_client = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
             .pool_idle_timeout(Duration::from_secs(90))
@@ -672,34 +672,4 @@ impl ProxyService {
             }
         }
     }
-}
-
-fn build_upstream_https_connector(
-) -> Result<hyper_rustls::HttpsConnector<HttpConnector>, Box<dyn std::error::Error>> {
-    let tls_config = if let Ok(path) = std::env::var("UPSTREAM_CA_CERT") {
-        let pem = std::fs::read(&path)
-            .map_err(|e| format!("failed to read UPSTREAM_CA_CERT {path}: {e}"))?;
-        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
-            rustls_pemfile::certs(&mut Cursor::new(pem))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .map(|cert| cert.into_owned())
-                .collect();
-        let mut roots = rustls::RootCertStore::empty();
-        roots.add_parsable_certificates(certs);
-        info!("Upstream TLS: trusting custom CA from UPSTREAM_CA_CERT");
-        rustls::ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth()
-    } else {
-        rustls::ClientConfig::builder()
-            .with_webpki_roots()
-            .with_no_client_auth()
-    };
-
-    Ok(hyper_rustls::HttpsConnectorBuilder::new()
-        .with_tls_config(tls_config)
-        .https_or_http()
-        .enable_http1()
-        .build())
 }

--- a/proxy/src/upstream.rs
+++ b/proxy/src/upstream.rs
@@ -1,0 +1,91 @@
+//! Upstream HTTP(S) client TLS configuration.
+
+use hyper_rustls::ConfigBuilderExt;
+use hyper_util::client::legacy::connect::HttpConnector;
+use std::io::Cursor;
+use tracing::info;
+
+#[derive(Clone, Debug, Default)]
+pub struct UpstreamTlsConfig {
+    /// Negotiate HTTP/2 via ALPN on TLS upstream connections.
+    pub http2_enabled: bool,
+}
+
+impl UpstreamTlsConfig {
+    pub fn from_env() -> Self {
+        let http2_enabled = std::env::var("UPSTREAM_HTTP2_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        Self { http2_enabled }
+    }
+}
+
+pub fn build_upstream_https_connector(
+    config: &UpstreamTlsConfig,
+) -> Result<hyper_rustls::HttpsConnector<HttpConnector>, Box<dyn std::error::Error>> {
+    let tls_config = if let Ok(path) = std::env::var("UPSTREAM_CA_CERT") {
+        let pem = std::fs::read(&path)
+            .map_err(|e| format!("failed to read UPSTREAM_CA_CERT {path}: {e}"))?;
+        let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
+            rustls_pemfile::certs(&mut Cursor::new(pem))
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .map(|cert| cert.into_owned())
+                .collect();
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add_parsable_certificates(certs);
+        info!("Upstream TLS: trusting custom CA from UPSTREAM_CA_CERT");
+        rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth()
+    } else {
+        rustls::ClientConfig::builder()
+            .with_webpki_roots()
+            .with_no_client_auth()
+    };
+
+    if config.http2_enabled {
+        info!("Upstream TLS: HTTP/2 ALPN enabled (UPSTREAM_HTTP2_ENABLED)");
+        Ok(hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .build())
+    } else {
+        Ok(hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(tls_config)
+            .https_or_http()
+            .enable_http1()
+            .build())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_tls_config_defaults_http2_off() {
+        std::env::remove_var("UPSTREAM_HTTP2_ENABLED");
+        let cfg = UpstreamTlsConfig::from_env();
+        assert!(!cfg.http2_enabled);
+    }
+
+    #[test]
+    fn upstream_tls_config_parses_http2_flag() {
+        std::env::set_var("UPSTREAM_HTTP2_ENABLED", "true");
+        let cfg = UpstreamTlsConfig::from_env();
+        assert!(cfg.http2_enabled);
+        std::env::remove_var("UPSTREAM_HTTP2_ENABLED");
+    }
+
+    #[test]
+    fn builds_connector_with_and_without_http2() {
+        let _ = build_upstream_https_connector(&UpstreamTlsConfig::default()).unwrap();
+        let _ = build_upstream_https_connector(&UpstreamTlsConfig {
+            http2_enabled: true,
+        })
+        .unwrap();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Добавлен опциональный HTTP/2 upstream client через ALPN на TLS-соединениях к origin.

- Новый модуль `proxy/src/upstream.rs`: `UpstreamTlsConfig`, `build_upstream_https_connector()`
- Флаг `UPSTREAM_HTTP2_ENABLED` (default `false`) — при `true` connector включает `enable_http2()` на `HttpsConnectorBuilder`
- Логика TLS connector вынесена из `proxy_service.rs`; `ProxyService::new` принимает `UpstreamTlsConfig`
- `hyper-rustls` feature `http2` в `proxy/Cargo.toml`
- Документация: `README.md`, `architecture.md`, `roadmap.md`, `BLOCKERS.md`, `bsdm-proxy.env.example`

## Связанные issue

- Closes #54
- Milestone / блокер: M2, B23

## Testing

```bash
cargo clippy -p bsdm-proxy -- -D warnings
cargo test -p bsdm-proxy
```

68 тестов (включая 3 новых в `upstream.rs`) — все прошли локально.

## Checklist

- [ ] CI зелёный
- [x] Документация обновлена (env `UPSTREAM_HTTP2_ENABLED`)
- [x] `docs/BLOCKERS.md` / `docs/roadmap.md` (B23 ✅)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

