### PR TITLE
(M2) At-rest Brotli/Zstd compression for cached responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +192,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +226,7 @@ name = "bsdm-proxy"
 version = "0.2.3-test"
 dependencies = [
  "base64",
+ "brotli",
  "bytes",
  "chrono",
  "hex",
@@ -218,6 +255,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "zstd",
 ]
 
 [[package]]
@@ -3314,3 +3352,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -393,7 +393,7 @@ ms_print massif.out | less
 - [ ] **SIMD для SHA256**: `sha2` с AVX2/NEON оптимизациями
 - [ ] **jemalloc**: Замена стандартного allocator
 - [ ] **HTTP/2 client**: Поддержка HTTP/2 к upstream
-- [ ] **Compression**: Brotli/Zstd для кешированных ответов
+- [x] **Compression**: Brotli/Zstd at-rest for cached responses (`CACHE_COMPRESSION`)
 
 ### v2.2 (Среднесрочные)
 - [ ] **Redis L2 cache**: Распределенный кеш

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 
 - [x] Redis L2 cache
 - [ ] HTTP/2 upstream client
-- [ ] Compression (Brotli/Zstd)
+- [x] Compression (Brotli/Zstd) — `CACHE_COMPRESSION=zstd|brotli`
 - [ ] ACL TimeWindow + group rules
 - [ ] NTLM auth
 - [ ] Hierarchy Phase 4 (discovery, digest, HTCP, hierarchy metrics)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,7 +86,7 @@ gantt
 - [ ] **Hierarchy Phase 4** — peer discovery, cache digest, HTCP (опционально mTLS)
 - [x] **Redis L2 cache** — распределённый кеш между инстансами (`docker-compose.redis-l2.yml`)
 - [ ] **HTTP/2 upstream client**
-- [ ] **Compression** — Brotli/Zstd для cacheable responses
+- [x] **Compression** — Brotli/Zstd at-rest for cacheable responses (`CACHE_COMPRESSION`)
 - [ ] **ACL completeness**
   - [x] TimeWindow rules (`HH:MM`, local time, overnight windows)
   - [x] Group-based Principal rules (LDAP `memberOf` cn matching)

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -12,6 +12,12 @@ CACHE_CAPACITY=10000
 CACHE_TTL_SECONDS=3600
 MAX_CACHE_BODY_SIZE=10485760
 
+# At-rest compression for cacheable responses (disabled by default)
+# CACHE_COMPRESSION=zstd
+# CACHE_COMPRESSION=brotli
+# CACHE_COMPRESS_MIN_BYTES=1024
+# CACHE_COMPRESS_ZSTD_LEVEL=3
+
 # Kafka (optional — cache events)
 # KAFKA_BROKERS=127.0.0.1:9092
 # KAFKA_TOPIC=cache-events

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -28,6 +28,8 @@ sha2 = "0.11"
 base64 = "0.22"
 url = "2.5"
 bytes = "1.12"
+zstd = "0.13"
+brotli = "8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -41,7 +41,10 @@ impl CachedResponse {
         match decode_body(&self.body, self.body_encoding) {
             Ok(body) => Some(body),
             Err(e) => {
-                warn!("failed to decode cached body ({:?}): {e}", self.body_encoding);
+                warn!(
+                    "failed to decode cached body ({:?}): {e}",
+                    self.body_encoding
+                );
                 None
             }
         }
@@ -52,9 +55,7 @@ impl CachedResponse {
     }
 
     pub fn to_response_with_cache_status(&self, cache_status: &str) -> Response<Body> {
-        let body = self
-            .decoded_body()
-            .unwrap_or_else(|| self.body.clone());
+        let body = self.decoded_body().unwrap_or_else(|| self.body.clone());
         let mut response = Response::new(Body::new(body));
         *response.status_mut() = StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK);
 
@@ -162,7 +163,13 @@ mod tests {
             min_bytes: 512,
             zstd_level: 3,
         };
-        let cached = CachedResponse::from_upstream(200, headers, body.clone(), Duration::from_secs(60), &compression);
+        let cached = CachedResponse::from_upstream(
+            200,
+            headers,
+            body.clone(),
+            Duration::from_secs(60),
+            &compression,
+        );
         assert_eq!(cached.body_encoding, BodyEncoding::Zstd);
         let response = cached.to_response();
         let collected = http_body_util::BodyExt::collect(response.into_body());

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -5,7 +5,9 @@ use hyper::header::{HeaderName, HeaderValue};
 use hyper::{Response, StatusCode};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
+use tracing::warn;
 
+use crate::cache_compress::{decode_body, prepare_body_for_cache, BodyEncoding, CompressionConfig};
 use crate::http_types::Body;
 
 pub const CACHEABLE_METHODS: &[&str] = &["GET", "HEAD"];
@@ -16,6 +18,9 @@ pub struct CachedResponse {
     pub status: u16,
     pub headers: Arc<[(Arc<str>, Arc<str>)]>,
     pub body: Bytes,
+    pub body_encoding: BodyEncoding,
+    /// Logical response body size (uncompressed) for clients and metrics.
+    pub uncompressed_len: usize,
     pub cached_at: SystemTime,
     pub ttl: Duration,
 }
@@ -28,12 +33,29 @@ impl CachedResponse {
             .map_or(true, |age| age > self.ttl)
     }
 
+    pub fn response_body_len(&self) -> usize {
+        self.uncompressed_len
+    }
+
+    pub fn decoded_body(&self) -> Option<Bytes> {
+        match decode_body(&self.body, self.body_encoding) {
+            Ok(body) => Some(body),
+            Err(e) => {
+                warn!("failed to decode cached body ({:?}): {e}", self.body_encoding);
+                None
+            }
+        }
+    }
+
     pub fn to_response(&self) -> Response<Body> {
         self.to_response_with_cache_status("HIT")
     }
 
     pub fn to_response_with_cache_status(&self, cache_status: &str) -> Response<Body> {
-        let mut response = Response::new(Body::new(self.body.clone()));
+        let body = self
+            .decoded_body()
+            .unwrap_or_else(|| self.body.clone());
+        let mut response = Response::new(Body::new(body));
         *response.status_mut() = StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK);
 
         let headers_mut = response.headers_mut();
@@ -46,10 +68,33 @@ impl CachedResponse {
             }
         }
 
+        if let Ok(val) = HeaderValue::from_str(&self.uncompressed_len.to_string()) {
+            headers_mut.insert("content-length", val);
+        }
+
         if let Ok(val) = HeaderValue::from_str(cache_status) {
             headers_mut.insert("x-cache-status", val);
         }
         response
+    }
+
+    pub fn from_upstream(
+        status: u16,
+        headers: Arc<[(Arc<str>, Arc<str>)]>,
+        body: Bytes,
+        ttl: Duration,
+        compression: &CompressionConfig,
+    ) -> Self {
+        let prepared = prepare_body_for_cache(body, headers, compression);
+        Self {
+            status,
+            headers: prepared.headers,
+            body: prepared.body,
+            body_encoding: prepared.encoding,
+            uncompressed_len: prepared.uncompressed_len,
+            cached_at: SystemTime::now(),
+            ttl,
+        }
     }
 }
 
@@ -58,6 +103,7 @@ pub struct CacheConfig {
     pub capacity: usize,
     pub default_ttl: Duration,
     pub max_body_size: usize,
+    pub compression: CompressionConfig,
 }
 
 impl Default for CacheConfig {
@@ -66,6 +112,7 @@ impl Default for CacheConfig {
             capacity: 10_000,
             default_ttl: Duration::from_secs(3600),
             max_body_size: 10 * 1024 * 1024,
+            compression: CompressionConfig::default(),
         }
     }
 }
@@ -89,6 +136,7 @@ impl CacheConfig {
             capacity,
             default_ttl: Duration::from_secs(cache_ttl_secs),
             max_body_size,
+            compression: CompressionConfig::from_env(),
         }
     }
 }
@@ -97,4 +145,29 @@ pub fn is_cacheable(method: &str, status: u16, body_size: usize, max_body_size: 
     CACHEABLE_METHODS.contains(&method)
         && CACHEABLE_STATUS_CODES.contains(&status)
         && body_size <= max_body_size
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache_compress::CompressionConfig;
+
+    #[test]
+    fn cached_response_serves_decompressed_body() {
+        let body = Bytes::from("y".repeat(2048));
+        let headers: Arc<[(Arc<str>, Arc<str>)]> =
+            Arc::from([(Arc::from("content-type"), Arc::from("text/plain"))]);
+        let compression = CompressionConfig {
+            codec: BodyEncoding::Zstd,
+            min_bytes: 512,
+            zstd_level: 3,
+        };
+        let cached = CachedResponse::from_upstream(200, headers, body.clone(), Duration::from_secs(60), &compression);
+        assert_eq!(cached.body_encoding, BodyEncoding::Zstd);
+        let response = cached.to_response();
+        let collected = http_body_util::BodyExt::collect(response.into_body());
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let bytes = rt.block_on(collected).unwrap().to_bytes();
+        assert_eq!(bytes, body);
+    }
 }

--- a/proxy/src/cache_compress.rs
+++ b/proxy/src/cache_compress.rs
@@ -1,0 +1,286 @@
+//! Transparent at-rest compression for cached HTTP response bodies.
+
+use bytes::Bytes;
+use std::sync::Arc;
+use tracing::debug;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BodyEncoding {
+    #[default]
+    Raw,
+    Zstd,
+    Brotli,
+}
+
+impl BodyEncoding {
+    pub fn from_wire(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "zstd" => Some(Self::Zstd),
+            "brotli" => Some(Self::Brotli),
+            _ => None,
+        }
+    }
+
+    pub fn wire_name(self) -> &'static str {
+        match self {
+            Self::Raw => "raw",
+            Self::Zstd => "zstd",
+            Self::Brotli => "brotli",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CompressionConfig {
+    pub codec: BodyEncoding,
+    pub min_bytes: usize,
+    pub zstd_level: i32,
+}
+
+impl Default for CompressionConfig {
+    fn default() -> Self {
+        Self {
+            codec: BodyEncoding::Raw,
+            min_bytes: 1024,
+            zstd_level: 3,
+        }
+    }
+}
+
+impl CompressionConfig {
+    pub fn from_env() -> Self {
+        let codec = std::env::var("CACHE_COMPRESSION")
+            .ok()
+            .and_then(|v| match v.to_ascii_lowercase().as_str() {
+                "zstd" => Some(BodyEncoding::Zstd),
+                "brotli" => Some(BodyEncoding::Brotli),
+                "off" | "false" | "0" | "" => Some(BodyEncoding::Raw),
+                _ => None,
+            })
+            .unwrap_or(BodyEncoding::Raw);
+        let min_bytes = std::env::var("CACHE_COMPRESS_MIN_BYTES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1024);
+        let zstd_level = std::env::var("CACHE_COMPRESS_ZSTD_LEVEL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3);
+
+        Self {
+            codec,
+            min_bytes,
+            zstd_level,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self.codec, BodyEncoding::Raw)
+    }
+}
+
+pub fn decode_body(body: &Bytes, encoding: BodyEncoding) -> Result<Bytes, String> {
+    match encoding {
+        BodyEncoding::Raw => Ok(body.clone()),
+        BodyEncoding::Zstd => zstd::decode_all(body.as_ref()).map(Bytes::from).map_err(|e| {
+            format!("zstd decompress failed: {e}")
+        }),
+        BodyEncoding::Brotli => {
+            let mut reader = std::io::Cursor::new(body.as_ref());
+            let mut out = Vec::new();
+            brotli::BrotliDecompress(&mut reader, &mut out)
+                .map_err(|e| format!("brotli decompress failed: {e:?}"))?;
+            Ok(Bytes::from(out))
+        }
+    }
+}
+
+fn compress_zstd(body: &[u8], level: i32) -> Result<Vec<u8>, String> {
+    zstd::encode_all(body, level).map_err(|e| format!("zstd compress failed: {e}"))
+}
+
+fn compress_brotli(body: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    brotli::BrotliCompress(
+        &mut std::io::Cursor::new(body),
+        &mut out,
+        &brotli::enc::BrotliEncoderParams::default(),
+    )
+    .map_err(|e| format!("brotli compress failed: {e:?}"))?;
+    Ok(out)
+}
+
+fn has_content_encoding(headers: &[(Arc<str>, Arc<str>)]) -> bool {
+    headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("content-encoding"))
+}
+
+fn strip_length_headers(headers: &[(Arc<str>, Arc<str>)]) -> Arc<[(Arc<str>, Arc<str>)]> {
+    headers
+        .iter()
+        .filter(|(k, _)| {
+            !k.eq_ignore_ascii_case("content-length")
+                && !k.eq_ignore_ascii_case("content-encoding")
+        })
+        .cloned()
+        .collect()
+}
+
+#[derive(Clone, Debug)]
+pub struct PreparedCacheBody {
+    pub body: Bytes,
+    pub headers: Arc<[(Arc<str>, Arc<str>)]>,
+    pub encoding: BodyEncoding,
+    pub uncompressed_len: usize,
+}
+
+/// Compress body for cache storage when configured.
+pub fn prepare_body_for_cache(
+    body: Bytes,
+    headers: Arc<[(Arc<str>, Arc<str>)]>,
+    config: &CompressionConfig,
+) -> PreparedCacheBody {
+    let uncompressed_len = body.len();
+
+    if !config.is_enabled()
+        || body.len() < config.min_bytes
+        || has_content_encoding(headers.as_ref())
+    {
+        return PreparedCacheBody {
+            body,
+            headers,
+            encoding: BodyEncoding::Raw,
+            uncompressed_len,
+        };
+    }
+
+    let compressed = match config.codec {
+        BodyEncoding::Raw => {
+            return PreparedCacheBody {
+                body,
+                headers,
+                encoding: BodyEncoding::Raw,
+                uncompressed_len,
+            };
+        }
+        BodyEncoding::Zstd => match compress_zstd(body.as_ref(), config.zstd_level) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("cache compression skipped: {e}");
+                return PreparedCacheBody {
+                    body,
+                    headers,
+                    encoding: BodyEncoding::Raw,
+                    uncompressed_len,
+                };
+            }
+        },
+        BodyEncoding::Brotli => match compress_brotli(body.as_ref()) {
+            Ok(v) => v,
+            Err(e) => {
+                debug!("cache compression skipped: {e}");
+                return PreparedCacheBody {
+                    body,
+                    headers,
+                    encoding: BodyEncoding::Raw,
+                    uncompressed_len,
+                };
+            }
+        },
+    };
+
+    if compressed.len() >= body.len() {
+        return PreparedCacheBody {
+            body,
+            headers,
+            encoding: BodyEncoding::Raw,
+            uncompressed_len,
+        };
+    }
+
+    debug!(
+        "cache body compressed {:?}: {} -> {} bytes",
+        config.codec,
+        body.len(),
+        compressed.len()
+    );
+
+    PreparedCacheBody {
+        body: Bytes::from(compressed),
+        headers: strip_length_headers(headers.as_ref()),
+        encoding: config.codec,
+        uncompressed_len,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_body() -> Bytes {
+        Bytes::from("x".repeat(2048))
+    }
+
+    #[test]
+    fn compression_config_defaults_off() {
+        std::env::remove_var("CACHE_COMPRESSION");
+        let cfg = CompressionConfig::from_env();
+        assert!(!cfg.is_enabled());
+    }
+
+    #[test]
+    fn compression_config_parses_zstd() {
+        std::env::set_var("CACHE_COMPRESSION", "zstd");
+        let cfg = CompressionConfig::from_env();
+        assert_eq!(cfg.codec, BodyEncoding::Zstd);
+        std::env::remove_var("CACHE_COMPRESSION");
+    }
+
+    #[test]
+    fn zstd_roundtrip() {
+        let body = sample_body();
+        let headers: Arc<[(Arc<str>, Arc<str>)]> =
+            Arc::from([(Arc::from("content-type"), Arc::from("text/plain"))]);
+        let config = CompressionConfig {
+            codec: BodyEncoding::Zstd,
+            min_bytes: 512,
+            zstd_level: 3,
+        };
+        let prepared = prepare_body_for_cache(body.clone(), headers, &config);
+        assert_eq!(prepared.encoding, BodyEncoding::Zstd);
+        assert!(prepared.body.len() < body.len());
+        assert_eq!(prepared.uncompressed_len, body.len());
+        let decoded = decode_body(&prepared.body, prepared.encoding).unwrap();
+        assert_eq!(decoded, body);
+    }
+
+    #[test]
+    fn brotli_roundtrip() {
+        let body = sample_body();
+        let headers: Arc<[(Arc<str>, Arc<str>)]> = Arc::from([]);
+        let config = CompressionConfig {
+            codec: BodyEncoding::Brotli,
+            min_bytes: 512,
+            zstd_level: 3,
+        };
+        let prepared = prepare_body_for_cache(body.clone(), headers, &config);
+        assert_eq!(prepared.encoding, BodyEncoding::Brotli);
+        let decoded = decode_body(&prepared.body, prepared.encoding).unwrap();
+        assert_eq!(decoded, body);
+    }
+
+    #[test]
+    fn skips_already_encoded_responses() {
+        let body = sample_body();
+        let headers: Arc<[(Arc<str>, Arc<str>)]> =
+            Arc::from([(Arc::from("content-encoding"), Arc::from("gzip"))]);
+        let config = CompressionConfig {
+            codec: BodyEncoding::Zstd,
+            min_bytes: 512,
+            zstd_level: 3,
+        };
+        let prepared = prepare_body_for_cache(body, headers, &config);
+        assert_eq!(prepared.encoding, BodyEncoding::Raw);
+    }
+}

--- a/proxy/src/cache_compress.rs
+++ b/proxy/src/cache_compress.rs
@@ -82,9 +82,9 @@ impl CompressionConfig {
 pub fn decode_body(body: &Bytes, encoding: BodyEncoding) -> Result<Bytes, String> {
     match encoding {
         BodyEncoding::Raw => Ok(body.clone()),
-        BodyEncoding::Zstd => zstd::decode_all(body.as_ref()).map(Bytes::from).map_err(|e| {
-            format!("zstd decompress failed: {e}")
-        }),
+        BodyEncoding::Zstd => zstd::decode_all(body.as_ref())
+            .map(Bytes::from)
+            .map_err(|e| format!("zstd decompress failed: {e}")),
         BodyEncoding::Brotli => {
             let mut reader = std::io::Cursor::new(body.as_ref());
             let mut out = Vec::new();
@@ -120,8 +120,7 @@ fn strip_length_headers(headers: &[(Arc<str>, Arc<str>)]) -> Arc<[(Arc<str>, Arc
     headers
         .iter()
         .filter(|(k, _)| {
-            !k.eq_ignore_ascii_case("content-length")
-                && !k.eq_ignore_ascii_case("content-encoding")
+            !k.eq_ignore_ascii_case("content-length") && !k.eq_ignore_ascii_case("content-encoding")
         })
         .cloned()
         .collect()

--- a/proxy/src/l2_cache.rs
+++ b/proxy/src/l2_cache.rs
@@ -1,6 +1,7 @@
 //! Redis L2 HTTP response cache (shared across proxy instances).
 
 use crate::cache::CachedResponse;
+use crate::cache_compress::BodyEncoding;
 use crate::metrics::Metrics;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
@@ -42,6 +43,10 @@ struct CachedResponseWire {
     status: u16,
     headers: Vec<(String, String)>,
     body_b64: String,
+    #[serde(default)]
+    body_encoding: Option<String>,
+    #[serde(default)]
+    uncompressed_len: Option<usize>,
     cached_at_secs: u64,
     ttl_secs: u64,
 }
@@ -58,6 +63,12 @@ impl CachedResponseWire {
             status: value.status,
             headers,
             body_b64: B64.encode(value.body.as_ref()),
+            body_encoding: if value.body_encoding == BodyEncoding::Raw {
+                None
+            } else {
+                Some(value.body_encoding.wire_name().to_string())
+            },
+            uncompressed_len: Some(value.uncompressed_len),
             cached_at_secs,
             ttl_secs: value.ttl.as_secs(),
         })
@@ -70,10 +81,18 @@ impl CachedResponseWire {
             .into_iter()
             .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
             .collect();
+        let body_encoding = self
+            .body_encoding
+            .as_deref()
+            .and_then(BodyEncoding::from_wire)
+            .unwrap_or(BodyEncoding::Raw);
+        let uncompressed_len = self.uncompressed_len.unwrap_or_else(|| body.len());
         Some(CachedResponse {
             status: self.status,
             headers,
             body,
+            body_encoding,
+            uncompressed_len,
             cached_at: UNIX_EPOCH + Duration::from_secs(self.cached_at_secs),
             ttl: Duration::from_secs(self.ttl_secs),
         })
@@ -188,6 +207,8 @@ mod tests {
             status: 200,
             headers: Arc::from([(Arc::from("content-type"), Arc::from("text/plain"))]),
             body: Bytes::from_static(b"hello"),
+            body_encoding: BodyEncoding::Raw,
+            uncompressed_len: 5,
             cached_at: SystemTime::now(),
             ttl: Duration::from_secs(3600),
         };
@@ -196,6 +217,33 @@ mod tests {
         assert_eq!(decoded.status, 200);
         assert_eq!(decoded.body, original.body);
         assert_eq!(decoded.headers.len(), 1);
+    }
+
+    #[test]
+    fn wire_roundtrip_compressed() {
+        use crate::cache_compress::CompressionConfig;
+
+        let body = Bytes::from("z".repeat(2048));
+        let headers: Arc<[(Arc<str>, Arc<str>)]> =
+            Arc::from([(Arc::from("content-type"), Arc::from("text/plain"))]);
+        let compression = CompressionConfig {
+            codec: BodyEncoding::Zstd,
+            min_bytes: 512,
+            zstd_level: 3,
+        };
+        let original = crate::cache::CachedResponse::from_upstream(
+            200,
+            headers,
+            body.clone(),
+            Duration::from_secs(3600),
+            &compression,
+        );
+        assert_eq!(original.body_encoding, BodyEncoding::Zstd);
+        let json = encode_cached_response(&original).unwrap();
+        let decoded = decode_cached_response(&json).unwrap();
+        assert_eq!(decoded.body_encoding, BodyEncoding::Zstd);
+        assert_eq!(decoded.uncompressed_len, body.len());
+        assert_eq!(decoded.decoded_body().unwrap(), body);
     }
 
     #[test]
@@ -211,6 +259,8 @@ mod tests {
             status: 200,
             headers: Arc::from([]),
             body: Bytes::new(),
+            body_encoding: BodyEncoding::Raw,
+            uncompressed_len: 0,
             cached_at: SystemTime::now(),
             ttl: Duration::from_secs(60),
         };

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod acl;
 pub mod auth;
 pub mod cache;
+pub mod cache_compress;
 pub mod cache_key;
 pub mod categorization;
 pub mod hierarchy;
@@ -24,6 +25,7 @@ pub mod tls;
 pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
 pub use auth::{AuthBackend, AuthConfig, AuthManager, UserInfo};
 pub use cache::{CacheConfig, CachedResponse};
+pub use cache_compress::{BodyEncoding, CompressionConfig};
 pub use cache_key::http_cache_key;
 pub use categorization::{CategorizationConfig, CategorizationEngine, Category};
 pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -147,7 +147,7 @@ impl ProxyService {
                 username: username.clone(),
                 client_ip: client_ip.to_string(),
                 domain: Self::extract_domain(url),
-                response_size: cached.body.len() as u64,
+                response_size: cached.response_body_len() as u64,
                 request_duration_ms: request_start.elapsed().as_millis() as u64,
                 content_type: cached
                     .headers
@@ -482,7 +482,7 @@ impl ProxyService {
                     request_start,
                 );
                 let response = cached.to_response();
-                let body_size = cached.body.len();
+                let body_size = cached.response_body_len();
                 guard.finish(cached.status, 0, body_size);
                 return response;
             }
@@ -507,7 +507,7 @@ impl ProxyService {
             );
 
             let response = cached.to_response_with_cache_status("L2-HIT");
-            let body_size = cached.body.len();
+            let body_size = cached.response_body_len();
             guard.finish(cached.status, 0, body_size);
             return response;
         }
@@ -607,13 +607,13 @@ impl ProxyService {
                         .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
                         .collect();
 
-                    let cached_response = CachedResponse {
-                        status: status.as_u16(),
-                        headers: headers_arc,
-                        body: body_bytes.clone(),
-                        cached_at: SystemTime::now(),
-                        ttl: self.cache_config.default_ttl,
-                    };
+                    let cached_response = CachedResponse::from_upstream(
+                        status.as_u16(),
+                        headers_arc,
+                        body_bytes.clone(),
+                        self.cache_config.default_ttl,
+                        &self.cache_config.compression,
+                    );
                     self.store_in_l1_and_l2(cache_key.clone(), cached_response);
                     guard.set_cache_status("MISS");
                     "MISS"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Прозрачное at-rest сжатие тел cacheable HTTP-ответов в L1/L2 кеше.

- Новый модуль `proxy/src/cache_compress.rs`: Zstd и Brotli
- `CACHE_COMPRESSION=zstd|brotli|off` (default `off`)
- `CACHE_COMPRESS_MIN_BYTES` (default 1024), `CACHE_COMPRESS_ZSTD_LEVEL` (default 3)
- При cache HIT тело распаковывается; клиент получает оригинальный ответ с корректным `Content-Length`
- Ответы с `Content-Encoding` не сжимаются повторно
- L2 wire format расширен полем `body_encoding` (обратная совместимость со старыми записями)

## Связанные issue

- Milestone: M2 — Squid parity (Compression)

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

72 теста — все прошли локально (включая roundtrip zstd/brotli и L2 wire).

## Checklist

- [x] CI зелёный (fmt fix в 6ba103f)
- [x] Документация обновлена (`README.md`, `roadmap.md`, `bsdm-proxy.env.example`)
- [x] `docs/roadmap.md` — Compression ✅

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

