### PR TITLE
docs: release 0.2.3-test notes and documentation update

### DIFF
--- a/OPTIMIZATIONS.md
+++ b/OPTIMIZATIONS.md
@@ -396,7 +396,7 @@ ms_print massif.out | less
 - [x] **Compression**: Brotli/Zstd at-rest for cached responses (`CACHE_COMPRESSION`)
 
 ### v2.2 (Среднесрочные)
-- [ ] **Redis L2 cache**: Распределенный кеш
+- [x] **Redis L2 cache**: Распределенный кеш (`REDIS_L2_ENABLED`, `docker-compose.redis-l2.yml`)
 - [ ] **io_uring**: Linux 5.1+ оптимизация I/O
 - [ ] **eBPF**: Мониторинг на уровне ядра
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Build Status](https://github.com/onixus/bsdm-proxy/actions/workflows/rust.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/rust.yml)
 [![E2E Tests](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.2.2b-blue.svg)](https://github.com/onixus/bsdm-proxy/releases/tag/v0.2.2b)
+[![Version](https://img.shields.io/badge/version-0.2.3--test-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
 [![Rust](https://img.shields.io/badge/rust-1.85+-orange.svg)](https://www.rust-lang.org)
 
-> **Текущая версия:** `0.2.2b` (beta) — см. [Releases](https://github.com/onixus/bsdm-proxy/releases)
+> **Текущая версия:** `0.2.3-test` (тестовый pre-release) — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [release notes](docs/releases/v0.2.3-test.md)
 
 ⚠️ **MITM-прокси для HTTPS.** Используйте только в корпоративной среде с согласия пользователей и в рамках законодательства.
 
@@ -18,7 +18,7 @@
 
 | Область | Возможности |
 |---------|-------------|
-| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (порты 443/8443), HTTP CONNECT, кеш L1, **иерархический кеш** (ICP + parent/sibling peers) |
+| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (порты 443/8443), HTTP CONNECT, кеш **L1 + Redis L2**, **иерархический кеш** (ICP + parent/sibling peers), **HTTP/2 upstream** (опц.) |
 | **Безопасность** | Proxy-аутентификация (Basic / LDAP), ACL, категоризация URL, rate limiting |
 | **Наблюдаемость** | Prometheus (20+ метрик), Grafana, `/health`, `/ready`, `/metrics` |
 | **Аналитика** | Kafka → cache-indexer → OpenSearch |
@@ -114,13 +114,13 @@ curl http://localhost:9090/metrics | grep bsdm_proxy
 ./scripts/build-package.sh
 ```
 
-Архив: `dist/bsdm-proxy-0.2.2b-linux-<arch>.tar.gz`
+Архив: `dist/bsdm-proxy-0.2.3test-linux-<arch>.tar.gz`
 
 Установка:
 
 ```bash
-tar xzf dist/bsdm-proxy-0.2.2b-linux-x86_64.tar.gz
-cd bsdm-proxy-0.2.2b-linux-x86_64
+tar xzf dist/bsdm-proxy-0.2.3test-linux-x86_64.tar.gz
+cd bsdm-proxy-0.2.3test-linux-x86_64
 sudo ./install.sh --create-user --systemd
 sudo cp certs/ca.key certs/ca.crt /certs/
 sudo systemctl start bsdm-proxy
@@ -155,6 +155,9 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Таймаут graceful shutdown |
 | `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab) |
 | `UPSTREAM_HTTP2_ENABLED` | `false` | HTTP/2 ALPN для upstream HTTPS |
+| `CACHE_COMPRESSION` | `off` | At-rest сжатие кеша: `zstd`, `brotli`, `off` |
+| `CACHE_COMPRESS_MIN_BYTES` | `1024` | Мин. размер body для сжатия в кеше |
+| `CACHE_COMPRESS_ZSTD_LEVEL` | `3` | Уровень Zstd (1–22) |
 | `RUST_LOG` | `info,bsdm_proxy=debug`¹ | Фильтр логов ([docs/logging.md](docs/logging.md)) |
 
 CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallback: `./certs/`).
@@ -216,6 +219,18 @@ Token-bucket лимиты на IP и аутентифицированного п
 Ответ при L2 hit: заголовок `x-cache-status: L2-HIT`.
 
 Демо: `docker compose -f docker-compose.redis-l2.yml up -d --build`
+
+### At-rest compression (опционально)
+
+Прозрачное сжатие тел cacheable-ответов в L1/L2. Клиент всегда получает распакованный ответ.
+
+| Переменная | По умолчанию | Описание |
+|-----------|-------------|----------|
+| `CACHE_COMPRESSION` | `off` | `zstd`, `brotli` или `off` |
+| `CACHE_COMPRESS_MIN_BYTES` | `1024` | Сжимать только если body ≥ N байт |
+| `CACHE_COMPRESS_ZSTD_LEVEL` | `3` | Уровень Zstd |
+
+Ответы с заголовком `Content-Encoding` не сжимаются повторно.
 
 ### Иерархический кеш (опционально)
 
@@ -306,6 +321,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш, ICP, peers |
 | [docs/architecture.md](docs/architecture.md) | Архитектура и блокеры |
 | [docs/roadmap.md](docs/roadmap.md) | Roadmap и milestones |
+| [docs/releases/v0.2.3-test.md](docs/releases/v0.2.3-test.md) | Release notes 0.2.3-test |
 | [packaging/README.md](packaging/README.md) | Release-пакет и systemd |
 | [OPTIMIZATIONS.md](OPTIMIZATIONS.md) | Оптимизации v2.0 |
 | [docker-compose.yml](docker-compose.yml) | Полный стек |
@@ -319,7 +335,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | Milestone | Версия | Фокус | Статус |
 |-----------|--------|-------|--------|
 | **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability, иерархия | ✅ Done |
-| **M2** Squid parity | v0.3.x | L2 Redis, rate limit, полный ACL, hierarchy Phase 4 | Planned |
+| **M2** Squid parity | v0.3.x | L2 Redis, HTTP/2, compression, полный ACL, hierarchy Phase 4 | ~45% |
 | **M3** Retro-search | v0.4.x | OpenSearch dashboards, поиск по истории | Planned |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | Planned |
 | **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | Planned |
@@ -331,7 +347,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] Proxy authentication (Basic / LDAP; NTLM — в backlog M2)
 - [x] ACL + URL categorization
 - [x] E2E / smoke test harness
-- [x] Release packaging (`0.2.2b`)
+- [x] Release packaging (`0.2.3-test`)
 - [x] Hierarchical caching Phase 3 — ICP server, peer fetch, env config
 - [x] Rate limiting per user/IP
 - [x] Рефакторинг `main.rs` (вынос `ProxyService` в lib)
@@ -343,9 +359,11 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] Redis L2 cache
 - [x] HTTP/2 upstream client — `UPSTREAM_HTTP2_ENABLED`
 - [x] Compression (Brotli/Zstd) — `CACHE_COMPRESSION=zstd|brotli`
-- [ ] ACL TimeWindow + group rules
+- [x] ACL TimeWindow + group rules
 - [ ] NTLM auth
-- [ ] Hierarchy Phase 4 (discovery, digest, HTCP, hierarchy metrics)
+- [ ] Hierarchy Phase 4 (discovery, digest, HTCP)
+- [ ] Negative caching / cache refresh (B22)
+- [ ] REST ACL API (`/api/acl/*`)
 
 ### M3–M5
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@
 | [README.md](../README.md) | Обзор, быстрый старт, конфигурация |
 | [packaging/README.md](../packaging/README.md) | Установка из release-пакета |
 | [development.md](development.md) | Сборка, тесты, CI, релиз |
+| [releases/v0.2.3-test.md](releases/v0.2.3-test.md) | **Release notes 0.2.3-test** |
 
 ## Функциональность
 
@@ -36,6 +37,7 @@
 |----------|----------|
 | [docker-compose.yml](../docker-compose.yml) | Полный стек (proxy, Kafka, OpenSearch, monitoring) |
 | [docker-compose.test.yml](../docker-compose.test.yml) | Минимальный стек для smoke-тестов |
+| [docker-compose.redis-l2.yml](../docker-compose.redis-l2.yml) | Демо Redis L2 (2 proxy + Redis) |
 | [OPENSEARCH_UPGRADE.md](../OPENSEARCH_UPGRADE.md) | Обновление OpenSearch |
 | [web-config/README.md](../web-config/README.md) | Web UI для генерации конфигурации |
 
@@ -50,6 +52,9 @@
 
 ## Версии
 
-Текущая beta-версия: **0.2.2b** — [GitHub Releases](https://github.com/onixus/bsdm-proxy/releases)
+| Версия | Тип | Описание |
+|--------|-----|----------|
+| **0.2.3-test** | test pre-release | M2: L2 Redis, HTTP/2 upstream, at-rest compression — [notes](releases/v0.2.3-test.md) |
+| 0.2.2b | beta | Иерархический кеш, optional MITM CA — [GitHub Releases](https://github.com/onixus/bsdm-proxy/releases/tag/v0.2.2b) |
 
-**Новое в 0.2.2b:** иерархический кеш (ICP + peer fetch), optional MITM CA, pre-push hook.
+**Новое в 0.2.3-test:** Redis L2, `UPSTREAM_HTTP2_ENABLED`, `CACHE_COMPRESSION` (zstd/brotli), ACL TimeWindow/group, rate limiting, `ProxyService` в lib.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,7 +230,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 |----|--------|-------|
 | **B21** | Feature flags не в main | `Cargo.toml` features |
 | **B22** | Нет negative caching / refresh | `main.rs` |
-| **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` |
+| **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` | ✅ |
 | **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
 | **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |
 
@@ -301,4 +301,4 @@ flowchart LR
 
 ---
 
-*Версия документа: 0.2.2b · B1–B5 resolved, B6–B25 open*
+*Версия документа: 0.2.3-test · M1 done, M2 ~45% (L2, HTTP/2, compression)*

--- a/docs/development.md
+++ b/docs/development.md
@@ -164,7 +164,7 @@ cargo test -p bsdm-proxy-e2e --test e2e e2e_mitm_https_with_self_signed_ca -- --
 - примерами конфигурации и systemd unit-файлами
 - `install.sh` и `SHA256SUMS`
 
-Версия берётся из `proxy/Cargo.toml` (например `0.2.2-b` → пакет `0.2.2b`).
+Версия берётся из `proxy/Cargo.toml` (например `0.2.3-test` → пакет `0.2.3test`, `0.2.2-b` → `0.2.2b`).
 
 ## Roadmap и milestones
 

--- a/docs/releases/v0.2.3-test.md
+++ b/docs/releases/v0.2.3-test.md
@@ -1,0 +1,77 @@
+# Release v0.2.3-test
+
+**Тип:** тестовый pre-release (M2 progress)  
+**Дата:** 2026-06-29  
+**База:** `main` после merge PR #75–#77
+
+> ⚠️ Версия с суффиксом `-test` предназначена для внутреннего тестирования. Не использовать в production без оценки рисков.
+
+## Что нового
+
+### M2 — Squid parity (частично)
+
+| Функция | Env / модуль | PR |
+|---------|--------------|-----|
+| **Redis L2 cache** | `REDIS_L2_ENABLED`, `docker-compose.redis-l2.yml` | #75 |
+| **HTTP/2 upstream** | `UPSTREAM_HTTP2_ENABLED`, `proxy/src/upstream.rs` | #76 |
+| **At-rest compression** | `CACHE_COMPRESSION=zstd\|brotli`, `proxy/src/cache_compress.rs` | #77 |
+
+### M1 (завершён ранее, включён в пакет)
+
+- Rate limiting per IP/user (`RATE_LIMIT_*`)
+- `ProxyService` в lib (`proxy/src/proxy_service.rs`)
+- ACL TimeWindow + group Principal rules
+- Hierarchy E2E, Prometheus metrics `bsdm_proxy_hierarchy_*`
+- Документация логирования (`docs/logging.md`)
+
+## Переменные окружения (новые)
+
+| Переменная | Default | Описание |
+|-----------|---------|----------|
+| `REDIS_L2_ENABLED` | `false` | Redis L2 между инстансами |
+| `REDIS_URL` | `redis://127.0.0.1:6379` | URL Redis |
+| `REDIS_KEY_PREFIX` | `bsdm:http:` | Префикс ключей L2 |
+| `UPSTREAM_HTTP2_ENABLED` | `false` | ALPN h2 к upstream HTTPS |
+| `CACHE_COMPRESSION` | `off` | `zstd`, `brotli` или `off` |
+| `CACHE_COMPRESS_MIN_BYTES` | `1024` | Мин. размер тела для сжатия |
+| `CACHE_COMPRESS_ZSTD_LEVEL` | `3` | Уровень Zstd |
+
+## Сборка пакета
+
+```bash
+./scripts/build-package.sh
+# → dist/bsdm-proxy-0.2.3test-linux-<arch>.tar.gz
+```
+
+## Установка
+
+```bash
+tar xzf dist/bsdm-proxy-0.2.3test-linux-x86_64.tar.gz
+cd bsdm-proxy-0.2.3test-linux-x86_64
+sudo ./install.sh --create-user --systemd
+```
+
+## Проверка после установки
+
+```bash
+curl http://127.0.0.1:9090/health
+./bin/proxy --version  # если поддерживается; иначе cat VERSION
+cat VERSION            # 0.2.3-test
+```
+
+## Известные ограничения
+
+- NTLM auth не реализован (`AUTH_BACKEND=ntlm` — warn)
+- REST ACL API (`/api/acl/*`) не реализован
+- Negative caching / cache refresh (B22) — не реализовано
+- Hierarchy Phase 4 (discovery, digest, HTCP) — не реализовано
+
+## Миграция с 0.2.2b
+
+1. Остановить сервис: `sudo systemctl stop bsdm-proxy`
+2. Распаковать новый пакет поверх `/opt/bsdm-proxy` или через `install.sh`
+3. Обновить `bsdm-proxy.env` — новые переменные опциональны (defaults безопасны)
+4. При включении L2: поднять Redis, `REDIS_L2_ENABLED=true`
+5. `sudo systemctl start bsdm-proxy`
+
+Старые L2-записи в Redis без `body_encoding` остаются совместимыми.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@
 | **Ретропоиск** | Поиск и аналитика по историческому HTTP-трафику |
 | **ML-безопасность** | Аномалии, фишинг и C&C поверх логов и поведенческих сигналов |
 
-Текущая версия: **0.2.2b** · [Releases](https://github.com/onixus/bsdm-proxy/releases)
+Текущая версия: **0.2.3-test** · [Releases](https://github.com/onixus/bsdm-proxy/releases) · [release notes](releases/v0.2.3-test.md)
 
 ---
 
@@ -21,7 +21,7 @@
 | Milestone | Версия | Фокус | Готовность |
 |-----------|--------|-------|------------|
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability, иерархия | ✅ Done |
-| [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, rate limit, полный ACL, hierarchy Phase 4 | ~10% |
+| [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, rate limit, полный ACL, hierarchy Phase 4 | ~45% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~15% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C beacon detection | ~0% |
@@ -190,12 +190,12 @@ ML-слой для аномалий, фишинга и C&C.
 
 ## Матрица зрелости
 
-| Столп | Сейчас (0.2.2b) | После M2 | После M3 | После M5 |
+| Столп | Сейчас (0.2.3-test) | После M2 | После M3 | После M5 |
 |-------|-----------------|----------|----------|----------|
-| Squid parity | ~45% | ~85% | ~85% | ~90% |
+| Squid parity | ~55% | ~85% | ~85% | ~90% |
 | Ретропоиск | ~15% | ~15% | ~80% | ~90% |
 | ML / C&C / phishing | ~5% | ~5% | ~10% | ~75% |
-| **Целевое состояние** | **~20%** | **~35%** | **~60%** | **~85%** |
+| **Целевое состояние** | **~25%** | **~35%** | **~60%** | **~85%** |
 
 ---
 
@@ -224,4 +224,4 @@ Issues привязывайте к milestones:
 
 ---
 
-*Последнее обновление: M1 завершён (v0.2.3-test)*
+*Последнее обновление: v0.2.3-test (M2 in progress — L2, HTTP/2, compression)*

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,6 +2,8 @@
 
 Установка из готового release-архива. Общая документация: [README.md](../README.md) · [docs/README.md](../docs/README.md)
 
+**Текущая версия пакета:** `0.2.3-test` — [release notes](../docs/releases/v0.2.3-test.md)
+
 ## Contents
 
 | Path | Description |
@@ -11,13 +13,14 @@
 | `config/*.example` | Environment and ACL templates |
 | `systemd/` | systemd unit files |
 | `install.sh` | Installer script |
+| `VERSION` | Package version string |
 | `SHA256SUMS` | Binary checksums |
 
 ## Quick start
 
 ```bash
-tar xzf bsdm-proxy-0.2.2b-linux-x86_64.tar.gz
-cd bsdm-proxy-0.2.2b-linux-x86_64
+tar xzf bsdm-proxy-0.2.3test-linux-x86_64.tar.gz
+cd bsdm-proxy-0.2.3test-linux-x86_64
 sudo ./install.sh --create-user --systemd
 ```
 
@@ -53,6 +56,7 @@ set +a
 curl http://127.0.0.1:9090/health
 curl http://127.0.0.1:9090/ready
 curl http://127.0.0.1:9090/metrics | head
+cat VERSION
 ```
 
 Логи: `journalctl -u bsdm-proxy -f` или см. [docs/logging.md](../docs/logging.md) (`RUST_LOG` в `config/*.env.example`).
@@ -61,7 +65,7 @@ curl http://127.0.0.1:9090/metrics | head
 
 ```bash
 ./scripts/build-package.sh
-# → dist/bsdm-proxy-0.2.2b-linux-<arch>.tar.gz
+# → dist/bsdm-proxy-0.2.3test-linux-<arch>.tar.gz
 ```
 
 См. также [docs/development.md](../docs/development.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Подготовка тестового релиза **0.2.3-test**:

- Новый файл [docs/releases/v0.2.3-test.md](docs/releases/v0.2.3-test.md) — changelog, env, миграция с 0.2.2b
- Обновлены README, docs/README, roadmap, architecture, packaging, development
- Версия в Cargo.toml уже `0.2.3-test` (без изменений в этом PR)

## Release artifact

```bash
./scripts/build-package.sh
# dist/bsdm-proxy-0.2.3test-linux-x86_64.tar.gz (13M)
```

После merge — создать GitHub Release `v0.2.3-test` (pre-release) с tarball.

## Testing

```bash
cargo fmt --all -- --check
cargo test --workspace
./scripts/build-package.sh
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

