### PR TITLE
docs: capacity planning and corporate cache limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш, ICP, peers |
 | [docs/architecture.md](docs/architecture.md) | Архитектура и блокеры |
 | [docs/roadmap.md](docs/roadmap.md) | Roadmap и milestones |
+| [docs/capacity-planning.md](docs/capacity-planning.md) | Планирование ёмкости (корп. сценарии) |
 | [docs/releases/v0.2.3-test.md](docs/releases/v0.2.3-test.md) | Release notes 0.2.3-test |
 | [packaging/README.md](packaging/README.md) | Release-пакет и systemd |
 | [OPTIMIZATIONS.md](OPTIMIZATIONS.md) | Оптимизации v2.0 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 | [packaging/README.md](../packaging/README.md) | Установка из release-пакета |
 | [development.md](development.md) | Сборка, тесты, CI, релиз |
 | [releases/v0.2.3-test.md](releases/v0.2.3-test.md) | **Release notes 0.2.3-test** |
+| [capacity-planning.md](capacity-planning.md) | **Планирование ёмкости (корп. сценарии)** |
 
 ## Функциональность
 

--- a/docs/capacity-planning.md
+++ b/docs/capacity-planning.md
@@ -1,0 +1,48 @@
+# Capacity Planning
+
+Планирование ёмкости для корпоративного развёртывания BSDM-Proxy.
+
+> Wiki (актуальная версия): [Capacity Planning](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning)
+
+## Референс-сценарий
+
+| Параметр | Значение |
+|----------|----------|
+| Пользователи | 5 000 |
+| Серверы | 300 |
+| Hot logs (OpenSearch) | 14 дней |
+| Cold logs | 28 дней (4 недели) |
+| Events/day (medium) | ~4M |
+| Peak RPS | ~330–350 |
+
+## Рекомендуемые лимиты кеша
+
+| Профиль | `CACHE_CAPACITY` | `MAX_CACHE_BODY_SIZE` | `CACHE_TTL` | `CACHE_COMPRESSION` | `REDIS_L2` |
+|---------|------------------|----------------------|-------------|---------------------|------------|
+| Lab / dev (defaults) | 10 000 | 10 MB | 3600 | off | off |
+| Малый prod | 50 000 | 4 MB | 3600 | zstd | optional |
+| **Corporate medium** | **100 000** | **2 MB** | **7200** | **zstd** | **on** |
+| Экономия RAM | 5 000 | 512 KB | 600 | off | off |
+
+```bash
+# Corporate medium — см. packaging/config/bsdm-proxy.env.example
+CACHE_CAPACITY=100000
+MAX_CACHE_BODY_SIZE=2097152
+CACHE_TTL_SECONDS=7200
+CACHE_COMPRESSION=zstd
+CACHE_COMPRESS_MIN_BYTES=8192
+REDIS_L2_ENABLED=true
+```
+
+## Ресурсы (medium, ~4M events/day)
+
+| Компонент | Кол-во | vCPU | RAM | Диск |
+|-----------|--------|------|-----|------|
+| bsdm-proxy | 4 | 8 | 16 GB | 50 GB SSD |
+| Redis L2 | 2 | 4 | 32 GB | 100 GB |
+| Kafka | 3 | 4 | 16 GB | 200 GB |
+| OpenSearch hot | 3 | 8 | 64 GB | 300 GB NVMe |
+| OpenSearch cold | 2 | 4 | 32 GB | 500 GB |
+| **Итого** | — | ~80 | ~350 GB | ~1.3 TB |
+
+Полные формулы, модели нагрузки и риски — на [wiki](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning).

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -7,10 +7,20 @@ METRICS_PORT=9090
 # MITM (requires /certs/ca.key and /certs/ca.crt when enabled)
 MITM_ENABLED=true
 
-# Cache
+# Cache — defaults for lab/dev (see docs/capacity-planning.md for corporate profiles)
 CACHE_CAPACITY=10000
 CACHE_TTL_SECONDS=3600
 MAX_CACHE_BODY_SIZE=10485760
+
+# Corporate medium (5000 users, 300 servers) — uncomment for production:
+# CACHE_CAPACITY=100000
+# MAX_CACHE_BODY_SIZE=2097152
+# CACHE_TTL_SECONDS=7200
+# CACHE_COMPRESSION=zstd
+# CACHE_COMPRESS_MIN_BYTES=8192
+# CACHE_COMPRESS_ZSTD_LEVEL=3
+# REDIS_L2_ENABLED=true
+# REDIS_URL=redis://redis-primary:6379
 
 # At-rest compression for cacheable responses (disabled by default)
 # CACHE_COMPRESSION=zstd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Документация планирования ёмкости для корпоративного сценария (5k users, 300 servers, hot 14d / cold 28d).

- `docs/capacity-planning.md` — краткая сводка + ссылка на wiki
- `packaging/config/bsdm-proxy.env.example` — профиль **Corporate medium** (закомментирован)
- Ссылки в `README.md`, `docs/README.md`

Полная версия на wiki: https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning

## Рекомендуемые лимиты (corporate medium)

| Параметр | Lab default | Corporate |
|----------|-------------|-----------|
| `CACHE_CAPACITY` | 10 000 | **100 000** |
| `MAX_CACHE_BODY_SIZE` | 10 MB | **2 MB** |
| `CACHE_TTL_SECONDS` | 3600 | **7200** |
| `CACHE_COMPRESSION` | off | **zstd** |
| `REDIS_L2_ENABLED` | false | **true** |

Defaults в коде не менялись.

## Testing

Документация only — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

