### PR TITLE
feat(cache): B22 negative caching and Cache-Control revalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,11 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `MITM_ENABLED` | `true` | MITM для портов 443 и 8443 |
 | `KAFKA_BROKERS` | — | Kafka (опционально) |
 | `CACHE_CAPACITY` | `10000` | Размер L1-кеша |
-| `CACHE_TTL_SECONDS` | `3600` | TTL кеша (сек) |
+| `CACHE_TTL_SECONDS` | `3600` | Fallback TTL кеша (сек), если нет `max-age` |
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
+| `NEGATIVE_CACHE_ENABLED` | `true` | Кешировать upstream 403/404 |
+| `NEGATIVE_CACHE_TTL_SECONDS` | `120` | TTL negative cache (сек) |
+| `CACHE_HONOR_CACHE_CONTROL` | `true` | Учитывать `Cache-Control`, ETag, revalidate |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Таймаут graceful shutdown |
 | `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab) |
 | `UPSTREAM_HTTP2_ENABLED` | `false` | HTTP/2 ALPN для upstream HTTPS |
@@ -363,7 +366,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] ACL TimeWindow + group rules
 - [ ] NTLM auth
 - [ ] Hierarchy Phase 4 (discovery, digest, HTCP)
-- [ ] Negative caching / cache refresh (B22)
+- [x] Negative caching / cache refresh (B22) — `Cache-Control`, ETag revalidate, 403/404 negative cache
 - [ ] REST ACL API (`/api/acl/*`)
 
 ### M3–M5

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -50,7 +50,7 @@
 | ID | Issue | Блокер | Статус |
 |----|-------|--------|--------|
 | B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
-| B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ❌ |
+| B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ✅ |
 | B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ✅ |
 | B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |
 | B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,7 +229,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | ID | Блокер | Файлы |
 |----|--------|-------|
 | **B21** | Feature flags не в main | `Cargo.toml` features |
-| **B22** | Нет negative caching / refresh | `main.rs` |
+| **B22** | Negative caching + `Cache-Control` revalidate | `cache_freshness.rs`, `proxy_service.rs` | ✅ |
 | **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` | ✅ |
 | **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
 | **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |

--- a/docs/releases/v0.2.3-test.md
+++ b/docs/releases/v0.2.3-test.md
@@ -63,7 +63,7 @@ cat VERSION            # 0.2.3-test
 
 - NTLM auth не реализован (`AUTH_BACKEND=ntlm` — warn)
 - REST ACL API (`/api/acl/*`) не реализован
-- Negative caching / cache refresh (B22) — не реализовано
+- Negative caching / cache refresh (B22) — `Cache-Control`, ETag revalidate, `NEGATIVE_CACHE_*`
 - Hierarchy Phase 4 (discovery, digest, HTCP) — не реализовано
 
 ## Миграция с 0.2.2b

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,8 +92,8 @@ gantt
   - [x] Group-based Principal rules (LDAP `memberOf` cn matching)
   - [ ] REST API управления ACL (`/api/acl/*` из docs)
 - [ ] **NTLM auth** — реализация или снятие с roadmap
-- [ ] **Negative caching** coordination
-- [ ] **Cache refresh / revalidate** — Squid-style freshness
+- [x] **Negative caching** — upstream 403/404 с коротким TTL (`NEGATIVE_CACHE_*`)
+- [x] **Cache refresh / revalidate** — `Cache-Control`, ETag / `If-Modified-Since`, `304` → `REVALIDATED`
 - [x] Hierarchy Prometheus metrics (`bsdm_proxy_hierarchy_*`)
 
 **Критерий завершения M2:** 3-tier cache hierarchy в docker-compose, hit rate sibling/parent измеряется, Redis L2 работает.

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -11,6 +11,11 @@ MITM_ENABLED=true
 CACHE_CAPACITY=10000
 CACHE_TTL_SECONDS=3600
 MAX_CACHE_BODY_SIZE=10485760
+# Negative caching for upstream 403/404 (short TTL, reduces origin load)
+NEGATIVE_CACHE_ENABLED=true
+NEGATIVE_CACHE_TTL_SECONDS=120
+# Honor Cache-Control / ETag / If-Modified-Since for TTL and revalidation
+CACHE_HONOR_CACHE_CONTROL=true
 
 # Corporate medium (5000 users, 300 servers) — uncomment for production:
 # CACHE_CAPACITY=100000

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -23,6 +23,10 @@ pub struct CachedResponse {
     pub uncompressed_len: usize,
     pub cached_at: SystemTime,
     pub ttl: Duration,
+    pub etag: Option<Arc<str>>,
+    pub last_modified: Option<Arc<str>>,
+    pub is_negative: bool,
+    pub must_revalidate: bool,
 }
 
 impl CachedResponse {
@@ -31,6 +35,24 @@ impl CachedResponse {
         SystemTime::now()
             .duration_since(self.cached_at)
             .map_or(true, |age| age > self.ttl)
+    }
+
+    #[inline]
+    pub fn can_serve_fresh(&self) -> bool {
+        !self.must_revalidate && !self.is_expired()
+    }
+
+    pub fn has_validators(&self) -> bool {
+        self.etag.is_some() || self.last_modified.is_some()
+    }
+
+    /// Refresh metadata after a `304 Not Modified` revalidation.
+    pub fn refreshed_after_not_modified(&self, ttl: Duration) -> Self {
+        let mut updated = self.clone();
+        updated.cached_at = SystemTime::now();
+        updated.ttl = ttl;
+        updated.must_revalidate = false;
+        updated
     }
 
     pub fn response_body_len(&self) -> usize {
@@ -79,12 +101,17 @@ impl CachedResponse {
         response
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn from_upstream(
         status: u16,
         headers: Arc<[(Arc<str>, Arc<str>)]>,
         body: Bytes,
         ttl: Duration,
         compression: &CompressionConfig,
+        etag: Option<Arc<str>>,
+        last_modified: Option<Arc<str>>,
+        is_negative: bool,
+        must_revalidate: bool,
     ) -> Self {
         let prepared = prepare_body_for_cache(body, headers, compression);
         Self {
@@ -95,6 +122,10 @@ impl CachedResponse {
             uncompressed_len: prepared.uncompressed_len,
             cached_at: SystemTime::now(),
             ttl,
+            etag,
+            last_modified,
+            is_negative,
+            must_revalidate,
         }
     }
 }
@@ -105,6 +136,9 @@ pub struct CacheConfig {
     pub default_ttl: Duration,
     pub max_body_size: usize,
     pub compression: CompressionConfig,
+    pub negative_cache_enabled: bool,
+    pub negative_cache_ttl: Duration,
+    pub honor_cache_control: bool,
 }
 
 impl Default for CacheConfig {
@@ -114,6 +148,9 @@ impl Default for CacheConfig {
             default_ttl: Duration::from_secs(3600),
             max_body_size: 10 * 1024 * 1024,
             compression: CompressionConfig::default(),
+            negative_cache_enabled: true,
+            negative_cache_ttl: Duration::from_secs(120),
+            honor_cache_control: true,
         }
     }
 }
@@ -132,12 +169,25 @@ impl CacheConfig {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(10 * 1024 * 1024);
+        let negative_cache_enabled = std::env::var("NEGATIVE_CACHE_ENABLED")
+            .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+            .unwrap_or(true);
+        let negative_cache_ttl_secs = std::env::var("NEGATIVE_CACHE_TTL_SECONDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(120);
+        let honor_cache_control = std::env::var("CACHE_HONOR_CACHE_CONTROL")
+            .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+            .unwrap_or(true);
 
         Self {
             capacity,
             default_ttl: Duration::from_secs(cache_ttl_secs),
             max_body_size,
             compression: CompressionConfig::from_env(),
+            negative_cache_enabled,
+            negative_cache_ttl: Duration::from_secs(negative_cache_ttl_secs),
+            honor_cache_control,
         }
     }
 }
@@ -169,6 +219,10 @@ mod tests {
             body.clone(),
             Duration::from_secs(60),
             &compression,
+            None,
+            None,
+            false,
+            false,
         );
         assert_eq!(cached.body_encoding, BodyEncoding::Zstd);
         let response = cached.to_response();
@@ -176,5 +230,23 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let bytes = rt.block_on(collected).unwrap().to_bytes();
         assert_eq!(bytes, body);
+    }
+
+    #[test]
+    fn can_serve_fresh_respects_must_revalidate() {
+        let cached = CachedResponse {
+            status: 200,
+            headers: Arc::from([]),
+            body: Bytes::new(),
+            body_encoding: BodyEncoding::Raw,
+            uncompressed_len: 0,
+            cached_at: SystemTime::now(),
+            ttl: Duration::from_secs(3600),
+            etag: Some(Arc::from("\"x\"")),
+            last_modified: None,
+            is_negative: false,
+            must_revalidate: true,
+        };
+        assert!(!cached.can_serve_fresh());
     }
 }

--- a/proxy/src/cache_freshness.rs
+++ b/proxy/src/cache_freshness.rs
@@ -1,0 +1,270 @@
+//! HTTP cache freshness: `Cache-Control`, validators, and negative caching.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::cache::{CacheConfig, CACHEABLE_METHODS};
+
+/// Parsed subset of `Cache-Control` relevant to the proxy cache.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CacheControlDirectives {
+    pub no_store: bool,
+    pub no_cache: bool,
+    pub max_age: Option<u64>,
+    pub s_maxage: Option<u64>,
+    pub private: bool,
+}
+
+/// Whether an upstream response may be stored and with what metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CacheStoreDecision {
+    pub store: bool,
+    pub ttl: Duration,
+    pub is_negative: bool,
+    pub must_revalidate: bool,
+    pub etag: Option<Arc<str>>,
+    pub last_modified: Option<Arc<str>>,
+}
+
+impl CacheStoreDecision {
+    pub fn bypass() -> Self {
+        Self {
+            store: false,
+            ttl: Duration::ZERO,
+            is_negative: false,
+            must_revalidate: false,
+            etag: None,
+            last_modified: None,
+        }
+    }
+}
+
+pub fn parse_cache_control(value: &str) -> CacheControlDirectives {
+    let mut directives = CacheControlDirectives::default();
+    for part in value.split(',') {
+        let token = part.trim();
+        if token.is_empty() {
+            continue;
+        }
+        let (name, arg) = token
+            .split_once('=')
+            .map(|(n, v)| (n.trim().to_ascii_lowercase(), Some(v.trim())))
+            .unwrap_or((token.to_ascii_lowercase(), None));
+
+        match name.as_str() {
+            "no-store" => directives.no_store = true,
+            "no-cache" => directives.no_cache = true,
+            "private" => directives.private = true,
+            "max-age" => {
+                if let Some(v) = arg.and_then(|s| s.parse::<u64>().ok()) {
+                    directives.max_age = Some(v);
+                }
+            }
+            "s-maxage" => {
+                if let Some(v) = arg.and_then(|s| s.parse::<u64>().ok()) {
+                    directives.s_maxage = Some(v);
+                }
+            }
+            _ => {}
+        }
+    }
+    directives
+}
+
+pub fn header_value<'a>(headers: &'a HashMap<String, String>, name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.as_str())
+}
+
+pub fn header_value_slice<'a>(headers: &'a [(Arc<str>, Arc<str>)], name: &str) -> Option<&'a str> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.as_ref())
+}
+
+fn is_negative_status(status: u16) -> bool {
+    matches!(status, 403 | 404)
+}
+
+/// Decide whether to store a response and compute freshness metadata.
+pub fn evaluate_store(
+    method: &str,
+    status: u16,
+    headers: &HashMap<String, String>,
+    body_size: usize,
+    config: &CacheConfig,
+) -> CacheStoreDecision {
+    if !CACHEABLE_METHODS.contains(&method) || body_size > config.max_body_size {
+        return CacheStoreDecision::bypass();
+    }
+
+    let cache_control = header_value(headers, "cache-control")
+        .map(parse_cache_control)
+        .unwrap_or_default();
+
+    if cache_control.no_store {
+        return CacheStoreDecision::bypass();
+    }
+
+    // Shared caches must not store private responses unless explicitly allowed.
+    if cache_control.private {
+        return CacheStoreDecision::bypass();
+    }
+
+    let negative = is_negative_status(status);
+    if negative {
+        if !config.negative_cache_enabled {
+            return CacheStoreDecision::bypass();
+        }
+    } else if !crate::cache::CACHEABLE_STATUS_CODES.contains(&status) {
+        return CacheStoreDecision::bypass();
+    }
+
+    let (ttl, must_revalidate) = if negative {
+        (config.negative_cache_ttl, false)
+    } else if config.honor_cache_control {
+        (
+            ttl_from_directives(&cache_control, config.default_ttl),
+            cache_control.no_cache,
+        )
+    } else {
+        (config.default_ttl, false)
+    };
+
+    let etag = header_value(headers, "etag").map(Arc::from);
+    let last_modified = header_value(headers, "last-modified").map(Arc::from);
+
+    CacheStoreDecision {
+        store: true,
+        ttl,
+        is_negative: negative,
+        must_revalidate,
+        etag,
+        last_modified,
+    }
+}
+
+fn ttl_from_directives(directives: &CacheControlDirectives, default_ttl: Duration) -> Duration {
+    if let Some(age) = directives.s_maxage.or(directives.max_age) {
+        return Duration::from_secs(age);
+    }
+    default_ttl
+}
+
+pub fn refresh_ttl_from_headers(
+    headers: &HashMap<String, String>,
+    default_ttl: Duration,
+) -> Duration {
+    let cache_control = header_value(headers, "cache-control")
+        .map(parse_cache_control)
+        .unwrap_or_default();
+    ttl_from_directives(&cache_control, default_ttl)
+}
+
+pub fn has_validators(cached: &crate::cache::CachedResponse) -> bool {
+    cached.etag.is_some() || cached.last_modified.is_some()
+}
+
+pub fn needs_revalidation(cached: &crate::cache::CachedResponse) -> bool {
+    cached.must_revalidate || cached.is_expired()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn default_config() -> CacheConfig {
+        CacheConfig {
+            negative_cache_enabled: true,
+            negative_cache_ttl: Duration::from_secs(120),
+            honor_cache_control: true,
+            ..CacheConfig::default()
+        }
+    }
+
+    #[test]
+    fn parse_cache_control_directives() {
+        let cc = parse_cache_control("private, max-age=3600, no-cache, s-maxage=7200");
+        assert!(cc.private);
+        assert!(cc.no_cache);
+        assert_eq!(cc.max_age, Some(3600));
+        assert_eq!(cc.s_maxage, Some(7200));
+        assert!(!cc.no_store);
+    }
+
+    #[test]
+    fn no_store_bypasses_cache() {
+        let h = headers(&[("Cache-Control", "no-store")]);
+        let decision = evaluate_store("GET", 200, &h, 100, &default_config());
+        assert!(!decision.store);
+    }
+
+    #[test]
+    fn max_age_sets_ttl() {
+        let h = headers(&[("Cache-Control", "max-age=600")]);
+        let decision = evaluate_store("GET", 200, &h, 100, &default_config());
+        assert!(decision.store);
+        assert_eq!(decision.ttl, Duration::from_secs(600));
+        assert!(!decision.is_negative);
+    }
+
+    #[test]
+    fn s_maxage_overrides_max_age() {
+        let h = headers(&[("Cache-Control", "max-age=600, s-maxage=300")]);
+        let decision = evaluate_store("GET", 200, &h, 100, &default_config());
+        assert_eq!(decision.ttl, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn negative_404_cached_when_enabled() {
+        let h = headers(&[]);
+        let decision = evaluate_store("GET", 404, &h, 0, &default_config());
+        assert!(decision.store);
+        assert!(decision.is_negative);
+        assert_eq!(decision.ttl, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn negative_403_cached_when_enabled() {
+        let h = headers(&[]);
+        let decision = evaluate_store("GET", 403, &h, 0, &default_config());
+        assert!(decision.store);
+        assert!(decision.is_negative);
+    }
+
+    #[test]
+    fn negative_disabled_bypasses() {
+        let mut config = default_config();
+        config.negative_cache_enabled = false;
+        let h = headers(&[]);
+        let decision = evaluate_store("GET", 404, &h, 0, &config);
+        assert!(!decision.store);
+    }
+
+    #[test]
+    fn no_cache_sets_must_revalidate() {
+        let h = headers(&[("Cache-Control", "no-cache"), ("ETag", "\"abc\"")]);
+        let decision = evaluate_store("GET", 200, &h, 100, &default_config());
+        assert!(decision.store);
+        assert!(decision.must_revalidate);
+        assert_eq!(decision.etag.as_deref(), Some("\"abc\""));
+    }
+
+    #[test]
+    fn private_response_not_stored() {
+        let h = headers(&[("Cache-Control", "private, max-age=3600")]);
+        let decision = evaluate_store("GET", 200, &h, 100, &default_config());
+        assert!(!decision.store);
+    }
+}

--- a/proxy/src/l2_cache.rs
+++ b/proxy/src/l2_cache.rs
@@ -49,6 +49,14 @@ struct CachedResponseWire {
     uncompressed_len: Option<usize>,
     cached_at_secs: u64,
     ttl_secs: u64,
+    #[serde(default)]
+    etag: Option<String>,
+    #[serde(default)]
+    last_modified: Option<String>,
+    #[serde(default)]
+    is_negative: bool,
+    #[serde(default)]
+    must_revalidate: bool,
 }
 
 impl CachedResponseWire {
@@ -71,6 +79,10 @@ impl CachedResponseWire {
             uncompressed_len: Some(value.uncompressed_len),
             cached_at_secs,
             ttl_secs: value.ttl.as_secs(),
+            etag: value.etag.as_ref().map(|v| v.to_string()),
+            last_modified: value.last_modified.as_ref().map(|v| v.to_string()),
+            is_negative: value.is_negative,
+            must_revalidate: value.must_revalidate,
         })
     }
 
@@ -95,6 +107,10 @@ impl CachedResponseWire {
             uncompressed_len,
             cached_at: UNIX_EPOCH + Duration::from_secs(self.cached_at_secs),
             ttl: Duration::from_secs(self.ttl_secs),
+            etag: self.etag.map(Arc::from),
+            last_modified: self.last_modified.map(Arc::from),
+            is_negative: self.is_negative,
+            must_revalidate: self.must_revalidate,
         })
     }
 }
@@ -162,7 +178,7 @@ impl RedisL2Cache {
         };
 
         let cached = match decode_cached_response(&payload) {
-            Some(v) if !v.is_expired() => v,
+            Some(v) if v.can_serve_fresh() => v,
             Some(_) => {
                 debug!("Redis L2 entry expired for {}", key);
                 self.metrics.cache_l2_misses_total.inc();
@@ -211,6 +227,10 @@ mod tests {
             uncompressed_len: 5,
             cached_at: SystemTime::now(),
             ttl: Duration::from_secs(3600),
+            etag: Some(Arc::from("\"v1\"")),
+            last_modified: Some(Arc::from("Mon, 01 Jan 2024 00:00:00 GMT")),
+            is_negative: false,
+            must_revalidate: false,
         };
         let json = encode_cached_response(&original).unwrap();
         let decoded = decode_cached_response(&json).unwrap();
@@ -237,6 +257,10 @@ mod tests {
             body.clone(),
             Duration::from_secs(3600),
             &compression,
+            None,
+            None,
+            false,
+            false,
         );
         assert_eq!(original.body_encoding, BodyEncoding::Zstd);
         let json = encode_cached_response(&original).unwrap();
@@ -263,6 +287,10 @@ mod tests {
             uncompressed_len: 0,
             cached_at: SystemTime::now(),
             ttl: Duration::from_secs(60),
+            etag: None,
+            last_modified: None,
+            is_negative: false,
+            must_revalidate: false,
         };
         assert!(RedisL2Cache::remaining_ttl_secs(&cached) >= 1);
     }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -4,6 +4,7 @@ pub mod acl;
 pub mod auth;
 pub mod cache;
 pub mod cache_compress;
+pub mod cache_freshness;
 pub mod cache_key;
 pub mod categorization;
 pub mod hierarchy;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let key = http_cache_key("GET", url);
             cache_for_icp
                 .get(&key)
-                .is_some_and(|cached| !cached.is_expired())
+                .is_some_and(|cached| cached.can_serve_fresh())
         })
         .await
         {

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -4,7 +4,9 @@ use base64::engine::general_purpose;
 use base64::Engine;
 use bytes::Bytes;
 use hyper::body::Incoming;
-use hyper::header::{HeaderName, HeaderValue, AUTHORIZATION, LOCATION};
+use hyper::header::{
+    HeaderName, HeaderValue, AUTHORIZATION, IF_MODIFIED_SINCE, IF_NONE_MATCH, LOCATION,
+};
 use hyper::{Request, Response, StatusCode};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
@@ -19,7 +21,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::acl::{AclAction, AclDecision, AclEngine};
 use crate::auth::{AuthManager, UserInfo};
-use crate::cache::{is_cacheable, CacheConfig, CachedResponse, CACHEABLE_METHODS};
+use crate::cache::{CacheConfig, CachedResponse, CACHEABLE_METHODS};
+use crate::cache_freshness::{evaluate_store, refresh_ttl_from_headers};
 use crate::cache_key::http_cache_key;
 use crate::categorization::{CategorizationEngine, Category};
 use crate::hierarchy::{HierarchyManager, HierarchyResult};
@@ -279,17 +282,19 @@ impl ProxyService {
         detailed_metrics: bool,
         guard: &mut Option<RequestMetricsGuard>,
         fast_scope: &mut Option<FastRequestScope>,
+        cache_status_label: &'static str,
+        x_cache_status: &str,
     ) -> Response<Body> {
         if detailed_metrics {
             if let Some(g) = guard.as_mut() {
-                g.set_cache_status("HIT");
+                g.set_cache_status(cache_status_label);
             }
             self.metrics.cache_hits_total.inc();
             self.emit_cache_hit_event(
                 url,
                 method,
                 cache_key,
-                "HIT",
+                cache_status_label,
                 cached,
                 user_id,
                 username,
@@ -301,12 +306,116 @@ impl ProxyService {
             scope.finish_cache_hit();
         }
 
-        let response = cached.to_response();
+        let response = cached.to_response_with_cache_status(x_cache_status);
         let body_size = cached.response_body_len();
         if let Some(g) = guard.take() {
             g.finish(cached.status, 0, body_size);
         }
         response
+    }
+
+    fn build_conditional_request(
+        req: &Request<Incoming>,
+        cached: &CachedResponse,
+    ) -> Option<Request<Body>> {
+        let mut builder = Request::builder()
+            .method(req.method())
+            .uri(req.uri().clone());
+        for (name, value) in req.headers() {
+            builder = builder.header(name, value);
+        }
+        if let Some(etag) = &cached.etag {
+            builder = builder.header(IF_NONE_MATCH, etag.as_ref());
+        }
+        if let Some(lm) = &cached.last_modified {
+            builder = builder.header(IF_MODIFIED_SINCE, lm.as_ref());
+        }
+        builder.body(Body::new(Bytes::new())).ok()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn try_revalidate_stale(
+        &self,
+        cached: &CachedResponse,
+        req: &Request<Incoming>,
+        cache_key: &Arc<str>,
+        url: &str,
+        method: &str,
+        user_id: &Option<String>,
+        username: &Option<String>,
+        client_ip: &str,
+        categories: &[String],
+        request_start: Instant,
+        detailed_metrics: bool,
+        guard: &mut Option<RequestMetricsGuard>,
+        fast_scope: &mut Option<FastRequestScope>,
+    ) -> Option<Response<Body>> {
+        if !self.cache_config.honor_cache_control || !cached.has_validators() {
+            return None;
+        }
+
+        let cond_req = Self::build_conditional_request(req, cached)?;
+        let domain = Self::extract_domain(url);
+        let upstream_start = Instant::now();
+
+        let response = match self.http_client.request(cond_req).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                warn!("Revalidation upstream error for {}: {}", url, e);
+                self.metrics
+                    .upstream_errors_total
+                    .with_label_values(&[&domain, "revalidate"])
+                    .inc();
+                return None;
+            }
+        };
+
+        let upstream_duration = upstream_start.elapsed().as_secs_f64();
+        let status = response.status();
+        self.metrics
+            .upstream_requests_total
+            .with_label_values(&[&domain, &status.as_u16().to_string()])
+            .inc();
+        self.metrics
+            .upstream_duration_seconds
+            .with_label_values(&[&domain])
+            .observe(upstream_duration);
+
+        if status == StatusCode::NOT_MODIFIED {
+            let headers_map: HashMap<String, String> = response
+                .headers()
+                .iter()
+                .filter_map(|(k, v)| {
+                    v.to_str()
+                        .ok()
+                        .map(|v| (k.as_str().to_string(), v.to_string()))
+                })
+                .collect();
+            let ttl = refresh_ttl_from_headers(&headers_map, self.cache_config.default_ttl);
+            let refreshed = cached.refreshed_after_not_modified(ttl);
+            self.store_in_l1_and_l2(cache_key.clone(), refreshed.clone());
+            debug!("Cache REVALIDATED (304): {} {}", method, url);
+            return Some(self.serve_l1_hit(
+                &refreshed,
+                cache_key,
+                url,
+                method,
+                user_id,
+                username,
+                client_ip,
+                categories,
+                request_start,
+                detailed_metrics,
+                guard,
+                fast_scope,
+                "REVALIDATED",
+                "REVALIDATED",
+            ));
+        }
+
+        // Changed response: consume body and fall through to normal miss handling upstream.
+        let _ = http_body_util::BodyExt::collect(response.into_body()).await;
+        None
     }
 
     pub(crate) fn policy_response(decision: &AclDecision) -> Response<Body> {
@@ -536,7 +645,7 @@ impl ProxyService {
 
         if self.perf.fast_cache_hit {
             if let Some(cached) = self.http_cache.get(&cache_key) {
-                if !cached.is_expired() {
+                if cached.can_serve_fresh() {
                     debug!("Cache HIT (fast path): {} {}", method, url);
                     return self.serve_l1_hit(
                         &cached,
@@ -551,6 +660,8 @@ impl ProxyService {
                         false,
                         &mut guard,
                         &mut fast_scope,
+                        "HIT",
+                        "HIT",
                     );
                 }
             }
@@ -598,7 +709,7 @@ impl ProxyService {
                     .observe(cache_lookup_start.elapsed().as_secs_f64());
             }
 
-            if !cached.is_expired() {
+            if cached.can_serve_fresh() {
                 debug!("Cache HIT: {} {}", method, url);
                 return self.serve_l1_hit(
                     &cached,
@@ -613,15 +724,48 @@ impl ProxyService {
                     detailed_metrics,
                     &mut guard,
                     &mut fast_scope,
+                    "HIT",
+                    "HIT",
                 );
+            }
+
+            if let Some(resp) = self
+                .try_revalidate_stale(
+                    &cached,
+                    &req,
+                    &cache_key,
+                    &url,
+                    method,
+                    &user_id,
+                    &username,
+                    &client_ip,
+                    &categories,
+                    request_start,
+                    detailed_metrics,
+                    &mut guard,
+                    &mut fast_scope,
+                )
+                .await
+            {
+                return resp;
             }
         }
 
         if let Some(cached) = self.try_l2_cache_get(&cache_key).await {
             debug!("Cache L2 HIT: {} {}", method, url);
             self.http_cache.insert(cache_key.clone(), cached.clone());
+            let hit_label = if cached.is_negative {
+                "NEGATIVE_HIT"
+            } else {
+                "L2_HIT"
+            };
+            let x_status = if cached.is_negative {
+                "NEGATIVE-HIT"
+            } else {
+                "L2-HIT"
+            };
             if let Some(g) = guard.as_mut() {
-                g.set_cache_status("L2_HIT");
+                g.set_cache_status(hit_label);
                 self.metrics.cache_hits_total.inc();
             }
 
@@ -630,7 +774,7 @@ impl ProxyService {
                     &url,
                     method,
                     &cache_key,
-                    "L2_HIT",
+                    hit_label,
                     &cached,
                     &user_id,
                     &username,
@@ -640,7 +784,7 @@ impl ProxyService {
                 );
             }
 
-            let response = cached.to_response_with_cache_status("L2-HIT");
+            let response = cached.to_response_with_cache_status(x_status);
             let body_size = cached.response_body_len();
             if let Some(g) = guard.take() {
                 g.finish(cached.status, 0, body_size);
@@ -741,12 +885,14 @@ impl ProxyService {
                     hierarchy.record_peer_hit(peer, body_size as u64).await;
                 }
 
-                let cache_status = if is_cacheable(
+                let store_decision = evaluate_store(
                     method,
                     status.as_u16(),
+                    &headers_map,
                     body_size,
-                    self.cache_config.max_body_size,
-                ) {
+                    &self.cache_config,
+                );
+                let cache_status = if store_decision.store {
                     let headers_arc: Arc<[(Arc<str>, Arc<str>)]> = headers_map
                         .iter()
                         .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
@@ -756,14 +902,26 @@ impl ProxyService {
                         status.as_u16(),
                         headers_arc,
                         body_bytes.clone(),
-                        self.cache_config.default_ttl,
+                        store_decision.ttl,
                         &self.cache_config.compression,
+                        store_decision.etag,
+                        store_decision.last_modified,
+                        store_decision.is_negative,
+                        store_decision.must_revalidate,
                     );
                     self.store_in_l1_and_l2(cache_key.clone(), cached_response);
                     if let Some(g) = guard.as_mut() {
-                        g.set_cache_status("MISS");
+                        g.set_cache_status(if store_decision.is_negative {
+                            "NEGATIVE_MISS"
+                        } else {
+                            "MISS"
+                        });
                     }
-                    "MISS"
+                    if store_decision.is_negative {
+                        "NEGATIVE_MISS"
+                    } else {
+                        "MISS"
+                    }
                 } else {
                     self.metrics.cache_bypasses_total.inc();
                     if let Some(g) = guard.as_mut() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Реализует блокер **B22**: Squid-style freshness вместо фиксированного TTL.

- Парсинг `Cache-Control` (`max-age`, `s-maxage`, `no-store`, `no-cache`, `private`)
- Negative cache для upstream **403/404** с коротким TTL
- Revalidation по **ETag** / **Last-Modified** (`If-None-Match`, `If-Modified-Since`)
- Ответ **304** обновляет запись и отдаёт `x-cache-status: REVALIDATED`
- Расширен L2 wire format (обратно совместимый)

## Связанные issue

- Closes #53
- Milestone / блокер: M2, **B22**

## Новые переменные окружения

| Переменная | Default | Описание |
|-----------|---------|----------|
| `NEGATIVE_CACHE_ENABLED` | `true` | Кешировать 403/404 |
| `NEGATIVE_CACHE_TTL_SECONDS` | `120` | TTL negative cache |
| `CACHE_HONOR_CACHE_CONTROL` | `true` | Учитывать Cache-Control и revalidate |

## Testing

```bash
cd proxy && cargo test
cd proxy && cargo clippy -- -D warnings
```

74 unit-теста проходят (включая 9 новых в `cache_freshness`).

## Checklist

- [ ] CI зелёный
- [x] Документация обновлена (README, roadmap, BLOCKERS, env example)
- [x] `docs/BLOCKERS.md` / `docs/roadmap.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

