### PR TITLE
feat(acl): B25 REST ACL API on metrics port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-test",

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallbac
 | `ACL_RULES_PATH` | Путь к JSON с правилами |
 | `ACL_AUTO_RELOAD` | Автоперезагрузка правил |
 | `ACL_RELOAD_INTERVAL` | Интервал перезагрузки (сек) |
+| `ACL_API_TOKEN` | Bearer-токен для REST API `/api/acl/*` (опционально) |
 | `CATEGORIZATION_ENABLED` | Категоризация URL |
 | `SHALLALIST_PATH` | Путь к Shallalist |
 | `CUSTOM_DB_PATH` | Пользовательская БД категорий |
@@ -367,7 +368,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [ ] NTLM auth
 - [ ] Hierarchy Phase 4 (discovery, digest, HTCP)
 - [x] Negative caching / cache refresh (B22) — `Cache-Control`, ETag revalidate, 403/404 negative cache
-- [ ] REST ACL API (`/api/acl/*`)
+- [x] REST ACL API (`/api/acl/*` на порту metrics)
 
 ### M3–M5
 

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -53,7 +53,7 @@
 | B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ✅ |
 | B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ✅ |
 | B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |
-| B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ❌ |
+| B25 | [#56](https://github.com/onixus/bsdm-proxy/issues/56) | Implement or remove REST ACL API | ✅ |
 
 ---
 

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -444,6 +444,10 @@ When `ACL_API_TOKEN` is set, pass `Authorization: Bearer <token>` on all `/api/a
 
 The API is available when `ACL_ENABLED=true` on the metrics port (`METRICS_PORT`, default `9090`).
 
+**Security:** in production set `ACL_API_TOKEN` or restrict network access to `METRICS_PORT` (the API listens on `0.0.0.0`).
+
+**Persistence:** `POST /api/acl/rules` updates the in-memory engine only; rules are not written to `ACL_RULES_PATH`. A subsequent `POST /api/acl/reload` (or `ACL_AUTO_RELOAD`) replaces in-memory rules from the file and drops API-added rules. To make changes permanent, edit the JSON file and call reload.
+
 ---
 
 **See also:**

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -435,6 +435,15 @@ curl http://localhost:9090/api/acl/rules
 curl -X POST http://localhost:9090/api/acl/reload
 ```
 
+Responses:
+- `GET /api/acl/rules` → `{ "count", "default_action", "rules": [...] }`
+- `POST /api/acl/rules` → `201 Created` with rule JSON (or `409` if `id` exists)
+- `POST /api/acl/reload` → `{ "status": "reloaded", "count": N }` (requires `ACL_RULES_PATH`)
+
+When `ACL_API_TOKEN` is set, pass `Authorization: Bearer <token>` on all `/api/acl/*` requests.
+
+The API is available when `ACL_ENABLED=true` on the metrics port (`METRICS_PORT`, default `9090`).
+
 ---
 
 **See also:**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,7 +232,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | **B22** | Negative caching + `Cache-Control` revalidate | `cache_freshness.rs`, `proxy_service.rs` | ✅ |
 | **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` | ✅ |
 | **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |
-| **B25** | REST ACL API документирован, не реализован | `docs/acl.md`, `main.rs` metrics server |
+| **B25** | REST ACL API на metrics port | `acl_api.rs`, `server.rs` | ✅ |
 
 ---
 

--- a/docs/releases/v0.2.3-test.md
+++ b/docs/releases/v0.2.3-test.md
@@ -62,7 +62,7 @@ cat VERSION            # 0.2.3-test
 ## Известные ограничения
 
 - NTLM auth не реализован (`AUTH_BACKEND=ntlm` — warn)
-- REST ACL API (`/api/acl/*`) — реализован на `METRICS_PORT` при `ACL_ENABLED=true`
+- REST ACL API (`/api/acl/*`) не реализован
 - Negative caching / cache refresh (B22) — `Cache-Control`, ETag revalidate, `NEGATIVE_CACHE_*`
 - Hierarchy Phase 4 (discovery, digest, HTCP) — не реализовано
 

--- a/docs/releases/v0.2.3-test.md
+++ b/docs/releases/v0.2.3-test.md
@@ -62,7 +62,7 @@ cat VERSION            # 0.2.3-test
 ## Известные ограничения
 
 - NTLM auth не реализован (`AUTH_BACKEND=ntlm` — warn)
-- REST ACL API (`/api/acl/*`) не реализован
+- REST ACL API (`/api/acl/*`) — реализован на `METRICS_PORT` при `ACL_ENABLED=true`
 - Negative caching / cache refresh (B22) — `Cache-Control`, ETag revalidate, `NEGATIVE_CACHE_*`
 - Hierarchy Phase 4 (discovery, digest, HTCP) — не реализовано
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -90,7 +90,7 @@ gantt
 - [ ] **ACL completeness**
   - [x] TimeWindow rules (`HH:MM`, local time, overnight windows)
   - [x] Group-based Principal rules (LDAP `memberOf` cn matching)
-  - [ ] REST API управления ACL (`/api/acl/*` из docs)
+  - [x] REST API управления ACL (`/api/acl/*` на `METRICS_PORT`)
 - [ ] **NTLM auth** — реализация или снятие с roadmap
 - [x] **Negative caching** — upstream 403/404 с коротким TTL (`NEGATIVE_CACHE_*`)
 - [x] **Cache refresh / revalidate** — `Cache-Control`, ETag / `If-Modified-Since`, `304` → `REVALIDATED`

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -56,6 +56,7 @@ ACL_RULES_PATH=/etc/bsdm-proxy/acl-rules.json
 ACL_AUTO_RELOAD=false
 # ACL_RELOAD_INTERVAL=60
 # Optional Bearer token for REST API on metrics port (/api/acl/*)
+# Strongly recommended in production when ACL_ENABLED=true
 # ACL_API_TOKEN=change-me-in-production
 
 CATEGORIZATION_ENABLED=false

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -55,6 +55,8 @@ ACL_DEFAULT_ACTION=allow
 ACL_RULES_PATH=/etc/bsdm-proxy/acl-rules.json
 ACL_AUTO_RELOAD=false
 # ACL_RELOAD_INTERVAL=60
+# Optional Bearer token for REST API on metrics port (/api/acl/*)
+# ACL_API_TOKEN=change-me-in-production
 
 CATEGORIZATION_ENABLED=false
 # CUSTOM_DB_PATH=/etc/bsdm-proxy/custom-categories.json

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -55,3 +55,4 @@ categorization = ["acl"]
 
 [dev-dependencies]
 tokio-test = "0.4"
+tempfile = "3.14"

--- a/proxy/src/acl.rs
+++ b/proxy/src/acl.rs
@@ -206,6 +206,22 @@ impl AclEngine {
         self.rules.sort_by_key(|b| std::cmp::Reverse(b.priority));
     }
 
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
+    }
+
+    pub fn default_action(&self) -> AclAction {
+        self.default_action
+    }
+
+    pub fn rules(&self) -> &[AclRule] {
+        &self.rules
+    }
+
+    pub fn has_rule(&self, id: &str) -> bool {
+        self.rules.iter().any(|r| r.id == id)
+    }
+
     /// Check if request is allowed (read-mostly; safe under `RwLock` read guard).
     pub fn check_access(
         &self,

--- a/proxy/src/acl_api.rs
+++ b/proxy/src/acl_api.rs
@@ -1,0 +1,368 @@
+//! REST API for runtime ACL management on the metrics/admin port.
+
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper::header::AUTHORIZATION;
+use hyper::{HeaderMap, Method, Request, Response, StatusCode};
+use serde::Serialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use crate::acl::{AclAction, AclEngine, AclRule};
+use crate::acl_config::{load_acl_engine_from_file, parse_acl_action};
+use crate::http_types::Body;
+
+#[derive(Clone)]
+pub struct AclApiConfig {
+    pub default_action: AclAction,
+    pub rules_path: Option<String>,
+    pub api_token: Option<String>,
+}
+
+impl AclApiConfig {
+    pub fn from_env(rules_path: Option<String>) -> Self {
+        let default_action = std::env::var("ACL_DEFAULT_ACTION")
+            .map(|v| parse_acl_action(&v))
+            .unwrap_or(AclAction::Allow);
+        let api_token = std::env::var("ACL_API_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty());
+        Self {
+            default_action,
+            rules_path,
+            api_token,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AclApiState {
+    engine: Arc<RwLock<AclEngine>>,
+    config: AclApiConfig,
+}
+
+impl AclApiState {
+    pub fn new(engine: Arc<RwLock<AclEngine>>, config: AclApiConfig) -> Self {
+        Self { engine, config }
+    }
+
+    pub async fn handle_request(&self, req: Request<Incoming>) -> Response<Body> {
+        let (parts, body) = req.into_parts();
+        let body = match BodyExt::collect(body).await {
+            Ok(collected) => collected.to_bytes(),
+            Err(e) => {
+                warn!("Failed to read ACL API body: {}", e);
+                Bytes::new()
+            }
+        };
+        self.dispatch(&parts.method, parts.uri.path(), body, &parts.headers)
+            .await
+    }
+
+    async fn dispatch(
+        &self,
+        method: &Method,
+        path: &str,
+        body: Bytes,
+        headers: &HeaderMap,
+    ) -> Response<Body> {
+        if !self.is_authorized(headers) {
+            return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
+        }
+
+        match (method, path) {
+            (&Method::GET, "/api/acl/rules") => self.list_rules().await,
+            (&Method::POST, "/api/acl/rules") => self.add_rule_body(body).await,
+            (&Method::POST, "/api/acl/reload") => self.reload_rules().await,
+            _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),
+        }
+    }
+
+    fn is_authorized(&self, headers: &HeaderMap) -> bool {
+        let Some(expected) = &self.config.api_token else {
+            return true;
+        };
+        headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .is_some_and(|token| token == expected)
+    }
+
+    async fn list_rules(&self) -> Response<Body> {
+        let engine = self.engine.read().await;
+        let payload = ListRulesResponse {
+            count: engine.rule_count(),
+            default_action: engine.default_action(),
+            rules: engine.rules().to_vec(),
+        };
+        match serde_json::to_string(&payload) {
+            Ok(body) => json_response(StatusCode::OK, &body),
+            Err(e) => {
+                warn!("Failed to serialize ACL rules: {}", e);
+                json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    r#"{"error":"serialization failed"}"#,
+                )
+            }
+        }
+    }
+
+    async fn add_rule_body(&self, body: Bytes) -> Response<Body> {
+        let rule: AclRule = match serde_json::from_slice(&body) {
+            Ok(rule) => rule,
+            Err(e) => {
+                warn!("Invalid ACL rule JSON: {}", e);
+                return json_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!(
+                        r#"{{"error":"invalid json: {}"}}"#,
+                        escape_json(&e.to_string())
+                    ),
+                );
+            }
+        };
+
+        if rule.id.trim().is_empty() {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"rule id is required"}"#,
+            );
+        }
+
+        let mut engine = self.engine.write().await;
+        if engine.has_rule(&rule.id) {
+            return json_response(
+                StatusCode::CONFLICT,
+                &format!(
+                    r#"{{"error":"rule id already exists: {}"}}"#,
+                    escape_json(&rule.id)
+                ),
+            );
+        }
+
+        info!("ACL API: adding rule {} ({})", rule.id, rule.name);
+        engine.add_rule(rule.clone());
+        match serde_json::to_string(&rule) {
+            Ok(body) => json_response(StatusCode::CREATED, &body),
+            Err(_) => json_response(StatusCode::CREATED, r#"{"status":"created"}"#),
+        }
+    }
+
+    async fn reload_rules(&self) -> Response<Body> {
+        let Some(path) = &self.config.rules_path else {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"ACL_RULES_PATH is not configured"}"#,
+            );
+        };
+
+        match load_acl_engine_from_file(path, self.config.default_action) {
+            Ok(loaded) => {
+                let count = loaded.rule_count();
+                let mut engine = self.engine.write().await;
+                *engine = loaded;
+                info!("ACL API: reloaded {} rules from {}", count, path);
+                json_response(
+                    StatusCode::OK,
+                    &format!(r#"{{"status":"reloaded","count":{count}}}"#),
+                )
+            }
+            Err(e) => {
+                warn!("ACL API reload failed: {}", e);
+                json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
+                )
+            }
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ListRulesResponse {
+    count: usize,
+    default_action: AclAction,
+    rules: Vec<AclRule>,
+}
+
+fn json_response(status: StatusCode, body: &str) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .body(Body::new(Bytes::from(body.to_string())))
+        .unwrap_or_else(|_| {
+            Response::new(Body::new(Bytes::from_static(b"500 Internal Server Error")))
+        })
+}
+
+fn escape_json(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acl::AclEngine;
+    use http_body_util::BodyExt;
+    use hyper::body::Bytes;
+    use hyper::{Method, StatusCode};
+
+    fn test_state() -> AclApiState {
+        let engine = Arc::new(RwLock::new(AclEngine::new(AclAction::Allow)));
+        AclApiState::new(
+            engine,
+            AclApiConfig {
+                default_action: AclAction::Allow,
+                rules_path: None,
+                api_token: None,
+            },
+        )
+    }
+
+    fn test_state_with_token() -> AclApiState {
+        let engine = Arc::new(RwLock::new(AclEngine::new(AclAction::Allow)));
+        AclApiState::new(
+            engine,
+            AclApiConfig {
+                default_action: AclAction::Allow,
+                rules_path: None,
+                api_token: Some("secret-token".to_string()),
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn list_rules_empty() {
+        let state = test_state();
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/acl/rules",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["count"], 0);
+    }
+
+    #[tokio::test]
+    async fn add_rule_via_api() {
+        let state = test_state();
+        let rule_json = br#"{
+            "id": "api-rule",
+            "name": "API rule",
+            "enabled": true,
+            "priority": 50,
+            "action": "deny",
+            "rule_type": { "Domain": "blocked.test" },
+            "redirect_url": null,
+            "comment": null
+        }"#;
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/rules",
+                Bytes::from_static(rule_json),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let list_resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/acl/rules",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        let body = BodyExt::collect(list_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_rule_returns_conflict() {
+        let state = test_state();
+        let rule_json = br#"{
+            "id": "dup",
+            "name": "dup",
+            "enabled": true,
+            "priority": 1,
+            "action": "deny",
+            "rule_type": { "Domain": "x.test" },
+            "redirect_url": null,
+            "comment": null
+        }"#;
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/rules",
+                Bytes::from_static(rule_json),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/rules",
+                Bytes::from_static(rule_json),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn reload_without_path_returns_bad_request() {
+        let state = test_state();
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/reload",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn api_token_required_when_configured() {
+        let state = test_state_with_token();
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/acl/rules",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            hyper::header::HeaderValue::from_static("Bearer secret-token"),
+        );
+        let resp = state
+            .dispatch(&Method::GET, "/api/acl/rules", Bytes::new(), &headers)
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/proxy/src/acl_config.rs
+++ b/proxy/src/acl_config.rs
@@ -1,0 +1,89 @@
+//! Load ACL rules from JSON configuration files.
+
+use crate::acl::{AclAction, AclEngine, AclRule};
+use serde::Deserialize;
+use tracing::info;
+
+pub fn parse_acl_action(value: &str) -> AclAction {
+    match value.to_ascii_lowercase().as_str() {
+        "deny" => AclAction::Deny,
+        "redirect" => AclAction::Redirect,
+        _ => AclAction::Allow,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AclRulesFile {
+    #[serde(default)]
+    default_action: Option<String>,
+    #[serde(default)]
+    rules: Vec<AclRule>,
+}
+
+/// Load ACL engine from a JSON rules file (`default_action` + `rules` array).
+pub fn load_acl_engine_from_file(
+    path: &str,
+    fallback_default: AclAction,
+) -> Result<AclEngine, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read ACL rules file: {}", e))?;
+    let file: AclRulesFile = serde_json::from_str(&content)
+        .map_err(|e| format!("failed to parse ACL rules JSON: {}", e))?;
+
+    let default_action = file
+        .default_action
+        .as_deref()
+        .map(parse_acl_action)
+        .unwrap_or(fallback_default);
+
+    let mut engine = AclEngine::new(default_action);
+    engine.load_rules(file.rules);
+    info!("Loaded {} ACL rules from {}", engine.rule_count(), path);
+    Ok(engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn load_rules_from_json_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"{{
+  "default_action": "deny",
+  "rules": [
+    {{
+      "id": "r1",
+      "name": "block evil",
+      "enabled": true,
+      "priority": 100,
+      "action": "deny",
+      "rule_type": {{ "Domain": "evil.test" }},
+      "redirect_url": null,
+      "comment": null
+    }}
+  ]
+}}"#
+        )
+        .unwrap();
+
+        let engine =
+            load_acl_engine_from_file(file.path().to_str().unwrap(), AclAction::Allow).unwrap();
+        assert_eq!(engine.rule_count(), 1);
+        assert_eq!(engine.default_action(), AclAction::Deny);
+        let decision =
+            engine.check_access("https://evil.test/path", "evil.test", &[], None, &[], None);
+        assert_eq!(decision.action, AclAction::Deny);
+    }
+
+    #[test]
+    fn parse_acl_action_values() {
+        assert_eq!(parse_acl_action("deny"), AclAction::Deny);
+        assert_eq!(parse_acl_action("ALLOW"), AclAction::Allow);
+        assert_eq!(parse_acl_action("redirect"), AclAction::Redirect);
+    }
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -1,6 +1,8 @@
 //! BSDM-Proxy library
 
 pub mod acl;
+pub mod acl_api;
+pub mod acl_config;
 pub mod auth;
 pub mod cache;
 pub mod cache_compress;
@@ -26,6 +28,8 @@ pub mod upstream;
 
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
+pub use acl_api::{AclApiConfig, AclApiState};
+pub use acl_config::{load_acl_engine_from_file, parse_acl_action};
 pub use auth::{AuthBackend, AuthConfig, AuthManager, UserInfo};
 pub use cache::{CacheConfig, CachedResponse};
 pub use cache_compress::{BodyEncoding, CompressionConfig};

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -96,6 +96,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     if acl_api.is_some() {
         info!("ACL REST API enabled on :{}/api/acl/*", metrics_port);
+        if std::env::var("ACL_API_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .is_none()
+        {
+            warn!(
+                "ACL_API_TOKEN is not set — REST API on :{}/api/acl/* is unauthenticated; \
+                set ACL_API_TOKEN or restrict access to METRICS_PORT",
+                metrics_port
+            );
+        }
     }
 
     tokio::spawn(metrics_server(

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -80,11 +80,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(9090);
 
+    let policy_config = load_policy_config();
+    if policy_config.acl_enabled {
+        info!("ACL enabled");
+    }
+    if policy_config.categorization.is_some() {
+        info!("URL categorization enabled");
+    }
+
+    let acl_api = policy_config.acl_engine.as_ref().map(|engine| {
+        Arc::new(bsdm_proxy::AclApiState::new(
+            engine.clone(),
+            bsdm_proxy::AclApiConfig::from_env(policy_config.acl_rules_path.clone()),
+        ))
+    });
+    if acl_api.is_some() {
+        info!("ACL REST API enabled on :{}/api/acl/*", metrics_port);
+    }
+
     tokio::spawn(metrics_server(
         metrics.clone(),
         draining.clone(),
         shutdown_rx.clone(),
         metrics_port,
+        acl_api,
     ));
 
     let mitm_enabled = std::env::var("MITM_ENABLED")
@@ -121,14 +140,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         None
     };
-
-    let policy_config = load_policy_config();
-    if policy_config.acl_enabled {
-        info!("ACL enabled");
-    }
-    if policy_config.categorization.is_some() {
-        info!("URL categorization enabled");
-    }
 
     let proxy_policy = ProxyPolicy {
         acl_engine: policy_config.acl_engine.clone(),

--- a/proxy/src/policy_config.rs
+++ b/proxy/src/policy_config.rs
@@ -1,8 +1,8 @@
 //! Load ACL and categorization configuration from environment variables.
 
-use bsdm_proxy::acl::{AclAction, AclEngine, AclRule};
+use bsdm_proxy::acl::{AclAction, AclEngine};
+use bsdm_proxy::acl_config::{load_acl_engine_from_file, parse_acl_action};
 use bsdm_proxy::categorization::{CategorizationConfig, CategorizationEngine};
-use serde::Deserialize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
@@ -22,39 +22,6 @@ fn env_flag(name: &str) -> bool {
     std::env::var(name)
         .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)
-}
-
-fn parse_acl_action(value: &str) -> AclAction {
-    match value.to_ascii_lowercase().as_str() {
-        "deny" => AclAction::Deny,
-        "redirect" => AclAction::Redirect,
-        _ => AclAction::Allow,
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct AclRulesFile {
-    #[serde(default)]
-    default_action: Option<String>,
-    #[serde(default)]
-    rules: Vec<AclRule>,
-}
-
-fn load_acl_rules(path: &str, fallback_default: AclAction) -> Result<AclEngine, String> {
-    let content = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read ACL rules file: {}", e))?;
-    let file: AclRulesFile = serde_json::from_str(&content)
-        .map_err(|e| format!("failed to parse ACL rules JSON: {}", e))?;
-
-    let default_action = file
-        .default_action
-        .as_deref()
-        .map(parse_acl_action)
-        .unwrap_or(fallback_default);
-
-    let mut engine = AclEngine::new(default_action);
-    engine.load_rules(file.rules);
-    Ok(engine)
 }
 
 fn load_categorization_config() -> CategorizationConfig {
@@ -94,7 +61,7 @@ pub fn load_policy_config() -> PolicyConfig {
 
     let acl_engine = if acl_enabled {
         let engine = if let Some(ref path) = rules_path {
-            match load_acl_rules(path, default_action) {
+            match load_acl_engine_from_file(path, default_action) {
                 Ok(engine) => engine,
                 Err(e) => {
                     warn!("Failed to load ACL rules from {}: {}", path, e);
@@ -129,7 +96,7 @@ pub fn load_policy_config() -> PolicyConfig {
 }
 
 pub fn reload_acl_engine(path: &str, fallback_default: AclAction) -> Result<AclEngine, String> {
-    load_acl_rules(path, fallback_default)
+    load_acl_engine_from_file(path, fallback_default)
 }
 
 #[cfg(test)]

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -22,6 +22,7 @@ use tokio_rustls::TlsAcceptor;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
 
+use crate::acl_api::AclApiState;
 use crate::auth::UserInfo;
 use crate::http_types::Body;
 use crate::metrics::Metrics;
@@ -34,6 +35,7 @@ pub async fn metrics_server(
     draining: Arc<AtomicBool>,
     mut shutdown_rx: watch::Receiver<bool>,
     metrics_port: u16,
+    acl_api: Option<Arc<AclApiState>>,
 ) {
     let bind_addr = format!("0.0.0.0:{}", metrics_port);
     let listener = match TcpListener::bind(&bind_addr).await {
@@ -59,14 +61,22 @@ pub async fn metrics_server(
 
                 let metrics = metrics.clone();
                 let draining = draining.clone();
+                let acl_api = acl_api.clone();
                 tokio::spawn(async move {
                     let io = TokioIo::new(stream);
                     let service = service_fn(move |req: Request<Incoming>| {
                         let metrics = metrics.clone();
                         let draining = draining.clone();
+                        let acl_api = acl_api.clone();
                         async move {
                             let path = req.uri().path();
                             debug!("Metrics request from {}: {}", addr, path);
+
+                            if let Some(api) = &acl_api {
+                                if path.starts_with("/api/acl/") {
+                                    return Ok::<_, Infallible>(api.handle_request(req).await);
+                                }
+                            }
 
                             let response = match path {
                                 "/metrics" => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Реализует блокер **B25**: REST API управления ACL на порту metrics, как описано в `docs/acl.md`.

### Endpoints (`METRICS_PORT`, при `ACL_ENABLED=true`)

| Method | Path | Описание |
|--------|------|----------|
| `GET` | `/api/acl/rules` | Список правил + `default_action` |
| `POST` | `/api/acl/rules` | Добавить правило в память (JSON body) |
| `POST` | `/api/acl/reload` | Перезагрузить из `ACL_RULES_PATH` |

Опционально: `ACL_API_TOKEN` → `Authorization: Bearer <token>`.  
Без токена при старте выводится **warn** в лог.

**Persistence:** `POST` не пишет на диск; `reload` перезаписывает правила из файла.

## Связанные issue

- Closes #56
- Milestone / блокер: M2, **B25**

## Testing

```bash
cd proxy && cargo test
cd proxy && cargo clippy -- -D warnings
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена (README, acl.md, roadmap, BLOCKERS, env)
- [x] `docs/BLOCKERS.md` / `docs/roadmap.md`
- [x] Security/persistence notes в `docs/acl.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

