### PR TITLE
feat(auth): LDAP group enrichment after NTLM/Kerberos

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -100,7 +100,23 @@ NTLM/Kerberos sessions are also keyed by client IP for the handshake duration.
 
 ### Group Membership (LDAP)
 
-LDAP backend extracts user group membership for ACL and analytics. NTLM/Kerberos populate `username`; optional LDAP enrichment can be added in a future release.
+LDAP password backend (`AUTH_BACKEND=ldap`) loads `memberOf` during bind.
+
+For **NTLM** and **Kerberos**, set the same `LDAP_*` variables plus a **service account** (`LDAP_BIND_DN`, `LDAP_BIND_PASSWORD`). After SSO handshake the proxy resolves groups via LDAP (no user password required):
+
+```bash
+export AUTH_BACKEND=ntlm   # or kerberos
+export LDAP_GROUP_ENRICHMENT=true   # default when LDAP_SERVERS is set
+export LDAP_SERVERS=ldaps://dc.corp.local:636
+export LDAP_BASE_DN=dc=corp,dc=local
+export LDAP_BIND_DN=cn=proxy-ldap,ou=services,dc=corp,dc=local
+export LDAP_BIND_PASSWORD=service_secret
+export LDAP_USER_FILTER="(sAMAccountName={username})"
+```
+
+Build with `auth-ldap` plus your SSO feature (or `auth-all`). Principal `user@REALM` is mapped to `sAMAccountName=user`; UPN lookup is tried as fallback.
+
+Enrichment failures are logged; authentication still succeeds with empty groups.
 
 ### Security
 
@@ -137,7 +153,7 @@ services:
       - KRB5_HOSTNAME=proxy.corp.local
 ```
 
-### Active Directory — NTLM (fallback)
+### Active Directory — NTLM with LDAP groups
 
 ```yaml
 services:
@@ -147,11 +163,18 @@ services:
       - AUTH_BACKEND=ntlm
       - NTLM_DOMAIN=CORP
       - NTLM_AUTH_HELPER=/usr/bin/ntlm_auth --helper-protocol=squid-2.5-ntlmssp
+      - LDAP_SERVERS=ldaps://dc.corp.local:636
+      - LDAP_BASE_DN=dc=corp,dc=local
+      - LDAP_BIND_DN=cn=proxy-ldap,ou=services,dc=corp,dc=local
+      - LDAP_BIND_PASSWORD=${LDAP_SERVICE_PASSWORD}
+      - LDAP_USER_FILTER=(sAMAccountName={username})
 ```
+
+Build with `--features auth-all` (or `auth-ntlm,auth-ldap`).
 
 ## Roadmap
 
 - [x] NTLM auth — [#44](https://github.com/onixus/bsdm-proxy/issues/44)
 - [x] Kerberos / SPNEGO with keytab
-- [ ] LDAP group lookup after NTLM/Kerberos principal resolution
+- [x] LDAP group lookup after NTLM/Kerberos principal resolution
 - [ ] Auth Prometheus metrics (`bsdm_proxy_auth_*`)

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -47,12 +47,19 @@ AUTH_ENABLED=false
 # AUTH_BACKEND=basic    # basic (default), ldap, ntlm, kerberos
 # Build: --features auth-ldap | auth-ntlm | auth-kerberos | auth-all
 
-# NTLM (requires --features auth-ntlm)
+# NTLM (requires --features auth-ntlm; add auth-ldap for ACL groups)
 # AUTH_BACKEND=ntlm
 # NTLM_DOMAIN=WORKGROUP
 # NTLM_WORKSTATION=PROXY01
 # NTLM_AUTH_HELPER=/usr/bin/ntlm_auth --helper-protocol=squid-2.5-ntlmssp
 # NTLM_USERS_FILE=/etc/bsdm-proxy/ntlm-users.txt
+# LDAP group enrichment (service bind; requires --features auth-ldap)
+# LDAP_GROUP_ENRICHMENT=true
+# LDAP_SERVERS=ldaps://dc.corp.local:636
+# LDAP_BASE_DN=dc=corp,dc=local
+# LDAP_BIND_DN=cn=proxy-service,ou=services,dc=corp,dc=local
+# LDAP_BIND_PASSWORD=service_password
+# LDAP_USER_FILTER=(sAMAccountName={username})
 
 # Kerberos / SPNEGO (requires --features auth-kerberos)
 # AUTH_BACKEND=kerberos
@@ -62,8 +69,6 @@ AUTH_ENABLED=false
 # KRB5_KDC_URL=tcp://kdc.example.com:88
 # KRB5_MAX_TIME_SKEW_SECONDS=300
 # AUTH_REALM=BSDM-Proxy
-# LDAP_SERVERS=ldap://127.0.0.1:389
-# LDAP_BASE_DN=dc=example,dc=com
 
 # ACL / categorization
 ACL_ENABLED=false

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -106,6 +106,8 @@ pub struct LdapConfig {
     pub group_filter: Option<String>,
     pub timeout: Duration,
     pub use_tls: bool,
+    /// Resolve group membership after NTLM/Kerberos (service bind only; no user password).
+    pub group_enrichment: bool,
 }
 
 #[cfg(feature = "auth-ldap")]
@@ -120,8 +122,29 @@ impl Default for LdapConfig {
             group_filter: Some("(member={user_dn})".to_string()),
             timeout: Duration::from_secs(5),
             use_tls: false,
+            group_enrichment: false,
         }
     }
+}
+
+/// Attributes loaded from LDAP (auth or group enrichment).
+#[cfg(feature = "auth-ldap")]
+#[derive(Debug, Clone, Default)]
+struct LdapUserAttrs {
+    display_name: Option<String>,
+    email: Option<String>,
+    groups: Vec<String>,
+}
+
+/// Account name for LDAP `{username}` filter from an SSO principal (`user@REALM`, `DOMAIN\user`, …).
+#[cfg(feature = "auth-ldap")]
+pub(crate) fn ldap_account_name_from_principal(principal: &str) -> &str {
+    if let Some((_domain, user)) = principal.split_once('\\') {
+        return user;
+    }
+    principal
+        .split_once('@')
+        .map_or(principal, |(user, _)| user)
 }
 
 /// NTLM configuration
@@ -224,6 +247,23 @@ impl AuthManager {
             "Authentication manager initialized with backend: {}",
             config.backend
         );
+
+        #[cfg(feature = "auth-ldap")]
+        if config.enabled && Self::should_enrich_groups_from_ldap_static(&config) {
+            if let Some(ldap) = &config.ldap {
+                if ldap.bind_dn.is_none() || ldap.bind_password.is_none() {
+                    warn!(
+                        "LDAP group enrichment enabled but LDAP_BIND_DN / LDAP_BIND_PASSWORD \
+                         not set — AD lookups may fail"
+                    );
+                }
+            } else {
+                warn!(
+                    "NTLM/Kerberos backend with LDAP_GROUP_ENRICHMENT but no LDAP_SERVERS — \
+                     groups will not be resolved"
+                );
+            }
+        }
 
         #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
         let sspi_engine = build_sspi_engine(&config).map(Arc::new);
@@ -375,13 +415,15 @@ impl AuthManager {
                 display_name,
             }) => {
                 self.handshake_sessions.write().await.remove(client_key);
-                let user = UserInfo {
+                let mut user = UserInfo {
                     username: username.clone(),
                     display_name,
                     email: None,
                     groups: vec![],
                     authenticated_at: Instant::now(),
                 };
+                #[cfg(feature = "auth-ldap")]
+                self.apply_ldap_group_enrichment(&mut user).await;
                 self.principal_cache
                     .write()
                     .await
@@ -497,70 +539,102 @@ impl AuthManager {
         username: &str,
         password: &str,
     ) -> Result<UserInfo, String> {
-        // Connect to LDAP server
         let settings = LdapConnSettings::new().set_conn_timeout(config.timeout);
 
         let mut ldap = LdapConn::with_settings(settings, server)
             .map_err(|e| format!("LDAP connection failed: {}", e))?;
 
-        // Bind with service account if configured
-        if let (Some(bind_dn), Some(bind_password)) = (&config.bind_dn, &config.bind_password) {
-            ldap.simple_bind(bind_dn, bind_password)
-                .map_err(|e| format!("LDAP bind failed: {}", e))?;
-        }
+        ldap_service_bind(&mut ldap, config)?;
 
-        // Search for user
-        let filter = config.user_filter.replace("{username}", username);
-        let result = ldap
-            .search(
-                &config.base_dn,
-                Scope::Subtree,
-                &filter,
-                vec!["cn", "mail", "memberOf"],
-            )
-            .map_err(|e| format!("LDAP search failed: {}", e))?;
+        let entry = ldap_search_user_entry(&mut ldap, config, username, Some(username))?;
 
-        let (entries, _) = result
-            .success()
-            .map_err(|e| format!("LDAP search error: {}", e))?;
-
-        if entries.is_empty() {
-            return Err("User not found".to_string());
-        }
-
-        let entry = SearchEntry::construct(entries[0].clone());
         let user_dn = entry.dn.clone();
-
-        // Authenticate user by binding with their credentials
         ldap.simple_bind(&user_dn, password)
             .map_err(|_| "Invalid credentials".to_string())?;
 
-        // Extract user information
-        let display_name = entry
-            .attrs
-            .get("cn")
-            .and_then(|v| v.first())
-            .map(|s| s.to_string());
-
-        let email = entry
-            .attrs
-            .get("mail")
-            .and_then(|v| v.first())
-            .map(|s| s.to_string());
-
-        let groups = entry
-            .attrs
-            .get("memberOf")
-            .map(|v| v.iter().map(|s| s.to_string()).collect())
-            .unwrap_or_default();
+        let attrs = ldap_attrs_from_entry(&entry);
 
         Ok(UserInfo {
             username: username.to_string(),
-            display_name,
-            email,
-            groups,
+            display_name: attrs.display_name,
+            email: attrs.email,
+            groups: attrs.groups,
             authenticated_at: Instant::now(),
         })
+    }
+
+    /// Merge LDAP `memberOf` (and optional profile fields) after NTLM/Kerberos auth.
+    #[cfg(feature = "auth-ldap")]
+    async fn apply_ldap_group_enrichment(&self, user: &mut UserInfo) {
+        if !self.should_enrich_groups_from_ldap() {
+            return;
+        }
+        let Some(ldap_config) = self.config.ldap.as_ref() else {
+            return;
+        };
+
+        match self
+            .lookup_ldap_user_attrs(ldap_config, &user.username)
+            .await
+        {
+            Ok(attrs) => {
+                if user.display_name.is_none() {
+                    user.display_name = attrs.display_name;
+                }
+                if user.email.is_none() {
+                    user.email = attrs.email;
+                }
+                user.groups = attrs.groups;
+                debug!(
+                    "LDAP enrichment for {}: {} group(s)",
+                    user.username,
+                    user.groups.len()
+                );
+            }
+            Err(e) => {
+                warn!("LDAP group enrichment failed for {}: {}", user.username, e);
+            }
+        }
+    }
+
+    #[cfg(feature = "auth-ldap")]
+    fn should_enrich_groups_from_ldap(&self) -> bool {
+        Self::should_enrich_groups_from_ldap_static(&self.config)
+    }
+
+    #[cfg(feature = "auth-ldap")]
+    fn should_enrich_groups_from_ldap_static(config: &AuthConfig) -> bool {
+        if !config.enabled {
+            return false;
+        }
+        let ldap_enabled = config.ldap.as_ref().is_some_and(|l| l.group_enrichment);
+        if !ldap_enabled {
+            return false;
+        }
+        match config.backend {
+            #[cfg(feature = "auth-ntlm")]
+            AuthBackend::Ntlm => true,
+            #[cfg(feature = "auth-kerberos")]
+            AuthBackend::Kerberos => true,
+            _ => false,
+        }
+    }
+
+    #[cfg(feature = "auth-ldap")]
+    async fn lookup_ldap_user_attrs(
+        &self,
+        config: &LdapConfig,
+        principal: &str,
+    ) -> Result<LdapUserAttrs, String> {
+        for server in &config.servers {
+            match try_ldap_lookup_server(server, config, principal).await {
+                Ok(attrs) => return Ok(attrs),
+                Err(e) => {
+                    ldap_warn!("LDAP lookup on {} failed: {}", server, e);
+                }
+            }
+        }
+        Err("All LDAP servers failed for group enrichment".to_string())
     }
 
     /// Get cached user
@@ -629,6 +703,99 @@ impl AuthManager {
     }
 }
 
+#[cfg(feature = "auth-ldap")]
+fn ldap_service_bind(ldap: &mut LdapConn, config: &LdapConfig) -> Result<(), String> {
+    if let (Some(bind_dn), Some(bind_password)) = (&config.bind_dn, &config.bind_password) {
+        ldap.simple_bind(bind_dn, bind_password)
+            .map_err(|e| format!("LDAP bind failed: {}", e))?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "auth-ldap")]
+fn ldap_attrs_from_entry(entry: &SearchEntry) -> LdapUserAttrs {
+    LdapUserAttrs {
+        display_name: entry
+            .attrs
+            .get("cn")
+            .and_then(|v| v.first())
+            .map(|s| s.to_string()),
+        email: entry
+            .attrs
+            .get("mail")
+            .and_then(|v| v.first())
+            .map(|s| s.to_string()),
+        groups: entry
+            .attrs
+            .get("memberOf")
+            .map(|v| v.iter().map(|s| s.to_string()).collect())
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(feature = "auth-ldap")]
+fn ldap_search_user_entry(
+    ldap: &mut LdapConn,
+    config: &LdapConfig,
+    principal: &str,
+    filter_username: Option<&str>,
+) -> Result<SearchEntry, String> {
+    let account = filter_username.unwrap_or_else(|| ldap_account_name_from_principal(principal));
+    let filter = config.user_filter.replace("{username}", account);
+    let mut entry = ldap_search_first(ldap, config, &filter)?;
+
+    if entry.is_none() && principal.contains('@') {
+        let upn_filter = format!("(userPrincipalName={principal})");
+        entry = ldap_search_first(ldap, config, &upn_filter)?;
+    }
+
+    entry.ok_or_else(|| format!("User not found in LDAP for principal '{principal}'"))
+}
+
+#[cfg(feature = "auth-ldap")]
+fn ldap_search_first(
+    ldap: &mut LdapConn,
+    config: &LdapConfig,
+    filter: &str,
+) -> Result<Option<SearchEntry>, String> {
+    let result = ldap
+        .search(
+            &config.base_dn,
+            Scope::Subtree,
+            filter,
+            vec!["cn", "mail", "memberOf"],
+        )
+        .map_err(|e| format!("LDAP search failed: {}", e))?;
+
+    let (entries, _) = result
+        .success()
+        .map_err(|e| format!("LDAP search error: {}", e))?;
+
+    Ok(entries.first().map(|e| SearchEntry::construct(e.clone())))
+}
+
+#[cfg(feature = "auth-ldap")]
+async fn try_ldap_lookup_server(
+    server: &str,
+    config: &LdapConfig,
+    principal: &str,
+) -> Result<LdapUserAttrs, String> {
+    let settings = LdapConnSettings::new().set_conn_timeout(config.timeout);
+    let server = server.to_string();
+    let config = config.clone();
+    let principal = principal.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        let mut ldap = LdapConn::with_settings(settings, &server)
+            .map_err(|e| format!("LDAP connection failed: {}", e))?;
+        ldap_service_bind(&mut ldap, &config)?;
+        let entry = ldap_search_user_entry(&mut ldap, &config, &principal, None)?;
+        Ok(ldap_attrs_from_entry(&entry))
+    })
+    .await
+    .map_err(|e| format!("LDAP lookup task failed: {}", e))?
+}
+
 #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
 fn build_sspi_engine(config: &AuthConfig) -> Option<SspiAuthEngine> {
     use crate::auth_sspi::{KerberosAuthConfig, NtlmAuthConfig};
@@ -692,6 +859,17 @@ mod tests {
 
         let hash3 = CachedUser::hash_password("different");
         assert_ne!(hash1, hash3);
+    }
+
+    #[cfg(feature = "auth-ldap")]
+    #[test]
+    fn ldap_account_name_from_principal_formats() {
+        assert_eq!(ldap_account_name_from_principal("alice"), "alice");
+        assert_eq!(
+            ldap_account_name_from_principal("alice@CORP.EXAMPLE.COM"),
+            "alice"
+        );
+        assert_eq!(ldap_account_name_from_principal("CORP\\alice"), "alice");
     }
 
     #[tokio::test]

--- a/proxy/src/auth_config.rs
+++ b/proxy/src/auth_config.rs
@@ -2,7 +2,6 @@
 
 use bsdm_proxy::{AuthBackend, AuthConfig};
 use std::time::Duration;
-use tracing::warn;
 
 #[cfg(feature = "auth-ldap")]
 use bsdm_proxy::LdapConfig;
@@ -11,6 +10,13 @@ fn env_flag(name: &str) -> bool {
     std::env::var(name)
         .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)
+}
+
+#[cfg(feature = "auth-ldap")]
+fn env_flag_default_true(name: &str) -> bool {
+    std::env::var(name)
+        .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
+        .unwrap_or(true)
 }
 
 fn parse_backend(value: &str) -> AuthBackend {
@@ -22,7 +28,7 @@ fn parse_backend(value: &str) -> AuthBackend {
             }
             #[cfg(not(feature = "auth-ldap"))]
             {
-                warn!(
+                tracing::warn!(
                     "AUTH_BACKEND=ldap but proxy was built without auth-ldap feature, using basic"
                 );
             }
@@ -34,7 +40,7 @@ fn parse_backend(value: &str) -> AuthBackend {
             }
             #[cfg(not(feature = "auth-ntlm"))]
             {
-                warn!(
+                tracing::warn!(
                     "AUTH_BACKEND=ntlm but proxy was built without auth-ntlm feature, using basic"
                 );
             }
@@ -46,7 +52,7 @@ fn parse_backend(value: &str) -> AuthBackend {
             }
             #[cfg(not(feature = "auth-kerberos"))]
             {
-                warn!(
+                tracing::warn!(
                     "AUTH_BACKEND=kerberos but proxy was built without auth-kerberos feature, using basic"
                 );
             }
@@ -57,11 +63,7 @@ fn parse_backend(value: &str) -> AuthBackend {
 }
 
 #[cfg(feature = "auth-ldap")]
-fn load_ldap_config(enabled: bool, backend: AuthBackend) -> Option<LdapConfig> {
-    if !enabled || backend != AuthBackend::Ldap {
-        return None;
-    }
-
+fn read_ldap_settings_from_env(group_enrichment: bool) -> LdapConfig {
     let servers = std::env::var("LDAP_SERVERS")
         .unwrap_or_else(|_| "ldap://localhost:389".to_string())
         .split(',')
@@ -75,7 +77,7 @@ fn load_ldap_config(enabled: bool, backend: AuthBackend) -> Option<LdapConfig> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(5);
 
-    Some(LdapConfig {
+    LdapConfig {
         servers,
         base_dn: std::env::var("LDAP_BASE_DN").unwrap_or_else(|_| "dc=example,dc=com".to_string()),
         bind_dn: std::env::var("LDAP_BIND_DN").ok(),
@@ -87,7 +89,39 @@ fn load_ldap_config(enabled: bool, backend: AuthBackend) -> Option<LdapConfig> {
             .or_else(|| Some("(member={user_dn})".to_string())),
         timeout: Duration::from_secs(timeout_secs),
         use_tls: env_flag("LDAP_USE_TLS"),
-    })
+        group_enrichment,
+    }
+}
+
+#[cfg(feature = "auth-ldap")]
+fn is_sso_backend(backend: AuthBackend) -> bool {
+    match backend {
+        #[cfg(feature = "auth-ntlm")]
+        AuthBackend::Ntlm => true,
+        #[cfg(feature = "auth-kerberos")]
+        AuthBackend::Kerberos => true,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "auth-ldap")]
+fn load_ldap_config(enabled: bool, backend: AuthBackend) -> Option<LdapConfig> {
+    if !enabled {
+        return None;
+    }
+
+    if backend == AuthBackend::Ldap {
+        return Some(read_ldap_settings_from_env(false));
+    }
+
+    if is_sso_backend(backend)
+        && env_flag_default_true("LDAP_GROUP_ENRICHMENT")
+        && std::env::var("LDAP_SERVERS").is_ok()
+    {
+        return Some(read_ldap_settings_from_env(true));
+    }
+
+    None
 }
 
 pub fn load_auth_config() -> AuthConfig {
@@ -161,5 +195,22 @@ mod tests {
         let config = load_auth_config();
         assert!(!config.enabled);
         assert_eq!(config.backend, AuthBackend::Basic);
+    }
+
+    #[cfg(all(feature = "auth-ldap", feature = "auth-ntlm"))]
+    #[test]
+    fn sso_backend_loads_ldap_when_enrichment_servers_set() {
+        std::env::set_var("AUTH_ENABLED", "true");
+        std::env::set_var("AUTH_BACKEND", "ntlm");
+        std::env::set_var("LDAP_SERVERS", "ldap://dc.example.com");
+        std::env::remove_var("LDAP_GROUP_ENRICHMENT");
+
+        let config = load_auth_config();
+        assert!(config.ldap.is_some());
+        assert!(config.ldap.unwrap().group_enrichment);
+
+        std::env::remove_var("AUTH_ENABLED");
+        std::env::remove_var("AUTH_BACKEND");
+        std::env::remove_var("LDAP_SERVERS");
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves LDAP `memberOf` lookup **after** NTLM/Kerberos SSO authentication so ACL Principal rules with groups work for integrated auth.

### How it works

1. Client completes NTLM/Kerberos handshake → proxy gets principal (`user@REALM`, etc.)
2. If `LDAP_SERVERS` is set and `LDAP_GROUP_ENRICHMENT=true` (default), proxy performs **service bind** (`LDAP_BIND_DN` / `LDAP_BIND_PASSWORD`) and searches AD for `memberOf`
3. Groups merge into `UserInfo` for ACL and analytics
4. Enrichment failure is logged; auth still succeeds (groups may be empty)

### Configuration

```bash
export AUTH_BACKEND=ntlm   # or kerberos
export LDAP_SERVERS=ldaps://dc.corp.local:636
export LDAP_BIND_DN=cn=proxy-ldap,ou=services,dc=corp,dc=local
export LDAP_BIND_PASSWORD=...
export LDAP_USER_FILTER="(sAMAccountName={username})"
# LDAP_GROUP_ENRICHMENT=true   # default when LDAP_SERVERS set
```

Build: `--features auth-all` or `auth-ntlm,auth-ldap` / `auth-kerberos,auth-ldap`.

### Tests

- `cargo test -p bsdm-proxy --features auth-all` — 93 lib + 11 integration ✅
- `cargo clippy --workspace --all-targets -D warnings` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

