### PR TITLE
fix(bench): oha keep-alive вместо curl xargs

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,15 +4,27 @@
 
 ## Baseline (0.3.0, 4 vCPU)
 
-| Сценарий | ~RPS |
-|----------|------|
-| wrk L1 HIT | 56k |
-| wrk L1 MISS | 6.1k |
-| curl HIT | 888 |
+| Сценарий | Инструмент | ~RPS | Примечание |
+|----------|------------|------|------------|
+| L1 HIT | wrk | 52–72k | sustained load, keep-alive |
+| L1 MISS | wrk | 6–8k | уникальные URL (lua) |
+| L1 HIT | **oha** | 50–72k | browser-like keep-alive |
+| L1 MISS | **oha** | 3–6k | `--rand-regex-url`, уникальные path |
+| L1 HIT | ~~curl xargs~~ | ~900 | **устарело** — потолок harness, не прокси |
 
 Цель после perf-режима: **≥110k wrk L1 HIT**.
 
-## Переменные окружения
+### Зависимости бенчмарка
+
+```bash
+# Debian/Ubuntu
+sudo apt install wrk curl
+cargo install oha   # или бинарь с https://github.com/hatoo/oha
+```
+
+Старый curl+xargs harness: `BENCH_LEGACY_CURL=1 ./scripts/run-proxy-benchmark.sh ...`
+
+## Переменные окружения (прокси)
 
 | Переменная | Default | Описание |
 |------------|---------|----------|
@@ -38,9 +50,24 @@ HTTP_PORT=12788 METRICS_PORT=19190 \
 ## Бенчмарк
 
 ```bash
-./scripts/compare-squid-bsdm.sh          # Squid vs BSDM, стандартный wrk/curl
+./scripts/compare-squid-bsdm.sh              # Squid vs BSDM (wrk + oha)
 ./scripts/run-proxy-benchmark.sh HOST:PORT LABEL
+./scripts/run-profile-benchmark.sh           # baseline / perf / corporate
+
+# Corporate auth для wrk/oha:
+export WRK_PROXY_AUTH_HEADER="Proxy-Authorization: Basic $(printf '%s' 'user:pass' | base64 -w0)"
+export CURL_PROXY_USER='user:pass'           # альтернатива
 ```
+
+### Сценарии `run-proxy-benchmark.sh`
+
+| Шаг | Что измеряет |
+|-----|----------------|
+| wrk L1 HIT/MISS | максимальный sustained RPS |
+| oha L1 HIT | keep-alive, N соединений (ближе к браузеру) |
+| oha L1 MISS | уникальные URL, cache cold path |
+
+Переменные: `OHA_CONN_HIT`, `OHA_CONN_MISS`, `OHA_DURATION` (по умолчанию = wrk).
 
 ## Профилирование
 

--- a/scripts/run-profile-benchmark.sh
+++ b/scripts/run-profile-benchmark.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Benchmark baseline / perf / corporate proxy profiles.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+PROXY_PORT=12788
+METRICS_PORT=19190
+BSDM_BIN="$ROOT/target/release/proxy"
+
+kill_proxy() {
+  tmux -f /exec-daemon/tmux.portal.conf kill-session -t bench-proxy 2>/dev/null || true
+  pkill -f 'target/release/proxy' 2>/dev/null || true
+  sleep 1
+}
+
+start_proxy() {
+  local name="$1"
+  shift
+  kill_proxy
+  local env_cmd=""
+  for kv in "$@"; do env_cmd+="$kv "; done
+  tmux -f /exec-daemon/tmux.portal.conf new-session -d -s bench-proxy -c "$ROOT" -- \
+    "${SHELL:-bash}" -lc "${env_cmd} HTTP_PORT=${PROXY_PORT} METRICS_PORT=${METRICS_PORT} ${BSDM_BIN}"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sf "http://127.0.0.1:${METRICS_PORT}/health" >/dev/null 2>&1; then
+      echo "Proxy [$name] ready"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Proxy [$name] failed to start" >&2
+  exit 1
+}
+
+ensure_upstream() {
+  if ! curl -sf http://127.0.0.1:18080/ping >/dev/null 2>&1; then
+    tmux -f /exec-daemon/tmux.portal.conf kill-session -t load-mock 2>/dev/null || true
+    tmux -f /exec-daemon/tmux.portal.conf new-session -d -s load-mock \
+      "python3 ${ROOT}/scripts/mock-upstream-threaded.py"
+    sleep 1
+  fi
+}
+
+run_bench() {
+  local label="$1"
+  unset WRK_PROXY_AUTH_HEADER CURL_PROXY_USER
+  if [[ -n "${2:-}" ]]; then
+    export WRK_PROXY_AUTH_HEADER="$2"
+    export CURL_PROXY_USER="${3:-}"
+  fi
+  "$ROOT/scripts/run-proxy-benchmark.sh" "127.0.0.1:${PROXY_PORT}" "$label" \
+    | tee "/tmp/bench-${label}.txt"
+}
+
+cargo build --release -p bsdm-proxy --bin proxy 2>&1 | tail -2
+ensure_upstream
+
+COMMON="MITM_ENABLED=false HIERARCHY_ENABLED=false RUST_LOG=warn"
+
+echo ""
+echo "========== PROFILE: baseline =========="
+start_proxy baseline "$COMMON"
+run_bench baseline-minimal
+
+echo ""
+echo "========== PROFILE: perf (PERF_FAST_CACHE_HIT) =========="
+start_proxy perf \
+  "$COMMON PERF_FAST_CACHE_HIT=true WORKER_COUNT=1 METRICS_SAMPLE_RATE=100 HTTP_PRESERVE_HEADER_CASE=false"
+run_bench perf-fast
+
+echo ""
+echo "========== PROFILE: corporate (ACL + categorization + auth) =========="
+CORP_AUTH_HDR="Proxy-Authorization: Basic $(printf '%s' 'corpuser:corppass' | base64 -w0)"
+start_proxy corporate \
+  "$COMMON ACL_ENABLED=true ACL_RULES_PATH=${ROOT}/config/acl-rules.example.json ACL_DEFAULT_ACTION=allow CATEGORIZATION_ENABLED=true AUTH_ENABLED=true AUTH_REALM=Corporate PERF_FAST_CACHE_HIT=false HTTP_PRESERVE_HEADER_CASE=true WORKER_COUNT=1"
+curl -fsS -x "http://127.0.0.1:${PROXY_PORT}" -U 'corpuser:corppass' \
+  "http://127.0.0.1:18080/bench-corporate-full-hit" >/dev/null
+run_bench corporate-full "$CORP_AUTH_HDR" 'corpuser:corppass'
+
+kill_proxy
+echo "Done. Results in /tmp/bench-*.txt"

--- a/scripts/run-proxy-benchmark.sh
+++ b/scripts/run-proxy-benchmark.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Run identical wrk/curl benchmarks against a forward proxy.
+# Run wrk + oha (keep-alive) benchmarks against a forward proxy.
+#
+# oha replaces the old curl+xargs harness which capped both BSDM and Squid at ~1k
+# req/s due to per-request process spawn. oha uses persistent connections (browser-like).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -11,51 +14,134 @@ UPSTREAM="${UPSTREAM:-http://127.0.0.1:18080}"
 WRK_CONN_HIT="${WRK_CONN_HIT:-150}"
 WRK_CONN_MISS="${WRK_CONN_MISS:-100}"
 WRK_DURATION="${WRK_DURATION:-30s}"
+OHA_CONN_HIT="${OHA_CONN_HIT:-${WRK_CONN_HIT}}"
+OHA_CONN_MISS="${OHA_CONN_MISS:-${WRK_CONN_MISS}}"
+OHA_DURATION="${OHA_DURATION:-${WRK_DURATION}}"
+# Legacy curl harness (optional, for regression comparison only)
 CURL_REQUESTS="${CURL_REQUESTS:-10000}"
 CURL_WORKERS="${CURL_WORKERS:-80}"
+BENCH_LEGACY_CURL="${BENCH_LEGACY_CURL:-0}"
 
 PROXY="http://${PROXY_HOSTPORT}"
 HIT_URL="${UPSTREAM}/bench-${LABEL}-hit"
 MISS_URL="${UPSTREAM}/bench-${LABEL}-miss"
 
-unset NO_COLOR FORCE_COLOR
+if ! command -v wrk >/dev/null 2>&1; then
+  echo "wrk not found (apt install wrk)" >&2
+  exit 1
+fi
+if [[ "$BENCH_LEGACY_CURL" != "1" ]] && ! command -v oha >/dev/null 2>&1; then
+  echo "oha not found; install with: cargo install oha" >&2
+  echo "Or set BENCH_LEGACY_CURL=1 to use the old curl+xargs harness." >&2
+  exit 1
+fi
+
+unset NO_COLOR FORCE_COLOR CLICOLOR
+
+# Optional proxy auth (corporate profile): WRK_PROXY_AUTH_HEADER or CURL_PROXY_USER=user:pass
+bench_proxy_auth_args() {
+  BENCH_PROXY_AUTH_ARGS=()
+  if [[ -n "${WRK_PROXY_AUTH_HEADER:-}" ]]; then
+    BENCH_PROXY_AUTH_ARGS=(-H "${WRK_PROXY_AUTH_HEADER}")
+    BENCH_OHA_PROXY_HEADER=(--proxy-header "${WRK_PROXY_AUTH_HEADER}")
+  elif [[ -n "${CURL_PROXY_USER:-}" ]]; then
+    local hdr="Proxy-Authorization: Basic $(printf '%s' "${CURL_PROXY_USER}" | base64 -w0)"
+    BENCH_PROXY_AUTH_ARGS=(-H "${hdr}")
+    BENCH_OHA_PROXY_HEADER=(--proxy-header "${hdr}")
+  else
+    BENCH_OHA_PROXY_HEADER=()
+  fi
+}
+
+bench_warm_hit() {
+  if [[ -n "${CURL_PROXY_USER:-}" ]]; then
+    curl -fsS -x "${PROXY}" -U "${CURL_PROXY_USER}" "${HIT_URL}" >/dev/null 2>&1 || true
+  else
+    curl -fsS -x "${PROXY}" "${HIT_URL}" >/dev/null 2>&1 || true
+  fi
+}
+
+run_oha() {
+  local mode="$1"
+  local conn="$2"
+  local -a cmd=(oha -c "${conn}" -z "${OHA_DURATION}" --no-tui -x "${PROXY}")
+  if ((${#BENCH_OHA_PROXY_HEADER[@]})); then
+    cmd+=("${BENCH_OHA_PROXY_HEADER[@]}")
+  fi
+  if [[ "$mode" == "miss" ]]; then
+    # Unique path per request → cache MISS (dots in host are literal in rand_regex)
+    cmd+=(--rand-regex-url "${MISS_URL}/[0-9]{12}")
+    "${cmd[@]}" 2>&1
+  else
+    "${cmd[@]}" "${HIT_URL}" 2>&1
+  fi
+}
+
+print_oha_summary() {
+  grep -E '^(  Success rate:|  Requests/sec:|  Average:|  Slowest:)' || true
+}
+
+run_legacy_curl_hit() {
+  echo ""
+  echo "==> curl HIT [legacy] (${CURL_REQUESTS} req, ${CURL_WORKERS} workers, no keep-alive)"
+  bench_warm_hit
+  local -a auth=()
+  [[ -n "${CURL_PROXY_USER:-}" ]] && auth=(-U "${CURL_PROXY_USER}")
+  local start end rps
+  start=$(date +%s.%N)
+  seq 1 "${CURL_REQUESTS}" | xargs -P "${CURL_WORKERS}" -I{} \
+    curl -sf -o /dev/null -x "${PROXY}" "${auth[@]}" "${HIT_URL}" || true
+  end=$(date +%s.%N)
+  rps=$(awk -v n="${CURL_REQUESTS}" -v s="$start" -v e="$end" 'BEGIN{printf "%.0f", n/(e-s)}')
+  echo "    ~${rps} req/s"
+}
+
+run_legacy_curl_miss() {
+  echo ""
+  echo "==> curl MISS [legacy] (${CURL_REQUESTS} req, ${CURL_WORKERS} workers)"
+  local start end rps
+  start=$(date +%s.%N)
+  export PROXY CURL_PROXY_USER
+  seq 1 "${CURL_REQUESTS}" | xargs -P "${CURL_WORKERS}" -I{} \
+    bash -c 'args=(-sf -o /dev/null -x "$PROXY"); [[ -n "${CURL_PROXY_USER:-}" ]] && args+=(-U "$CURL_PROXY_USER"); curl "${args[@]}" "$1/$2$RANDOM$RANDOM"' _ "${MISS_URL}" x || true
+  end=$(date +%s.%N)
+  rps=$(awk -v n="${CURL_REQUESTS}" -v s="$start" -v e="$end" 'BEGIN{printf "%.0f", n/(e-s)}')
+  echo "    ~${rps} req/s"
+}
+
+bench_proxy_auth_args
 
 echo "############################################"
 echo "# ${LABEL} @ ${PROXY}"
 echo "############################################"
 
-curl -fsS -x "${PROXY}" "${HIT_URL}" >/dev/null 2>&1 || true
+bench_warm_hit
 
 echo ""
 echo "==> wrk L1 HIT (${WRK_DURATION}, ${WRK_CONN_HIT} conn)"
 WRK_TARGET_URL="${HIT_URL}" WRK_MISS_MODE=0 \
   wrk -t4 -c"${WRK_CONN_HIT}" -d"${WRK_DURATION}" \
+    "${BENCH_PROXY_AUTH_ARGS[@]}" \
     -s "${ROOT}/scripts/wrk-proxy.lua" "${PROXY}" 2>&1 \
-  | grep -E 'Requests/sec|Latency|Non-2xx|Socket errors' || true
+  | grep -E 'Requests/sec|Latency|Non-2xx|Socket errors|wrk status' || true
 
 echo ""
 echo "==> wrk L1 MISS (${WRK_DURATION}, ${WRK_CONN_MISS} conn)"
 WRK_TARGET_URL="${HIT_URL}" WRK_MISS_MODE=1 \
   wrk -t4 -c"${WRK_CONN_MISS}" -d"${WRK_DURATION}" \
+    "${BENCH_PROXY_AUTH_ARGS[@]}" \
     -s "${ROOT}/scripts/wrk-proxy.lua" "${PROXY}" 2>&1 \
-  | grep -E 'Requests/sec|Latency|Non-2xx|Socket errors' || true
+  | grep -E 'Requests/sec|Latency|Non-2xx|Socket errors|wrk status' || true
 
 echo ""
-echo "==> curl HIT (${CURL_REQUESTS} req, ${CURL_WORKERS} workers)"
-curl -fsS -x "${PROXY}" "${HIT_URL}" >/dev/null 2>&1 || true
-start=$(date +%s.%N)
-seq 1 "${CURL_REQUESTS}" | xargs -P "${CURL_WORKERS}" -I{} \
-  curl -sf -o /dev/null -x "${PROXY}" "${HIT_URL}" || true
-end=$(date +%s.%N)
-rps=$(awk -v n="${CURL_REQUESTS}" -v s="$start" -v e="$end" 'BEGIN{printf "%.0f", n/(e-s)}')
-echo "    ~${rps} req/s"
+echo "==> oha L1 HIT (${OHA_DURATION}, ${OHA_CONN_HIT} conn, keep-alive)"
+run_oha hit "${OHA_CONN_HIT}" | print_oha_summary
 
 echo ""
-echo "==> curl MISS (${CURL_REQUESTS} req, ${CURL_WORKERS} workers)"
-start=$(date +%s.%N)
-export PROXY
-seq 1 "${CURL_REQUESTS}" | xargs -P "${CURL_WORKERS}" -I{} \
-  bash -c 'curl -sf -o /dev/null -x "$PROXY" "$1/$2$RANDOM$RANDOM"' _ "${MISS_URL}" x || true
-end=$(date +%s.%N)
-rps=$(awk -v n="${CURL_REQUESTS}" -v s="$start" -v e="$end" 'BEGIN{printf "%.0f", n/(e-s)}')
-echo "    ~${rps} req/s"
+echo "==> oha L1 MISS (${OHA_DURATION}, ${OHA_CONN_MISS} conn, unique URLs)"
+run_oha miss "${OHA_CONN_MISS}" | print_oha_summary
+
+if [[ "$BENCH_LEGACY_CURL" == "1" ]]; then
+  run_legacy_curl_hit
+  run_legacy_curl_miss
+fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема

`curl + xargs -P 80` создавал **новый процесс и TCP на каждый запрос** → оба прокси (BSDM и Squid) упирались в **~800–1000 req/s**, создавая ложный «паритет».

## Решение

`run-proxy-benchmark.sh` теперь запускает:

| Сценарий | Инструмент | Смысл |
|----------|------------|--------|
| L1 HIT/MISS | **wrk** | максимальный sustained RPS |
| L1 HIT | **oha** `-c 150 -z 30s` + keep-alive | browser-like |
| L1 MISS | **oha** `--rand-regex-url` | уникальные URL |

### Auth (corporate)

```bash
export WRK_PROXY_AUTH_HEADER="Proxy-Authorization: Basic ..."
# или
export CURL_PROXY_USER='corpuser:corppass'
```

Работает для wrk (`-H`) и oha (`--proxy-header`).

### Legacy

`BENCH_LEGACY_CURL=1` — старый curl harness для сравнения.

## Проверка (v0.3.0, perf profile)

| Сценарий | Было (curl) | Стало (oha) |
|----------|-------------|-------------|
| L1 HIT | ~900 req/s | **~52 800 req/s** |
| wrk HIT | — | ~55 800 req/s (без изменений) |

## Файлы

- `scripts/run-proxy-benchmark.sh` — основной harness
- `scripts/run-profile-benchmark.sh` — baseline / perf / corporate
- `docs/performance.md` — обновлённая документация

## Зависимости

`wrk` (apt), `oha` (`cargo install oha`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

