### PR TITLE
feat(m3): shared event schema and retro-search enrichment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,11 +322,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsdm-events"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bsdm-proxy"
 version = "0.3.0"
 dependencies = [
  "base64",
  "brotli",
+ "bsdm-events",
  "bytes",
  "chrono",
  "hex",
@@ -408,6 +417,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 name = "cache-indexer"
 version = "0.3.0"
 dependencies = [
+ "bsdm-events",
  "bytes",
  "opensearch",
  "rdkafka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,14 @@
 [workspace]
 resolver = "2"
 members = [
+    "bsdm-events",
     "proxy",
     "cache-indexer",
     "e2e",
 ]
 
 [workspace.dependencies]
+bsdm-events = { path = "bsdm-events" }
 tokio = { version = "1", features = ["full"] }
 rdkafka = "0.39"
 serde = { version = "1.0", features = ["derive"] }

--- a/bsdm-events/Cargo.toml
+++ b/bsdm-events/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bsdm-events"
+version = "0.3.0"
+edition = "2021"
+license = "MIT"
+description = "Shared HTTP cache event schema for BSDM-Proxy Kafka pipeline"
+repository = "https://github.com/onixus/bsdm-proxy"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/bsdm-events/src/lib.rs
+++ b/bsdm-events/src/lib.rs
@@ -1,0 +1,190 @@
+//! Shared cache event schema for the Kafka → OpenSearch pipeline.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// HTTP cache / policy event emitted by proxy and indexed by cache-indexer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CacheEvent {
+    pub url: String,
+    pub method: String,
+    pub status: u16,
+    pub cache_key: String,
+    #[serde(default)]
+    pub cache_status: String,
+    pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub headers: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    pub client_ip: String,
+    pub domain: String,
+    pub response_size: u64,
+    pub request_duration_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<String>,
+    /// Feed identifiers: shallalist, urlhaus, phishtank, custom, cache, multiple.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub threat_sources: Vec<String>,
+    /// ACL decision when request was denied or redirected: deny, redirect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_action: Option<String>,
+    #[serde(default)]
+    pub event_id: String,
+}
+
+/// Stable OpenSearch document id for idempotent indexing.
+pub fn document_id(event: &CacheEvent) -> String {
+    if !event.event_id.is_empty() {
+        return event.event_id.clone();
+    }
+
+    format!(
+        "{}:{}:{}:{}",
+        event.timestamp, event.request_duration_ms, event.client_ip, event.cache_key
+    )
+}
+
+/// OpenSearch index mappings for `http-cache` documents.
+pub fn index_mappings() -> serde_json::Value {
+    serde_json::json!({
+        "properties": {
+            "url": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                    }
+                }
+            },
+            "method": { "type": "keyword" },
+            "status": { "type": "short" },
+            "cache_key": { "type": "keyword" },
+            "cache_status": { "type": "keyword" },
+            "timestamp": { "type": "date", "format": "epoch_second" },
+            "headers": { "type": "object" },
+            "user_id": { "type": "keyword" },
+            "username": { "type": "keyword" },
+            "client_ip": { "type": "ip" },
+            "domain": { "type": "keyword" },
+            "response_size": { "type": "long" },
+            "request_duration_ms": { "type": "long" },
+            "content_type": { "type": "keyword" },
+            "user_agent": {
+                "type": "text",
+                "fields": {
+                    "keyword": {
+                        "type": "keyword",
+                        "ignore_above": 256
+                    }
+                }
+            },
+            "categories": { "type": "keyword" },
+            "threat_sources": { "type": "keyword" },
+            "acl_action": { "type": "keyword" },
+            "event_id": { "type": "keyword" }
+        }
+    })
+}
+
+/// Index template body for `http-cache*` indices.
+pub fn index_template_body(index_pattern: &str) -> serde_json::Value {
+    serde_json::json!({
+        "index_patterns": [index_pattern],
+        "template": {
+            "settings": {
+                "number_of_shards": 1,
+                "number_of_replicas": 0
+            },
+            "mappings": index_mappings()
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn document_id_prefers_event_id() {
+        let event = CacheEvent {
+            url: "https://example.com".to_string(),
+            method: "GET".to_string(),
+            status: 200,
+            cache_key: "abc".to_string(),
+            cache_status: "HIT".to_string(),
+            timestamp: 1,
+            headers: HashMap::new(),
+            user_id: None,
+            username: None,
+            client_ip: "127.0.0.1".to_string(),
+            domain: "example.com".to_string(),
+            response_size: 0,
+            request_duration_ms: 5,
+            content_type: None,
+            user_agent: None,
+            categories: vec![],
+            threat_sources: vec![],
+            acl_action: None,
+            event_id: "evt-1".to_string(),
+        };
+        assert_eq!(document_id(&event), "evt-1");
+    }
+
+    #[test]
+    fn deserializes_legacy_proxy_payload() {
+        let json = r#"{
+            "url": "https://example.com",
+            "method": "GET",
+            "status": 200,
+            "cache_key": "key",
+            "cache_status": "MISS",
+            "timestamp": 1700000000,
+            "client_ip": "10.0.0.1",
+            "domain": "example.com",
+            "response_size": 100,
+            "request_duration_ms": 10,
+            "categories": ["malware"],
+            "event_id": "evt-legacy"
+        }"#;
+        let event: CacheEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.categories, vec!["malware"]);
+        assert!(event.threat_sources.is_empty());
+        assert!(event.acl_action.is_none());
+    }
+
+    #[test]
+    fn serializes_policy_event_fields() {
+        let event = CacheEvent {
+            url: "https://evil.com".to_string(),
+            method: "GET".to_string(),
+            status: 403,
+            cache_key: "k".to_string(),
+            cache_status: "BLOCKED".to_string(),
+            timestamp: 1,
+            headers: HashMap::new(),
+            user_id: None,
+            username: Some("alice".to_string()),
+            client_ip: "10.0.0.2".to_string(),
+            domain: "evil.com".to_string(),
+            response_size: 0,
+            request_duration_ms: 3,
+            content_type: None,
+            user_agent: None,
+            categories: vec!["malware".to_string()],
+            threat_sources: vec!["urlhaus".to_string()],
+            acl_action: Some("deny".to_string()),
+            event_id: "evt-block".to_string(),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"acl_action\":\"deny\""));
+        assert!(json.contains("\"threat_sources\":[\"urlhaus\"]"));
+    }
+}

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -14,6 +14,7 @@ name = "cache-indexer"
 path = "src/main.rs"
 
 [dependencies]
+bsdm-events = { workspace = true }
 tokio = { workspace = true }
 rdkafka = { workspace = true }
 serde = { workspace = true }

--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -1,7 +1,9 @@
+use bsdm_events::{document_id, index_mappings, index_template_body, CacheEvent};
 use opensearch::{
     auth::Credentials,
     cert::CertificateValidation,
     http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    indices::{IndicesCreateParts, IndicesExistsParts},
     BulkParts, OpenSearch,
 };
 use rdkafka::{
@@ -9,59 +11,15 @@ use rdkafka::{
     consumer::{CommitMode, Consumer, StreamConsumer},
     message::Message,
 };
-use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
 use std::time::Duration;
 use tracing::{error, info, warn};
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-struct CacheEvent {
-    url: String,
-    method: String,
-    status: u16,
-    cache_key: String,
-    timestamp: u64,
-    #[serde(default)] // ИСПРАВЛЕНИЕ: делаем поле опциональным
-    headers: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    cache_status: Option<String>,
-    // New fields for user analytics
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    username: Option<String>,
-    client_ip: String,
-    domain: String,
-    response_size: u64,
-    request_duration_ms: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    content_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    user_agent: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    categories: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    event_id: Option<String>,
-}
-
-fn document_id(event: &CacheEvent) -> String {
-    if let Some(id) = event.event_id.as_deref() {
-        if !id.is_empty() {
-            return id.to_string();
-        }
-    }
-
-    format!(
-        "{}:{}:{}:{}",
-        event.timestamp, event.request_duration_ms, event.client_ip, event.cache_key
-    )
-}
 
 struct Indexer {
     opensearch: OpenSearch,
     consumer: StreamConsumer,
     index_name: String,
+    index_pattern: String,
 }
 
 impl Indexer {
@@ -87,17 +45,14 @@ impl Indexer {
         consumer.subscribe(&[kafka_topic])?;
         info!("Subscribed to Kafka topic: {}", kafka_topic);
 
-        // Создаём транспорт с аутентификацией
         let mut transport_builder =
             TransportBuilder::new(SingleNodeConnectionPool::new(opensearch_url.parse()?));
 
-        // Добавляем credentials если указаны
         if let (Some(username), Some(password)) = (opensearch_username, opensearch_password) {
             info!("Using authentication for OpenSearch: {}", username);
             transport_builder = transport_builder.auth(Credentials::Basic(username, password));
         }
 
-        // Отключаем проверку SSL если нужно
         if !ssl_verify {
             warn!("SSL certificate verification is disabled!");
             transport_builder = transport_builder.cert_validation(CertificateValidation::None);
@@ -105,54 +60,54 @@ impl Indexer {
 
         let transport = transport_builder.build()?;
         let opensearch = OpenSearch::new(transport);
+        let index_pattern = format!("{index_name}*");
 
         Ok(Self {
             opensearch,
             consumer,
             index_name: index_name.to_string(),
+            index_pattern,
         })
+    }
+
+    async fn ensure_index_template(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let template_name = "bsdm-http-cache";
+        let body = index_template_body(&self.index_pattern);
+
+        match self
+            .opensearch
+            .indices()
+            .put_index_template(opensearch::indices::IndicesPutIndexTemplateParts::Name(
+                template_name,
+            ))
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) if response.status_code().is_success() => {
+                info!(
+                    "Index template '{}' applied for pattern '{}'",
+                    template_name, self.index_pattern
+                );
+                Ok(())
+            }
+            Ok(response) => {
+                warn!(
+                    "Index template upsert returned status {}",
+                    response.status_code()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Failed to upsert index template: {}", e);
+                Ok(())
+            }
+        }
     }
 
     async fn ensure_index_exists(&self) -> Result<(), Box<dyn std::error::Error>> {
         let index_body = json!({
-            "mappings": {
-                "properties": {
-                    "url": {
-                        "type": "text",
-                        "fields": {
-                            "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                            }
-                        }
-                    },
-                    "method": { "type": "keyword" },
-                    "status": { "type": "short" },
-                    "cache_key": { "type": "keyword" },
-                    "cache_status": { "type": "keyword" },
-                    "timestamp": { "type": "date", "format": "epoch_second" },
-                    "headers": { "type": "object" },
-                    // New fields for user analytics
-                    "user_id": { "type": "keyword" },
-                    "username": { "type": "keyword" },
-                    "client_ip": { "type": "ip" },
-                    "domain": { "type": "keyword" },
-                    "response_size": { "type": "long" },
-                    "request_duration_ms": { "type": "long" },
-                    "content_type": { "type": "keyword" },
-                    "user_agent": {
-                        "type": "text",
-                        "fields": {
-                            "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                            }
-                        }
-                    },
-                    "categories": { "type": "keyword" },
-                    "event_id": { "type": "keyword" }
-                }
-            },
+            "mappings": index_mappings(),
             "settings": {
                 "number_of_shards": 1,
                 "number_of_replicas": 0
@@ -162,29 +117,22 @@ impl Indexer {
         match self
             .opensearch
             .indices()
-            .exists(opensearch::indices::IndicesExistsParts::Index(&[
-                &self.index_name
-            ]))
+            .exists(IndicesExistsParts::Index(&[&self.index_name]))
             .send()
             .await
         {
-            Ok(response) => {
-                if response.status_code().is_success() {
-                    info!("Index '{}' already exists", self.index_name);
-                    return Ok(());
-                }
+            Ok(response) if response.status_code().is_success() => {
+                info!("Index '{}' already exists", self.index_name);
+                return Ok(());
             }
-            Err(e) => {
-                warn!("Error checking index existence: {}", e);
-            }
+            Ok(_) => {}
+            Err(e) => warn!("Error checking index existence: {}", e),
         }
 
         match self
             .opensearch
             .indices()
-            .create(opensearch::indices::IndicesCreateParts::Index(
-                &self.index_name,
-            ))
+            .create(IndicesCreateParts::Index(&self.index_name))
             .body(index_body)
             .send()
             .await
@@ -268,12 +216,10 @@ impl Indexer {
                 }
             });
             body_lines.push(serde_json::to_string(&action)?);
-
             body_lines.push(serde_json::to_string(&event)?);
         }
 
         let body_str = body_lines.join("\n") + "\n";
-
         let body = vec![body_str.into_bytes()];
 
         match self
@@ -283,15 +229,15 @@ impl Indexer {
             .send()
             .await
         {
+            Ok(response) if response.status_code().is_success() => {
+                info!("Indexed {} events to OpenSearch", events.len());
+                Ok(())
+            }
             Ok(response) => {
-                if response.status_code().is_success() {
-                    info!("✅ Indexed {} events to OpenSearch", events.len());
-                } else {
-                    warn!(
-                        "Bulk index returned non-success status: {}",
-                        response.status_code()
-                    );
-                }
+                warn!(
+                    "Bulk index returned non-success status: {}",
+                    response.status_code()
+                );
                 Ok(())
             }
             Err(e) => {
@@ -302,6 +248,7 @@ impl Indexer {
     }
 
     async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.ensure_index_template().await?;
         self.ensure_index_exists().await?;
         self.process_events().await
     }
@@ -330,13 +277,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "cache-indexer-group".to_string());
     let index_name = std::env::var("OPENSEARCH_INDEX").unwrap_or_else(|_| "http-cache".to_string());
 
-    info!("🚀 Starting cache-indexer");
-    info!("📡 Kafka brokers: {}", kafka_brokers);
-    info!("🔍 OpenSearch URL: {}", opensearch_url);
-    info!("🔐 SSL verification: {}", ssl_verify);
-    info!("📨 Kafka topic: {}", kafka_topic);
-    info!("👥 Kafka group: {}", kafka_group);
-    info!("📇 OpenSearch index: {}", index_name);
+    info!("Starting cache-indexer");
+    info!("Kafka brokers: {}", kafka_brokers);
+    info!("OpenSearch URL: {}", opensearch_url);
+    info!("SSL verification: {}", ssl_verify);
+    info!("Kafka topic: {}", kafka_topic);
+    info!("Kafka group: {}", kafka_group);
+    info!("OpenSearch index: {}", index_name);
 
     let indexer = Indexer::new(
         &kafka_brokers,
@@ -356,17 +303,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
-    #[test]
-    fn document_id_prefers_event_id() {
-        let event = CacheEvent {
+    fn sample_event(event_id: &str) -> CacheEvent {
+        CacheEvent {
             url: "https://example.com".to_string(),
             method: "GET".to_string(),
             status: 200,
             cache_key: "abc123".to_string(),
+            cache_status: "HIT".to_string(),
             timestamp: 1700000001,
             headers: HashMap::new(),
-            cache_status: Some("HIT".to_string()),
             user_id: None,
             username: None,
             client_ip: "127.0.0.1".to_string(),
@@ -376,37 +323,22 @@ mod tests {
             content_type: None,
             user_agent: None,
             categories: vec!["malware".to_string()],
-            event_id: Some("evt-unique-1".to_string()),
-        };
+            threat_sources: vec!["urlhaus".to_string()],
+            acl_action: None,
+            event_id: event_id.to_string(),
+        }
+    }
 
-        assert_eq!(document_id(&event), "evt-unique-1");
+    #[test]
+    fn document_id_prefers_event_id() {
+        assert_eq!(document_id(&sample_event("evt-unique-1")), "evt-unique-1");
     }
 
     #[test]
     fn document_id_differs_for_same_second_and_cache_key() {
-        let base = CacheEvent {
-            url: "https://example.com".to_string(),
-            method: "GET".to_string(),
-            status: 200,
-            cache_key: "abc123".to_string(),
-            timestamp: 1700000001,
-            headers: HashMap::new(),
-            cache_status: Some("MISS".to_string()),
-            user_id: None,
-            username: None,
-            client_ip: "127.0.0.1".to_string(),
-            domain: "example.com".to_string(),
-            response_size: 100,
-            request_duration_ms: 5,
-            content_type: None,
-            user_agent: None,
-            categories: vec![],
-            event_id: None,
-        };
-
+        let base = sample_event("");
         let mut other = base.clone();
         other.request_duration_ms = 9;
-
         assert_ne!(document_id(&base), document_id(&other));
     }
 
@@ -425,11 +357,15 @@ mod tests {
             "response_size": 512,
             "request_duration_ms": 42,
             "categories": ["phishing", "malware"],
+            "threat_sources": ["phishtank"],
+            "acl_action": "deny",
             "event_id": "evt-proxy-1"
         }"#;
 
         let event: CacheEvent = serde_json::from_str(json_data).unwrap();
         assert_eq!(event.categories, vec!["phishing", "malware"]);
-        assert_eq!(event.event_id.as_deref(), Some("evt-proxy-1"));
+        assert_eq!(event.threat_sources, vec!["phishtank"]);
+        assert_eq!(event.acl_action.as_deref(), Some("deny"));
+        assert_eq!(event.event_id, "evt-proxy-1");
     }
 }

--- a/cache-indexer/tests/integration_test.rs
+++ b/cache-indexer/tests/integration_test.rs
@@ -1,20 +1,10 @@
+use bsdm_events::CacheEvent;
 use serde_json::json;
 use std::collections::HashMap;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
-    struct CacheEvent {
-        url: String,
-        method: String,
-        status: u16,
-        cache_key: String,
-        timestamp: u64,
-        headers: HashMap<String, String>,
-        body: String,
-    }
 
     #[test]
     fn test_cache_event_serialization() {
@@ -26,15 +16,26 @@ mod tests {
             method: "GET".to_string(),
             status: 200,
             cache_key: "abc123".to_string(),
+            cache_status: "MISS".to_string(),
             timestamp: 1234567890,
             headers,
-            body: "test body".to_string(),
+            user_id: None,
+            username: Some("alice".to_string()),
+            client_ip: "10.0.0.1".to_string(),
+            domain: "example.com".to_string(),
+            response_size: 128,
+            request_duration_ms: 12,
+            content_type: Some("application/json".to_string()),
+            user_agent: None,
+            categories: vec!["malware".to_string()],
+            threat_sources: vec!["urlhaus".to_string()],
+            acl_action: None,
+            event_id: "evt-1".to_string(),
         };
 
         let json_str = serde_json::to_string(&event).unwrap();
         assert!(json_str.contains("https://example.com/api"));
-        assert!(json_str.contains("GET"));
-        assert!(json_str.contains("200"));
+        assert!(json_str.contains("\"threat_sources\":[\"urlhaus\"]"));
     }
 
     #[test]
@@ -44,9 +45,14 @@ mod tests {
             "method": "POST",
             "status": 201,
             "cache_key": "key123",
+            "cache_status": "MISS",
             "timestamp": 9876543210,
             "headers": {"X-Custom": "value"},
-            "body": "response body"
+            "client_ip": "10.0.0.2",
+            "domain": "example.com",
+            "response_size": 64,
+            "request_duration_ms": 8,
+            "event_id": "evt-2"
         }"#;
 
         let event: CacheEvent = serde_json::from_str(json_data).unwrap();
@@ -59,96 +65,47 @@ mod tests {
     #[test]
     fn test_opensearch_index_mapping() {
         let mapping = json!({
-            "mappings": {
-                "properties": {
-                    "url": {
-                        "type": "text",
-                        "fields": {
-                            "keyword": {
-                                "type": "keyword",
-                                "ignore_above": 256
-                            }
-                        }
-                    },
-                    "method": { "type": "keyword" },
-                    "status": { "type": "short" },
-                    "cache_key": { "type": "keyword" },
-                    "cache_status": { "type": "keyword" },
-                    "timestamp": { "type": "date", "format": "epoch_second" },
-                    "headers": { "type": "object" },
-                    "user_id": { "type": "keyword" },
-                    "username": { "type": "keyword" },
-                    "client_ip": { "type": "ip" },
-                    "domain": { "type": "keyword" },
-                    "response_size": { "type": "long" },
-                    "request_duration_ms": { "type": "long" },
-                    "content_type": { "type": "keyword" },
-                    "categories": { "type": "keyword" }
-                }
+            "mappings": bsdm_events::index_mappings(),
+            "settings": {
+                "number_of_shards": 1,
+                "number_of_replicas": 0
             }
         });
 
-        assert!(mapping["mappings"]["properties"]["url"]["type"].is_string());
-        assert_eq!(
-            mapping["mappings"]["properties"]["method"]["type"],
-            "keyword"
-        );
-        assert_eq!(mapping["mappings"]["properties"]["status"]["type"], "short");
+        assert!(mapping["mappings"]["properties"]["categories"].is_object());
+        assert!(mapping["mappings"]["properties"]["acl_action"].is_object());
+        assert!(mapping["mappings"]["properties"]["threat_sources"].is_object());
     }
 
     #[test]
-    fn test_bulk_action_format() {
-        let index_name = "http-cache";
-        let document_id = "evt-unique-1".to_string();
-
-        let action = json!({
-            "index": {
-                "_index": index_name,
-                "_id": document_id
-            }
-        });
-
-        assert_eq!(action["index"]["_index"], "http-cache");
-        assert_eq!(action["index"]["_id"], "evt-unique-1");
-    }
-
-    #[test]
-    fn test_ndjson_format() {
-        let mut lines: Vec<String> = Vec::new();
-
-        let action = json!({"index": {"_index": "test"}});
-        let document = json!({"field": "value"});
-
-        lines.push(serde_json::to_string(&action).unwrap());
-        lines.push(serde_json::to_string(&document).unwrap());
-
-        let ndjson = lines.join("\n") + "\n";
-
-        assert!(ndjson.contains("{\"index\":"));
-        assert!(ndjson.contains("{\"field\":"));
-        assert!(ndjson.ends_with("\n"));
-        assert_eq!(ndjson.matches('\n').count(), 2);
-    }
-
-    #[test]
-    fn test_batch_processing() {
-        let batch_size = 50;
+    fn test_batch_processing_logic() {
         let mut batch: Vec<CacheEvent> = Vec::new();
 
-        for i in 0..30 {
+        for i in 0..5 {
             batch.push(CacheEvent {
-                url: format!("https://example.com/api/{}", i),
+                url: format!("https://example{i}.com"),
                 method: "GET".to_string(),
                 status: 200,
-                cache_key: format!("key-{}", i),
+                cache_key: format!("key{i}"),
+                cache_status: "MISS".to_string(),
                 timestamp: 1234567890 + i,
                 headers: HashMap::new(),
-                body: String::new(),
+                user_id: None,
+                username: None,
+                client_ip: "127.0.0.1".to_string(),
+                domain: format!("example{i}.com"),
+                response_size: 0,
+                request_duration_ms: i as u64,
+                content_type: None,
+                user_agent: None,
+                categories: vec![],
+                threat_sources: vec![],
+                acl_action: None,
+                event_id: format!("evt-{i}"),
             });
         }
 
-        assert_eq!(batch.len(), 30);
-        assert!(batch.len() < batch_size);
+        assert_eq!(batch.len(), 5);
     }
 
     #[test]
@@ -158,39 +115,31 @@ mod tests {
     }
 
     #[test]
-    fn test_event_timestamp_validation() {
+    fn test_policy_event_fields() {
         let event = CacheEvent {
-            url: "https://test.com".to_string(),
+            url: "https://blocked.example".to_string(),
             method: "GET".to_string(),
-            status: 200,
-            cache_key: "key".to_string(),
-            timestamp: 1700000000, // Nov 2023
+            status: 403,
+            cache_key: "k".to_string(),
+            cache_status: "BLOCKED".to_string(),
+            timestamp: 1,
             headers: HashMap::new(),
-            body: String::new(),
+            user_id: None,
+            username: Some("bob".to_string()),
+            client_ip: "10.0.0.3".to_string(),
+            domain: "blocked.example".to_string(),
+            response_size: 0,
+            request_duration_ms: 2,
+            content_type: None,
+            user_agent: None,
+            categories: vec!["malware".to_string()],
+            threat_sources: vec!["shallalist".to_string()],
+            acl_action: Some("deny".to_string()),
+            event_id: "evt-block".to_string(),
         };
 
-        // Timestamp should be after 2020
-        assert!(event.timestamp > 1577836800);
-    }
-
-    #[test]
-    fn test_status_code_ranges() {
-        let success_codes = vec![200, 201, 204];
-        let redirect_codes = vec![301, 302, 307];
-        let client_error_codes = vec![400, 401, 404];
-        let server_error_codes = vec![500, 502, 503];
-
-        for code in success_codes {
-            assert!((200..300).contains(&code));
-        }
-        for code in redirect_codes {
-            assert!((300..400).contains(&code));
-        }
-        for code in client_error_codes {
-            assert!((400..500).contains(&code));
-        }
-        for code in server_error_codes {
-            assert!((500..600).contains(&code));
-        }
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"acl_action\":\"deny\""));
+        assert!(json.contains("\"cache_status\":\"BLOCKED\""));
     }
 }

--- a/cache-indexer/tests/integration_test.rs
+++ b/cache-indexer/tests/integration_test.rs
@@ -95,7 +95,7 @@ mod tests {
                 client_ip: "127.0.0.1".to_string(),
                 domain: format!("example{i}.com"),
                 response_size: 0,
-                request_duration_ms: i as u64,
+                request_duration_ms: i,
                 content_type: None,
                 user_agent: None,
                 categories: vec![],

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -28,9 +28,9 @@
 | B7 | [#38](https://github.com/onixus/bsdm-proxy/issues/38) | Refactor ProxyService out of `main.rs` | ✅ |
 | B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path | ❌ |
 | B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | ❌ |
-| B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) | ❌ |
-| B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ❌ |
-| B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ❌ |
+| B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) | ✅ |
+| B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ✅ |
+| B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ✅ |
 | B13 | [#44](https://github.com/onixus/bsdm-proxy/issues/44) | Implement NTLM or remove from docs | ✅ docs |
 | B14 | [#45](https://github.com/onixus/bsdm-proxy/issues/45) | ACL TimeWindow + group rules | ✅ |
 
@@ -39,8 +39,8 @@
 | ID | Issue | Блокер | Статус |
 |----|-------|--------|--------|
 | B15 | [#46](https://github.com/onixus/bsdm-proxy/issues/46) | Design analytics/ML worker service | ❌ |
-| B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics | ❌ |
-| B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | OpenSearch Dashboards in docker-compose | ❌ |
+| B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics | 🔄 |
+| B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | OpenSearch Dashboards in docker-compose | ✅ |
 | B18 | [#49](https://github.com/onixus/bsdm-proxy/issues/49) | Behavioral threat signals (beyond blocklists) | ❌ |
 | B19 | [#50](https://github.com/onixus/bsdm-proxy/issues/50) | Alerting pipeline to SIEM/webhook | ❌ |
 | B20 | [#51](https://github.com/onixus/bsdm-proxy/issues/51) | Security analytics dashboards (historical) | ❌ |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
 |-----------|--------|-------|------------|
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability, иерархия | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, rate limit, полный ACL, hierarchy Phase 4, NTLM/Kerberos | ✅ Done |
-| [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~15% |
+| [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, поиск по истории | ~30% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C beacon detection | ~0% |
 
@@ -110,23 +110,23 @@ gantt
 
 ### Текущий gap
 
-Pipeline Kafka → OpenSearch есть, но:
-- поле `categories` теряется в `cache-indexer`
-- нет OpenSearch Dashboards в стеке
-- нет saved searches и search API
+Pipeline Kafka → OpenSearch работает; в v0.3.0+ добавлены `bsdm-events`, `acl_action`, `threat_sources`, события ACL block.
+Остаётся:
+- ILM / retention policy
+- saved searches + dashboard objects (базовые saved searches есть)
+- search API и session correlation
 
 ### Задачи
 
-- [ ] **Расширить схему событий**
-  - [ ] `categories`, `acl_action`, `threat_sources` в indexer
-  - [ ] OpenSearch index template + mapping
-  - [ ] ILM / retention policy
-- [ ] **OpenSearch Dashboards** в `docker-compose.yml`
+- [x] **Расширить схему событий**
+  - [x] `categories` в indexer (`bsdm-events`)
+  - [x] `acl_action`, `threat_sources` в proxy + indexer
+  - [x] События при ACL deny/redirect
+  - [ ] OpenSearch ILM / retention policy
+- [x] **OpenSearch Dashboards** в `docker-compose.yml`
 - [ ] **Saved searches / playbooks**
-  - [ ] Все запросы пользователя X за период
-  - [ ] Доступ к домену Y
-  - [ ] Blocked + phishing/malware events
-  - [ ] Top domains per user / per IP
+  - [x] Базовые saved searches (user, domain, blocked/threat)
+  - [ ] Dashboard visualizations
 - [ ] **Search API** (опционально) — thin REST поверх OpenSearch
 - [ ] **Session correlation** — `session_id`, redirect chains
 - [ ] **Экспорт** — CSV/JSON для SOC
@@ -195,9 +195,9 @@ ML-слой для аномалий, фишинга и C&C.
 | Столп | Сейчас (0.3.0) | После M3 | После M5 |
 |-------|----------------|----------|----------|
 | Squid parity | ~85% | ~85% | ~90% |
-| Ретропоиск | ~15% | ~80% | ~90% |
+| Ретропоиск | ~30% | ~80% | ~90% |
 | ML / C&C / phishing | ~5% | ~10% | ~75% |
-| **Целевое состояние** | **~35%** | **~60%** | **~85%** |
+| **Целевое состояние** | **~40%** | **~60%** | **~85%** |
 
 ---
 
@@ -226,4 +226,4 @@ Issues привязывайте к milestones:
 
 ---
 
-*Последнее обновление: v0.3.0 (M2 done — hierarchy Phase 4, NTLM/Kerberos, ACL API)*
+*Последнее обновление: M3 in progress — `bsdm-events`, acl_action/threat_sources, index template*

--- a/opensearch-dashboards/setup-saved-objects.sh
+++ b/opensearch-dashboards/setup-saved-objects.sh
@@ -63,8 +63,8 @@ upsert_saved_object "search" "requests-by-domain" \
     '["timestamp","username","client_ip","domain","url","method","status","cache_status"]')"
 
 upsert_saved_object "search" "blocked-threat-events" \
-  "$(search_body "Blocked and threat categories" "cache_status:BYPASS OR categories:*" \
-    '["timestamp","username","client_ip","domain","url","cache_status","categories"]')"
+  "$(search_body "Blocked and threat categories" "acl_action:deny OR acl_action:redirect OR categories:*" \
+    '["timestamp","username","client_ip","domain","url","acl_action","cache_status","categories","threat_sources"]')"
 
 upsert_saved_object "search" "top-domains-overview" \
   "$(search_body "Traffic overview by domain" "*" \

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -36,6 +36,7 @@ CACHE_HONOR_CACHE_CONTROL=true
 # Kafka (optional — cache events)
 # KAFKA_BROKERS=127.0.0.1:9092
 # KAFKA_TOPIC=cache-events
+# KAFKA_ACKS=1
 
 # Graceful shutdown
 SHUTDOWN_TIMEOUT_SECONDS=30

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -9,6 +9,7 @@ name = "proxy"
 path = "src/main.rs"
 
 [dependencies]
+bsdm-events = { workspace = true }
 hyper = { version = "1.10", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -40,6 +40,7 @@ pub use auth::KerberosConfig;
 #[cfg(feature = "auth-ntlm")]
 pub use auth::NtlmConfig;
 pub use auth::{AuthBackend, AuthConfig, AuthManager, ProxyAuthOutcome, UserInfo};
+pub use bsdm_events::CacheEvent;
 pub use cache::{CacheConfig, CachedResponse};
 pub use cache_compress::{BodyEncoding, CompressionConfig};
 pub use cache_digest::DigestRegistry;
@@ -58,7 +59,6 @@ pub use peer_discovery::{run_peer_discovery, PeerDiscoveryConfig};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
 pub use perf::{bind_http_listeners, PerfConfig};
-pub use pipeline::CacheEvent;
 pub use proxy_service::{ProxyPolicy, ProxyService};
 pub use rate_limit::{RateLimitConfig, RateLimitViolation, RateLimiter};
 pub use selection::{parse_strategy, SelectionStrategy};

--- a/proxy/src/pipeline.rs
+++ b/proxy/src/pipeline.rs
@@ -2,53 +2,27 @@
 
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
-use serde::Serialize;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, warn};
 
 use crate::metrics::Metrics;
 
-#[derive(Serialize, Clone, Debug)]
-pub struct CacheEvent {
-    pub url: String,
-    pub method: String,
-    pub status: u16,
-    pub cache_key: String,
-    pub cache_status: &'static str,
-    pub timestamp: u64,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub headers: HashMap<String, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub username: Option<String>,
-    pub client_ip: String,
-    pub domain: String,
-    pub response_size: u64,
-    pub request_duration_ms: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub content_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub categories: Vec<String>,
-    pub event_id: String,
-}
+pub use bsdm_events::CacheEvent;
 
 pub fn new_event_id() -> String {
     hex::encode(rand::random::<u128>().to_be_bytes())
 }
 
 pub fn create_kafka_producer(brokers: &str) -> Option<Arc<FutureProducer>> {
+    let acks = std::env::var("KAFKA_ACKS").unwrap_or_else(|_| "1".to_string());
     ClientConfig::new()
         .set("bootstrap.servers", brokers)
         .set("message.timeout.ms", "5000")
         .set("compression.type", "snappy")
         .set("batch.size", "32768")
         .set("linger.ms", "5")
-        .set("acks", "1")
+        .set("acks", &acks)
         .create()
         .ok()
         .map(Arc::new)

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -25,7 +25,7 @@ use crate::cache::{CacheConfig, CachedResponse, CACHEABLE_METHODS};
 use crate::cache_digest::DigestRegistry;
 use crate::cache_freshness::{evaluate_store, refresh_ttl_from_headers};
 use crate::cache_key::http_cache_key;
-use crate::categorization::{CategorizationEngine, Category};
+use crate::categorization::CategorizationEngine;
 use crate::hierarchy::{HierarchyManager, HierarchyResult};
 use crate::http_types::Body;
 use crate::l2_cache::RedisL2Cache;
@@ -147,6 +147,7 @@ impl ProxyService {
         username: &Option<String>,
         client_ip: &str,
         categories: &[String],
+        threat_sources: &[String],
         request_start: Instant,
     ) {
         if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
@@ -155,7 +156,7 @@ impl ProxyService {
                 method: method.to_string(),
                 status: cached.status,
                 cache_key: cache_key.to_string(),
-                cache_status,
+                cache_status: cache_status.to_string(),
                 timestamp: timestamp.as_secs(),
                 headers: HashMap::new(),
                 user_id: user_id.clone(),
@@ -171,6 +172,54 @@ impl ProxyService {
                     .map(|(_, v)| v.to_string()),
                 user_agent: None,
                 categories: categories.to_vec(),
+                threat_sources: threat_sources.to_vec(),
+                acl_action: None,
+                event_id: new_event_id(),
+            };
+            self.send_cache_event(event);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn emit_policy_event(
+        &self,
+        url: &str,
+        method: &str,
+        cache_key: &str,
+        decision: &AclDecision,
+        user_id: &Option<String>,
+        username: &Option<String>,
+        client_ip: &str,
+        domain: &str,
+        categories: &[String],
+        threat_sources: &[String],
+        request_start: Instant,
+    ) {
+        if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+            let status = match decision.action {
+                AclAction::Deny => 403,
+                AclAction::Redirect => 302,
+                AclAction::Allow => 200,
+            };
+            let event = CacheEvent {
+                url: url.to_string(),
+                method: method.to_string(),
+                status,
+                cache_key: cache_key.to_string(),
+                cache_status: "BLOCKED".to_string(),
+                timestamp: timestamp.as_secs(),
+                headers: HashMap::new(),
+                user_id: user_id.clone(),
+                username: username.clone(),
+                client_ip: client_ip.to_string(),
+                domain: domain.to_string(),
+                response_size: 0,
+                request_duration_ms: request_start.elapsed().as_millis() as u64,
+                content_type: None,
+                user_agent: None,
+                categories: categories.to_vec(),
+                threat_sources: threat_sources.to_vec(),
+                acl_action: Some(decision.action.to_string()),
                 event_id: new_event_id(),
             };
             self.send_cache_event(event);
@@ -200,17 +249,23 @@ impl ProxyService {
         }
     }
 
-    async fn categorize_url(&self, url: &str) -> Vec<String> {
+    async fn categorize_url(&self, url: &str) -> (Vec<String>, Vec<String>) {
         let Some(engine) = &self.categorization else {
-            return Vec::new();
+            return (Vec::new(), Vec::new());
         };
         let result = engine.categorize(url).await;
-        result
+        let categories: Vec<String> = result
             .categories
             .iter()
-            .map(Category::acl_name)
+            .map(crate::categorization::Category::acl_name)
             .filter(|name| !name.is_empty())
-            .collect()
+            .collect();
+        let threat_sources = if result.source != "unknown" && !categories.is_empty() {
+            vec![result.source]
+        } else {
+            Vec::new()
+        };
+        (categories, threat_sources)
     }
 
     async fn check_acl(
@@ -270,12 +325,12 @@ impl ProxyService {
         username: Option<&str>,
         groups: &[&str],
         client_ip: &str,
-    ) -> (Option<AclDecision>, Vec<String>) {
-        let category_names = self.categorize_url(url).await;
+    ) -> (Option<AclDecision>, Vec<String>, Vec<String>) {
+        let (category_names, threat_sources) = self.categorize_url(url).await;
         let decision = self
             .check_acl(url, domain, &category_names, username, groups, client_ip)
             .await;
-        (decision, category_names)
+        (decision, category_names, threat_sources)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -289,6 +344,7 @@ impl ProxyService {
         username: &Option<String>,
         client_ip: &str,
         categories: &[String],
+        threat_sources: &[String],
         request_start: Instant,
         detailed_metrics: bool,
         guard: &mut Option<RequestMetricsGuard>,
@@ -311,6 +367,7 @@ impl ProxyService {
                 username,
                 client_ip,
                 categories,
+                threat_sources,
                 request_start,
             );
         } else if let Some(scope) = fast_scope.take() {
@@ -356,6 +413,7 @@ impl ProxyService {
         username: &Option<String>,
         client_ip: &str,
         categories: &[String],
+        threat_sources: &[String],
         request_start: Instant,
         detailed_metrics: bool,
         guard: &mut Option<RequestMetricsGuard>,
@@ -415,6 +473,7 @@ impl ProxyService {
                 username,
                 client_ip,
                 categories,
+                threat_sources,
                 request_start,
                 detailed_metrics,
                 guard,
@@ -666,6 +725,7 @@ impl ProxyService {
                         &None,
                         &client_ip,
                         &[],
+                        &[],
                         request_start,
                         false,
                         &mut guard,
@@ -698,10 +758,23 @@ impl ProxyService {
             .unwrap_or_default();
 
         let domain = Self::extract_domain(&url);
-        let (policy_decision, categories) = self
+        let (policy_decision, categories, threat_sources) = self
             .check_policy(&url, &domain, username.as_deref(), &user_groups, &client_ip)
             .await;
         if let Some(decision) = policy_decision {
+            self.emit_policy_event(
+                &url,
+                method,
+                &cache_key,
+                &decision,
+                &user_id,
+                &username,
+                &client_ip,
+                &domain,
+                &categories,
+                &threat_sources,
+                request_start,
+            );
             let response = Self::policy_response(&decision);
             if let Some(g) = guard.take() {
                 g.finish(response.status().as_u16(), 0, 0);
@@ -730,6 +803,7 @@ impl ProxyService {
                     &username,
                     &client_ip,
                     &categories,
+                    &threat_sources,
                     request_start,
                     detailed_metrics,
                     &mut guard,
@@ -750,6 +824,7 @@ impl ProxyService {
                     &username,
                     &client_ip,
                     &categories,
+                    &threat_sources,
                     request_start,
                     detailed_metrics,
                     &mut guard,
@@ -790,6 +865,7 @@ impl ProxyService {
                     &username,
                     &client_ip,
                     &categories,
+                    &threat_sources,
                     request_start,
                 );
             }
@@ -946,7 +1022,7 @@ impl ProxyService {
                         method: method.to_string(),
                         status: status.as_u16(),
                         cache_key: cache_key.to_string(),
-                        cache_status,
+                        cache_status: cache_status.to_string(),
                         timestamp: timestamp.as_secs(),
                         headers: headers_map.clone(),
                         user_id,
@@ -958,6 +1034,8 @@ impl ProxyService {
                         content_type: headers_map.get("content-type").cloned(),
                         user_agent: headers_map.get("user-agent").cloned(),
                         categories: categories.clone(),
+                        threat_sources: threat_sources.clone(),
+                        acl_action: None,
                         event_id: new_event_id(),
                     };
                     self.send_cache_event(event);

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -253,7 +253,7 @@ async fn handle_connect_tunnel(
                             cache_key: service
                                 .generate_cache_key("CONNECT", &authority)
                                 .to_string(),
-                            cache_status: "BYPASS",
+                            cache_status: "BYPASS".to_string(),
                             timestamp: timestamp.as_secs(),
                             headers: HashMap::new(),
                             user_id,
@@ -265,6 +265,8 @@ async fn handle_connect_tunnel(
                             content_type: None,
                             user_agent: None,
                             categories: vec![],
+                            threat_sources: vec![],
+                            acl_action: None,
                             event_id: new_event_id(),
                         };
                         service.send_cache_event(event);
@@ -408,7 +410,7 @@ pub async fn handle_connection(
 
                 let connect_url = format!("https://{}", authority);
                 let connect_domain = parse_authority(&authority).0;
-                let (policy_decision, _) = service
+                let (policy_decision, _, _) = service
                     .check_policy(
                         &connect_url,
                         &connect_domain,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First M3 (Retro-search) increment: unified Kafka event contract and richer fields for OpenSearch analytics.

- **`bsdm-events` crate (B12)** — shared `CacheEvent` schema, `document_id()`, OpenSearch mappings and index template
- **Proxy** — emits `acl_action` and `threat_sources`; logs ACL **deny/redirect** events to Kafka (previously invisible in retro-search)
- **cache-indexer** — uses `bsdm-events`; applies index template on startup; maps new fields
- **Dashboards** — `blocked-threat-events` saved search uses `acl_action:deny` instead of misleading `cache_status:BYPASS`
- **Kafka** — `KAFKA_ACKS` env (default `1`, closes B10)

## M3 progress

| Done in this PR | Still open |
|-----------------|------------|
| Shared schema (B12) | ILM / retention policy |
| `categories`, `acl_action`, `threat_sources` | Search API |
| ACL block events indexed | Session correlation |
| Index template bootstrap | Dashboard visualizations |
| B10/B11/B12/B17 closed | CSV/JSON export |

Roadmap M3: ~15% → ~30%

## Test plan

- [x] `cargo test -p bsdm-events`
- [x] `cargo test -p cache-indexer`
- [x] `cargo test -p bsdm-proxy --lib` (89 tests)
- [ ] Manual: ACL deny → event in OpenSearch with `acl_action:deny`
- [ ] Manual: OpenSearch Dashboards → saved search "Blocked and threat categories"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

