### PR TITLE
docs: Kubernetes architecture guide and Helm chart skeleton

### DIFF
--- a/charts/bsdm/Chart.yaml
+++ b/charts/bsdm/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: bsdm
+description: BSDM-Proxy forward proxy with optional Redis L2
+type: application
+version: 0.1.0
+appVersion: "0.3.0"
+keywords:
+  - proxy
+  - cache
+  - swg
+maintainers:
+  - name: onixus
+    url: https://github.com/onixus/bsdm-proxy

--- a/charts/bsdm/README.md
+++ b/charts/bsdm/README.md
@@ -1,0 +1,56 @@
+# Helm chart skeleton for BSDM-Proxy on Kubernetes.
+#
+# Install:
+#   helm install bsdm ./charts/bsdm -n bsdm-proxy --create-namespace
+#
+# Production profile:
+#   helm install bsdm ./charts/bsdm -f values-prod.yaml -n bsdm-proxy --create-namespace
+#
+# Full architecture: docs/k8s-architecture.md
+
+## Prerequisites
+
+- Kubernetes 1.28+
+- Helm 3
+- (prod) Redis L2 — deploy separately or enable future redis subchart
+- (prod) Kafka in `bsdm-analytics` namespace
+- MITM CA Secret (if `mitm.enabled`):
+
+```bash
+kubectl create secret generic bsdm-mitm-ca -n bsdm-proxy \
+  --from-file=ca.crt=./certs/ca.crt \
+  --from-file=ca.key=./certs/ca.key
+```
+
+Set `mitm.existingSecret: bsdm-mitm-ca` in values.
+
+## Values
+
+| Key | Default | Prod (`values-prod.yaml`) |
+|-----|---------|-------------------------|
+| `replicaCount` | 2 | 4 |
+| `proxy.workerCount` | 1 | 1 |
+| `proxy.cacheCapacity` | 10000 | 25000 per pod |
+| `proxy.redisL2Enabled` | false | true |
+| `spill.sizeLimit` | 20Gi | 30Gi |
+
+## Templates
+
+| File | Resource |
+|------|----------|
+| `deployment.yaml` | proxy Deployment |
+| `service.yaml` | ClusterIP :1488, :9090 |
+| `configmap-env.yaml` | non-secret env |
+| `hpa.yaml` | optional HPA |
+| `pdb.yaml` | PodDisruptionBudget |
+| `networkpolicy.yaml` | optional NetworkPolicy |
+| `servicemonitor.yaml` | Prometheus Operator |
+
+## Not included (deploy separately)
+
+- Redis / Sentinel
+- Kafka, OpenSearch, cache-indexer
+- Ingress / Gateway API
+- cert-manager Issuer
+
+See `docker-compose.ha.yml` for local HA demo without k8s.

--- a/charts/bsdm/templates/_helpers.tpl
+++ b/charts/bsdm/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bsdm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "bsdm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "bsdm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "bsdm.labels" -}}
+helm.sh/chart: {{ include "bsdm.chart" . }}
+{{ include "bsdm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "bsdm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bsdm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "bsdm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bsdm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/bsdm/templates/configmap-env.yaml
+++ b/charts/bsdm/templates/configmap-env.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bsdm.fullname" . }}-env
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+data:
+  HTTP_PORT: {{ .Values.service.proxyPort | quote }}
+  METRICS_PORT: {{ .Values.service.metricsPort | quote }}
+  WORKER_COUNT: {{ .Values.proxy.workerCount | quote }}
+  CACHE_CAPACITY: {{ .Values.proxy.cacheCapacity | quote }}
+  CACHE_SHARDS: {{ .Values.proxy.cacheShards | quote }}
+  CACHE_TTL_SECONDS: {{ .Values.proxy.cacheTtlSeconds | quote }}
+  MAX_CACHE_BODY_SIZE: {{ .Values.proxy.maxCacheBodySize | quote }}
+  CACHE_SPILL_THRESHOLD_BYTES: {{ .Values.proxy.spillThresholdBytes | quote }}
+  CACHE_SPILL_DIR: {{ .Values.spill.mountPath | quote }}
+  REDIS_L2_ENABLED: {{ .Values.proxy.redisL2Enabled | quote }}
+  REDIS_URL: {{ .Values.proxy.redisUrl | quote }}
+  REDIS_KEY_PREFIX: {{ .Values.proxy.redisKeyPrefix | quote }}
+  KAFKA_TOPIC: {{ .Values.proxy.kafkaTopic | quote }}
+  KAFKA_SAMPLE_RATE: {{ .Values.proxy.kafkaSampleRate | quote }}
+  METRICS_SAMPLE_RATE: {{ .Values.proxy.metricsSampleRate | quote }}
+  PERF_FAST_CACHE_HIT: {{ .Values.proxy.perfFastCacheHit | quote }}
+  MITM_ENABLED: {{ .Values.proxy.mitmEnabled | quote }}
+  AUTH_ENABLED: {{ .Values.proxy.authEnabled | quote }}
+  ACL_ENABLED: {{ .Values.proxy.aclEnabled | quote }}
+  ACL_DEFAULT_ACTION: {{ .Values.acl.defaultAction | quote }}
+  ACL_RULES_PATH: {{ printf "%s/acl-rules.json" .Values.acl.mountPath | quote }}
+  CATEGORIZATION_ENABLED: {{ .Values.proxy.categorizationEnabled | quote }}
+  HIERARCHY_ENABLED: {{ .Values.proxy.hierarchyEnabled | quote }}
+  RUST_LOG: {{ .Values.proxy.rustLog | quote }}
+  SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.proxy.shutdownTimeoutSeconds | quote }}
+  {{- if .Values.proxy.kafkaBrokers }}
+  KAFKA_BROKERS: {{ .Values.proxy.kafkaBrokers | quote }}
+  {{- end }}

--- a/charts/bsdm/templates/deployment.yaml
+++ b/charts/bsdm/templates/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bsdm.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-env.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "bsdm.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "bsdm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ add .Values.proxy.shutdownTimeoutSeconds .Values.lifecycle.preStopSleepSeconds }}
+      containers:
+        - name: proxy
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.service.proxyPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.service.metricsPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "bsdm.fullname" . }}-env
+          {{- with .Values.proxy.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.spill.enabled }}
+            - name: spill
+              mountPath: {{ .Values.spill.mountPath }}
+            {{- end }}
+            {{- if and .Values.mitm.enabled .Values.mitm.existingSecret }}
+            - name: mitm-certs
+              mountPath: {{ .Values.mitm.certMountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if and .Values.acl.enabled .Values.acl.existingConfigMap }}
+            - name: acl-rules
+              mountPath: {{ .Values.acl.mountPath }}
+              readOnly: true
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: metrics
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.probes.startup.path }}
+              port: metrics
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.lifecycle.preStopSleepSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.spill.enabled }}
+        - name: spill
+          emptyDir:
+            sizeLimit: {{ .Values.spill.sizeLimit }}
+        {{- end }}
+        {{- if and .Values.mitm.enabled .Values.mitm.existingSecret }}
+        - name: mitm-certs
+          secret:
+            secretName: {{ .Values.mitm.existingSecret }}
+        {{- end }}
+        {{- if and .Values.acl.enabled .Values.acl.existingConfigMap }}
+        - name: acl-rules
+          configMap:
+            name: {{ .Values.acl.existingConfigMap }}
+        {{- end }}

--- a/charts/bsdm/templates/hpa.yaml
+++ b/charts/bsdm/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "bsdm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/bsdm/templates/networkpolicy.yaml
+++ b/charts/bsdm/templates/networkpolicy.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bsdm.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        {{- range .Values.networkPolicy.proxyIngressCidrs }}
+        - ipBlock:
+            cidr: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.proxyPort }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.metricsPort }}
+  egress:
+    {{- if .Values.networkPolicy.allowEgressInternet }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443
+    {{- end }}
+    {{- if .Values.networkPolicy.redisNamespace }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.redisNamespace }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    {{- end }}
+    {{- if .Values.networkPolicy.kafkaNamespace }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.kafkaNamespace }}
+      ports:
+        - protocol: TCP
+          port: 9092
+    {{- end }}
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end }}

--- a/charts/bsdm/templates/pdb.yaml
+++ b/charts/bsdm/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "bsdm.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/bsdm/templates/service.yaml
+++ b/charts/bsdm/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  ports:
+    - name: proxy
+      port: {{ .Values.service.proxyPort }}
+      targetPort: proxy
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.service.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    {{- include "bsdm.selectorLabels" . | nindent 4 }}

--- a/charts/bsdm/templates/serviceaccount.yaml
+++ b/charts/bsdm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bsdm.serviceAccountName" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/bsdm/templates/servicemonitor.yaml
+++ b/charts/bsdm/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "bsdm.fullname" . }}
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "bsdm.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/charts/bsdm/values-prod.yaml
+++ b/charts/bsdm/values-prod.yaml
@@ -1,0 +1,60 @@
+# Production profile — corporate medium (~5k users).
+# 4 replicas × 25k L1 capacity ≈ 100k total; Redis L2 required.
+# See docs/k8s-architecture.md
+
+replicaCount: 4
+
+resources:
+  requests:
+    cpu: "4"
+    memory: 8Gi
+  limits:
+    cpu: "8"
+    memory: 16Gi
+
+spill:
+  enabled: true
+  sizeLimit: 30Gi
+
+proxy:
+  workerCount: 1
+  cacheCapacity: 25000
+  cacheShards: 16
+  cacheTtlSeconds: 7200
+  maxCacheBodySize: 2097152
+  spillThresholdBytes: 262144
+  redisL2Enabled: true
+  redisUrl: "redis://redis-master.bsdm-proxy.svc:6379"
+  kafkaBrokers: "kafka-bootstrap.bsdm-analytics.svc:9092"
+  kafkaSampleRate: 10
+  metricsSampleRate: 100
+  perfFastCacheHit: false
+  mitmEnabled: true
+  authEnabled: true
+  aclEnabled: true
+  categorizationEnabled: true
+  rustLog: "warn,bsdm_proxy=info"
+
+acl:
+  enabled: true
+
+autoscaling:
+  enabled: true
+  minReplicas: 4
+  maxReplicas: 12
+  targetCPUUtilizationPercentage: 70
+
+pdb:
+  enabled: true
+  minAvailable: 2
+
+networkPolicy:
+  enabled: true
+  proxyIngressCidrs:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+  redisNamespace: bsdm-proxy
+  kafkaNamespace: bsdm-analytics
+
+serviceMonitor:
+  enabled: true

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -1,0 +1,132 @@
+# Default values for bsdm-proxy on Kubernetes.
+# See docs/k8s-architecture.md and values-prod.yaml.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/onixus/bsdm-proxy
+  tag: "0.3.0"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  proxyPort: 1488
+  metricsPort: 9090
+  sessionAffinity: None
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: "2"
+    memory: 4Gi
+  limits:
+    cpu: "4"
+    memory: 8Gi
+
+# emptyDir for mmap spill — do not use shared RWX PVC
+spill:
+  enabled: true
+  sizeLimit: 20Gi
+  mountPath: /var/cache/bsdm-spill
+
+mitm:
+  enabled: true
+  existingSecret: ""          # if set, mount /certs from secret keys ca.crt, ca.key
+  certMountPath: /certs
+
+acl:
+  enabled: false
+  existingConfigMap: ""       # if set, mount acl-rules.json
+  mountPath: /etc/bsdm-proxy
+  defaultAction: allow
+
+# Proxy environment — maps to packaging/config/bsdm-proxy.env.example
+proxy:
+  workerCount: 1
+  cacheCapacity: 10000
+  cacheShards: 16
+  cacheTtlSeconds: 3600
+  maxCacheBodySize: 10485760
+  spillThresholdBytes: 262144
+  redisL2Enabled: false
+  redisUrl: "redis://redis-master:6379"
+  redisKeyPrefix: "bsdm:http:"
+  kafkaBrokers: ""
+  kafkaTopic: cache-events
+  kafkaSampleRate: 10
+  metricsSampleRate: 100
+  perfFastCacheHit: false
+  mitmEnabled: true
+  authEnabled: false
+  aclEnabled: false
+  categorizationEnabled: false
+  hierarchyEnabled: false
+  rustLog: "info,bsdm_proxy=info"
+  shutdownTimeoutSeconds: 30
+  extraEnv: []
+
+probes:
+  liveness:
+    path: /health
+    initialDelaySeconds: 10
+    periodSeconds: 10
+  readiness:
+    path: /ready
+    initialDelaySeconds: 5
+    periodSeconds: 5
+  startup:
+    path: /health
+    failureThreshold: 30
+    periodSeconds: 5
+
+lifecycle:
+  preStopSleepSeconds: 15
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 8
+  targetCPUUtilizationPercentage: 70
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+networkPolicy:
+  enabled: false
+  proxyIngressCidrs:
+    - 10.0.0.0/8
+  allowEgressInternet: true
+  redisNamespace: ""
+  kafkaNamespace: ""
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  labels: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -1,0 +1,100 @@
+# HA sketch: 2 proxy instances + Redis L2 behind implicit round-robin.
+# No k8s required — validates L2-HIT across restarts before Helm deploy.
+#
+# Usage:
+#   docker compose -f docker-compose.ha.yml up -d --build
+#   curl -x http://127.0.0.1:1488 http://upstream/get          # MISS via proxy-a
+#   docker compose -f docker-compose.ha.yml restart proxy-a
+#   curl -x http://127.0.0.1:1488 http://upstream/get          # L2-HIT on proxy-b path
+#
+# k8s equivalent: docs/k8s-architecture.md, charts/bsdm/
+
+services:
+  redis:
+    image: redis:7.4-alpine
+    networks:
+      - ha-net
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  upstream:
+    image: kennethreitz/httpbin:latest
+    networks:
+      - ha-net
+
+  proxy-a:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    ports:
+      - "1488:1488"
+    environment:
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - WORKER_COUNT=1
+      - CACHE_SHARDS=16
+      - CACHE_CAPACITY=5000
+      - CACHE_SPILL_DIR=/var/cache/bsdm-spill
+      - CACHE_SPILL_THRESHOLD_BYTES=262144
+      - REDIS_L2_ENABLED=true
+      - REDIS_URL=redis://redis:6379
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - RUST_LOG=info,bsdm_proxy=info
+    volumes:
+      - spill-a:/var/cache/bsdm-spill
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - ha-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  proxy-b:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    environment:
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - WORKER_COUNT=1
+      - CACHE_SHARDS=16
+      - CACHE_CAPACITY=5000
+      - CACHE_SPILL_DIR=/var/cache/bsdm-spill
+      - CACHE_SPILL_THRESHOLD_BYTES=262144
+      - REDIS_L2_ENABLED=true
+      - REDIS_URL=redis://redis:6379
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - RUST_LOG=info,bsdm_proxy=info
+    volumes:
+      - spill-b:/var/cache/bsdm-spill
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - ha-net
+
+  # Simulates second endpoint — in prod use LB across proxy replicas.
+  # Only proxy-a is exposed; restart proxy-a to demo L2 recovery via shared Redis.
+
+networks:
+  ha-net:
+    driver: bridge
+
+volumes:
+  spill-a:
+  spill-b:

--- a/docs/capacity-planning.md
+++ b/docs/capacity-planning.md
@@ -48,3 +48,9 @@ REDIS_L2_ENABLED=true
 | **Итого** | — | ~80 | ~350 GB | ~1.3 TB |
 
 Полные формулы, модели нагрузки и риски — на [wiki](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning).
+
+## Kubernetes
+
+См. [k8s-architecture.md](k8s-architecture.md) и Helm chart [`charts/bsdm/`](../charts/bsdm/README.md).
+
+Локальный HA sketch без k8s: `docker compose -f docker-compose.ha.yml up -d`.

--- a/docs/k8s-architecture.md
+++ b/docs/k8s-architecture.md
@@ -1,0 +1,274 @@
+# BSDM-Proxy on Kubernetes
+
+Рекомендуемая архитектура развёртывания BSDM на Kubernetes: data plane (proxy + Redis L2) и analytics plane (Kafka → indexer → OpenSearch).
+
+См. также: [capacity-planning.md](capacity-planning.md) · [swg-backlog-mapping.md](swg-backlog-mapping.md) · [helm chart](../charts/bsdm/README.md)
+
+---
+
+## Принципы
+
+| Принцип | Обоснование |
+|---------|-------------|
+| Горизонтальный scale proxy pods | Bench: `WORKER_COUNT=4` + shared L1 хуже, чем N реплик с `WORKER_COUNT=1` |
+| Redis L2 обязателен для HA | L1 локален; без L2 — sticky sessions и cache miss storm |
+| Spill локальный per pod | mmap spill (`CACHE_SPILL_DIR`) не шарить через NFS |
+| Analytics в отдельном namespace | Kafka/OpenSearch не конкурируют с proxy за CPU |
+| `sessionAffinity: None` | Когерентность через L2, не через LB stickiness |
+
+---
+
+## Топология (corporate medium)
+
+```mermaid
+flowchart TB
+  subgraph clients [Clients]
+    B[Browsers PAC]
+    S[Servers]
+  end
+
+  subgraph ingress [Ingress]
+    LB[LB / Gateway :1488]
+  end
+
+  subgraph ns_proxy [namespace bsdm-proxy]
+    P[proxy Deployment N replicas]
+    R[(Redis L2)]
+  end
+
+  subgraph ns_analytics [namespace bsdm-analytics]
+    K[Kafka]
+    I[cache-indexer]
+    OS[(OpenSearch)]
+    PM[Prometheus]
+  end
+
+  B --> LB --> P
+  S --> LB
+  P --> R
+  P -.->|async| K --> I --> OS
+  P -->|/metrics| PM
+```
+
+### Референс sizing (5k users, ~350 peak RPS)
+
+| Компонент | K8s | Replicas | CPU/pod | RAM/pod |
+|-----------|-----|----------|---------|---------|
+| bsdm-proxy | Deployment | 4 | 4 req / 8 lim | 8 Gi / 16 Gi |
+| Redis L2 | StatefulSet / Helm | 2+1 sentinel | 2 / 4 | 16 Gi / 32 Gi |
+| cache-indexer | Deployment | 2 | 1 / 2 | 512 Mi / 1 Gi |
+| Kafka | Strimzi / external | 3 | 2 / 4 | 8 Gi |
+| OpenSearch | StatefulSet / managed | 3+2 | 8 / 8 | 64 Gi |
+
+Полные цифры: [capacity-planning.md](capacity-planning.md).
+
+---
+
+## Data plane: proxy Deployment
+
+### Workload type
+
+- **Deployment** (не StatefulSet) — pods взаимозаменяемы
+- **RollingUpdate** + **PodDisruptionBudget** `minAvailable: 1`
+- **Не использовать** `sessionAffinity: ClientIP`
+
+### Рекомендуемый env (k8s-prod)
+
+```bash
+WORKER_COUNT=1
+CACHE_SHARDS=16
+CACHE_CAPACITY=25000              # per pod; 4× = 100k суммарно
+CACHE_SPILL_DIR=/var/cache/bsdm-spill
+CACHE_SPILL_THRESHOLD_BYTES=262144
+REDIS_L2_ENABLED=true
+REDIS_URL=redis://redis-master:6379
+KAFKA_SAMPLE_RATE=10
+METRICS_SAMPLE_RATE=100
+SHUTDOWN_TIMEOUT_SECONDS=30
+```
+
+Corporate profile: `MAX_CACHE_BODY_SIZE=2097152`, `CACHE_COMPRESSION=zstd`, `CACHE_COMPRESS_MIN_BYTES=1048576`.
+
+### Volumes
+
+| Volume | Тип | Назначение |
+|--------|-----|------------|
+| `mitm-certs` | Secret | `ca.crt`, `ca.key` → `/certs` |
+| `acl-rules` | ConfigMap | `/etc/bsdm-proxy/acl-rules.json` |
+| `spill` | emptyDir (sizeLimit 30Gi) | mmap spill; prefer nodes with local SSD |
+| `shallalist` | ConfigMap / initContainer | categorization DB |
+
+### Probes
+
+| Probe | Path | Port |
+|-------|------|------|
+| liveness | `/health` | 9090 |
+| readiness | `/ready` | 9090 |
+| startup | `/health` | 9090 (failureThreshold высокий) |
+
+`lifecycle.preStop`: `sleep 15` + graceful shutdown в proxy.
+
+### securityContext
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  fsGroup: 65532
+```
+
+Spill files: `mode 0o600` (см. [#98](https://github.com/onixus/bsdm-proxy/issues/98)).
+
+---
+
+## Service & networking
+
+```yaml
+# bsdm-proxy — user traffic
+ports:
+  - name: proxy
+    port: 1488
+  - name: metrics
+    port: 9090
+sessionAffinity: None
+```
+
+| Трафик | Доступ |
+|--------|--------|
+| Proxy :1488 | Internal LB / ClusterIP из corporate CIDR |
+| Metrics :9090 | NetworkPolicy: только `monitoring` namespace |
+| ACL API `/api/acl/*` | Тот же :9090 + `ACL_API_TOKEN` |
+
+**NetworkPolicy (минимум):**
+- Ingress → proxy:1488 from `corporate` CIDR
+- Egress: internet :80/:443, Redis, Kafka, LDAP
+- Deny all else
+
+---
+
+## Redis L2
+
+Обязателен при `replicas > 1`.
+
+| Вариант | Когда |
+|---------|-------|
+| Bitnami Redis + Sentinel (subchart) | on-prem k8s, lab |
+| Redis Cluster | >100k L2 keys |
+| Managed (ElastiCache, Azure) | cloud k8s |
+
+Поведение: pod-A кеширует MISS → L1+L2 → pod-B после restart получает **L2-HIT**.
+
+Демо без k8s: `docker compose -f docker-compose.redis-l2.yml`.
+
+---
+
+## Analytics plane (`bsdm-analytics` namespace)
+
+| Компонент | Назначение |
+|-----------|------------|
+| Kafka topic `cache-events` | 12 partitions, RF=3, retention 7d |
+| cache-indexer | Consumer group, HPA по lag |
+| OpenSearch | Index `http-cache`, ILM 14d hot |
+| Prometheus + Grafana | Scrape `/metrics` всех proxy pods |
+
+Proxy **не должен** блокироваться на Kafka (см. [#106](https://github.com/onixus/bsdm-proxy/issues/106)).
+
+---
+
+## Autoscaling
+
+**HPA** на proxy Deployment:
+
+- CPU utilization 70%
+- Custom: `bsdm_proxy_requests_total` rate (Prometheus Adapter)
+
+**Не масштабировать** по memory L1 — фиксируйте `CACHE_CAPACITY` per pod, добавляйте replicas.
+
+---
+
+## Hierarchy (optional)
+
+ICP/HTCP (UDP) в k8s сложен. Рекомендация на старте:
+
+- `HIERARCHY_ENABLED=true`
+- Parent fetch через internal Service
+- ICP/HTCP: dedicated node pool + `hostNetwork: true` или отключить siblings
+
+См. [hierarchical-caching.md](hierarchical-caching.md).
+
+---
+
+## Deployment profiles
+
+### A. Edge (minimal)
+
+```
+bsdm-proxy (4 pods) + Redis Sentinel
+Prometheus Agent → remote_write
+Kafka external / small cluster
+```
+
+### B. Full stack
+
+```
+bsdm-proxy + Redis + Kafka + OpenSearch + indexer + Grafana
+```
+
+См. `docker-compose.yml` как reference stack; в k8s — разнести по namespace.
+
+---
+
+## GitOps layout
+
+```
+gitops/
+├── bsdm-proxy/          # Helm release, values-prod.yaml
+├── bsdm-analytics/      # Kafka, OS, indexer
+└── secrets/             # External Secrets → mitm-ca, ldap-bind
+```
+
+| Артефакт | Источник |
+|----------|----------|
+| Env defaults | Helm `values.yaml` → ConfigMap |
+| ACL rules | ConfigMap + `ACL_AUTO_RELOAD=true` |
+| MITM CA | cert-manager Certificate → Secret |
+
+---
+
+## Антипаттерны
+
+| ❌ | ✅ |
+|----|-----|
+| 1 pod × WORKER_COUNT=4 × 32 CPU | 4 pods × WORKER_COUNT=1 |
+| Shared PVC/NFS для spill | emptyDir local per pod |
+| sessionAffinity для cache | Redis L2 |
+| Kafka в том же pod | Отдельный namespace |
+| MITM CA baked in image | Secret mount |
+
+---
+
+## Helm chart
+
+Скелет: [`charts/bsdm/`](../charts/bsdm/README.md)
+
+```bash
+helm install bsdm ./charts/bsdm \
+  -f charts/bsdm/values-prod.yaml \
+  -n bsdm-proxy --create-namespace
+```
+
+---
+
+## Backlog → k8s
+
+| Issue | K8s impact |
+|-------|------------|
+| [#94](https://github.com/onixus/bsdm-proxy/issues/94) Streaming MISS | Lower memory limits per pod |
+| [#95](https://github.com/onixus/bsdm-proxy/issues/95) Conn auth cache | Less LDAP load behind LB keep-alive |
+| [#96](https://github.com/onixus/bsdm-proxy/issues/96) Policy cache | Lower CPU → fewer replicas |
+| [#97](https://github.com/onixus/bsdm-proxy/issues/97) WORKER_COUNT profiles | `values-prod.yaml`: `workerCount: 1` |
+| [#107](https://github.com/onixus/bsdm-proxy/issues/107) HA guide | This document |
+
+---
+
+*Последнее обновление: 2026-06 · BSDM v0.3.0*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -219,6 +219,7 @@ Issues привязывайте к milestones:
 
 - [architecture.md](architecture.md) — архитектура и блокеры B1–B25
 - [swg-backlog-mapping.md](swg-backlog-mapping.md) — mapping vs Zscaler/Netskope/Palo Alto + Squid rock
+- [k8s-architecture.md](k8s-architecture.md) — Kubernetes deployment guide
 - [hierarchical-caching.md](hierarchical-caching.md) — дизайн ICP/HTCP (M2)
 - [logging.md](logging.md) — `RUST_LOG` и профили логирования
 - [categorization.md](categorization.md) — threat intel feeds (M1/M4)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,6 +218,7 @@ Issues привязывайте к milestones:
 ## Связанные документы
 
 - [architecture.md](architecture.md) — архитектура и блокеры B1–B25
+- [swg-backlog-mapping.md](swg-backlog-mapping.md) — mapping vs Zscaler/Netskope/Palo Alto + Squid rock
 - [hierarchical-caching.md](hierarchical-caching.md) — дизайн ICP/HTCP (M2)
 - [logging.md](logging.md) — `RUST_LOG` и профили логирования
 - [categorization.md](categorization.md) — threat intel feeds (M1/M4)

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -239,19 +239,37 @@ gantt
 
 ---
 
-## Конкретные issue-заготовки (для GitHub)
+## GitHub issues
 
-```
-[P0] streaming MISS: tee upstream body to client while populating cache
-[P0] connection-level proxy auth cache (per TcpStream, TTL configurable)
-[P0] policy decision cache: (principal, domain) → AclDecision with TTL
-[P0] spill files: create with mode 0o600
-[P1] PERF_FAST_PATH: document and test matrix (HIT/REVALIDATED/NEGATIVE_HIT)
-[P1] categorization: hot path = Shallalist only; async enrich to Kafka
-[P1] Kafka producer: bounded queue, drop policy, zero await on hot path
-[P2] docs: Squid rock ↔ BSDM spill threshold sizing guide
-[P2] hierarchy: mTLS for peer_fetch
-```
+| ID | Issue | Приоритет |
+|----|-------|-----------|
+| P0-3 | [#94](https://github.com/onixus/bsdm-proxy/issues/94) Streaming MISS | P0 |
+| P0-4 | [#95](https://github.com/onixus/bsdm-proxy/issues/95) Connection-level auth cache | P0 |
+| P0-5 | [#96](https://github.com/onixus/bsdm-proxy/issues/96) Policy decision cache | P0 |
+| P0-6 | [#97](https://github.com/onixus/bsdm-proxy/issues/97) Bench profiles WORKER_COUNT | P0 |
+| P0-7 | [#98](https://github.com/onixus/bsdm-proxy/issues/98) Spill files mode 0o600 | P0 |
+| P1-1 | [#100](https://github.com/onixus/bsdm-proxy/issues/100) PERF fast path matrix | P1 |
+| P1-2 | [#104](https://github.com/onixus/bsdm-proxy/issues/104) Offline categorization | P1 |
+| P1-3 | [#106](https://github.com/onixus/bsdm-proxy/issues/106) Kafka bounded queue | P1 |
+| P1-4 | [#109](https://github.com/onixus/bsdm-proxy/issues/109) ACL read-mostly | P1 |
+| P1-5 | [#111](https://github.com/onixus/bsdm-proxy/issues/111) x-cache-status MISS | P1 |
+| P2-1 | [#101](https://github.com/onixus/bsdm-proxy/issues/101) Squid rock sizing guide | P2 |
+| P2-2 | [#103](https://github.com/onixus/bsdm-proxy/issues/103) Peer mTLS | P2 |
+| P2-3 | [#107](https://github.com/onixus/bsdm-proxy/issues/107) HA deployment guide | P2 |
+| P2-4 | [#110](https://github.com/onixus/bsdm-proxy/issues/110) Search API (M3) | P2 |
+| P2-5 | [#112](https://github.com/onixus/bsdm-proxy/issues/112) Web config ACL UI | P2 |
+| P3-1 | [#99](https://github.com/onixus/bsdm-proxy/issues/99) ICAP adapter | P3 |
+| P3-2 | [#102](https://github.com/onixus/bsdm-proxy/issues/102) Event schema enrichment | P3 |
+| P3-3 | [#105](https://github.com/onixus/bsdm-proxy/issues/105) Categorization metrics | P3 |
+| P3-4 | [#108](https://github.com/onixus/bsdm-proxy/issues/108) DNS sinkhole module | P3 |
+
+P0-1 / P0-2 tracked by PR [#93](https://github.com/onixus/bsdm-proxy/pull/93) and PR [#92](https://github.com/onixus/bsdm-proxy/pull/92).
+
+---
+
+## Конкретные issue-заготовки (архив)
+
+См. таблицу **GitHub issues** выше — все заведены.
 
 ---
 

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -1,0 +1,279 @@
+# BSDM ↔ Market Leaders: backlog mapping
+
+Сопоставление возможностей **BSDM-Proxy** с архитектурой лидеров **SSE/SWG** (Zscaler, Netskope, Palo Alto Prisma Access) и с **Squid rock** как референсом on-prem data plane.
+
+См. также: [roadmap.md](roadmap.md) · [adr/0001-tiered-sharded-l1-cache.md](adr/0001-tiered-sharded-l1-cache.md) · [performance.md](performance.md)
+
+---
+
+## Позиционирование
+
+| Ось | BSDM сейчас | Zscaler / Netskope / Palo Alto |
+|-----|-------------|--------------------------------|
+| Deployment | self-hosted forward proxy | cloud PoP / multitenant SaaS |
+| Сильная сторона | Squid-parity cache + hierarchy + retro-search pipeline | single-pass inline security at scale |
+| Слабая сторона | data plane throughput, policy on hot path | не ваш on-prem control plane |
+| Уникальность | Kafka → OpenSearch ретропоиск + ML roadmap | commodity cloud SWG |
+
+**Цель mapping:** не копировать cloud SWG целиком, а взять **data-plane и policy patterns**, которые закрывают измеримые gaps (HTTP Archive bench, enterprise proxy shops).
+
+---
+
+## Матрица: лидеры vs BSDM (v0.3.0 + PR #93)
+
+Легенда: ✅ есть · ⚠️ частично · ❌ нет · 🎯 backlog
+
+### Data plane (hot path)
+
+| Паттерн лидеров | Zscaler | Netskope | Palo Alto | BSDM | Backlog |
+|-----------------|---------|----------|-----------|------|---------|
+| Cloud-native proxy (не FW-in-cloud) | ZIA Service Edge | NewEdge POP | Prisma explicit proxy | ✅ forward HTTP proxy | — |
+| Single-pass inspection | Single Scan Multi-Action | single-pass microservices | unified threat stack | ⚠️ цепочка auth→ACL→cat→cache | **P0** unified fast path |
+| Sharded L1 / reduced lock contention | multitenant internal | per-POP shards | cloud scale-out | ✅ `HttpL1Cache` (PR #93) | merge #93 |
+| Tiered body storage (inline + spill) | cloud object store | bare-metal optimized | cloud store | ✅ mmap spill (PR #93) | merge #93 |
+| Zero-copy large HIT serve | yes | yes | yes | ✅ `Bytes::from_owner` | — |
+| Streaming MISS (tee upstream→client) | yes | yes | yes | ❌ buffer-then-serve | **P0** `streaming_miss` |
+| Connection-level auth cache | session at edge | identity on tunnel | GP session | ❌ auth per request | **P0** `conn_auth_cache` |
+| Policy decision cache | context cached at edge | unified policy engine | forwarding profiles | ❌ ACL+cat every request | **P0** `policy_decision_cache` |
+| PERF_FAST_CACHE_HIT (skip policy on HIT) | implicit | implicit | implicit | ✅ env flag | default on bench |
+| Multi-worker accept (SO_REUSEPORT) | internal | internal | internal | ✅ `WORKER_COUNT` | tune 1 vs 4 profiles |
+| TCP send buffer tuning | internal | internal | internal | ✅ `TCP_SNDBUF_BYTES` | merge PR #92 |
+| Full TLS MITM at scale | 100% cloud | 100% cloud | 100% cloud | ⚠️ MITM 443/8443 | cert lifecycle, exceptions |
+| HTTP/2 upstream | yes | yes | yes | ✅ `UPSTREAM_HTTP2_ENABLED` | — |
+| HTTP/2 to client | yes | yes | limited | ❌ HTTP/1.1 only | **P2** h2 server |
+
+### Cache & hierarchy
+
+| Паттерн | Zscaler | Netskope | Palo Alto | BSDM | Backlog |
+|---------|---------|----------|-----------|------|---------|
+| L1 RAM cache | minimal | minimal | minimal | ✅ sharded quick_cache | — |
+| Disk / mmap spill (rock-like) | internal | internal | internal | ✅ `CACHE_SPILL_*` | chmod 0600 spill |
+| L2 shared cache (Redis) | cloud internal | cloud internal | cloud internal | ✅ Redis L2 | — |
+| Parent/sibling hierarchy | limited | limited | limited | ✅ ICP/HTCP/digest | mTLS peers **P2** |
+| Negative cache | yes | yes | yes | ✅ `NEGATIVE_CACHE_*` | — |
+| Revalidation (304) | yes | yes | yes | ✅ ETag/IMS | — |
+| At-rest compression | internal | internal | internal | ✅ zstd/brotli | — |
+| Aggressive object cache (Squid-style) | no | no | no | ⚠️ tuning gap vs Squid | see § Squid rock |
+
+### Security services (cold path / async)
+
+| Сервис | Zscaler | Netskope | Palo Alto | BSDM | Backlog |
+|--------|---------|----------|-----------|------|---------|
+| URL filtering / categories | cloud intel | SkopeIT | PAN-DB | ⚠️ Shallalist+URLhaus+PhishTank | offline cat DB **P1** |
+| AV / sandbox | cloud | cloud | WildFire | ❌ | ICAP or async scan **P3** |
+| DLP (body) | inline | inline | Enterprise DLP | ❌ | M5 / optional ICAP **P4** |
+| RBI (remote browser) | yes | yes | yes | ❌ | out of scope v1 |
+| CASB / SaaS control | yes | yes | NG-CASB | ❌ | out of scope v1 |
+| ZTNA | ZPA | NPA | Prisma Access | ❌ | out of scope v1 |
+| DNS security layer | limited | limited | limited | ❌ | optional **P3** |
+| Threat intel inline score | yes | yes | yes | ❌ | M4 rules → M5 ML |
+| Rate limiting | yes | yes | yes | ✅ token bucket | — |
+
+### Control plane & observability
+
+| Возможность | Лидеры | BSDM | Backlog |
+|-------------|--------|------|---------|
+| Central admin console | SaaS UI | JSON ACL + REST API | web-config UI **P2** |
+| Identity-aware policy | user/device/location | user/group/IP/time | device posture **P4** |
+| Global PoP / anycast | 120–150+ DC | single node / K8s | HA guide **P2** |
+| Async telemetry (не на hot path) | yes | ⚠️ Kafka inline (sampled) | **P1** async-only events |
+| Retro-search / SOC | cloud logs | Kafka→OpenSearch | M3 Search API |
+| SIEM export | native | OpenSearch/Kafka | ILM + schema **M3** |
+
+---
+
+## Приоритизированный backlog (по паттернам лидеров)
+
+### P0 — Data plane throughput (закрывает HTTP Archive gap)
+
+Измеримая цель: warm goodput **538 → 600+ Mbit/s** на sites bench (70×2.6MB, 12 conn).
+
+| ID | Задача | Паттерн у лидеров | Файлы / заметки |
+|----|--------|-------------------|-----------------|
+| P0-1 | Merge tiered + sharded L1 | NewEdge bare-metal tiering | PR #93 |
+| P0-2 | Merge TCP sndbuf + bench defaults | edge socket tuning | PR #92 |
+| P0-3 | **Streaming MISS** — tee upstream→client while caching | все лидеры: no buffer-full-object | `proxy_service.rs`, `upstream.rs` |
+| P0-4 | **Connection-level auth** — cache `Proxy-Authorization` outcome per TCP conn | identity on tunnel (ZCC/GP) | `server.rs`, `auth.rs` |
+| P0-5 | **Policy decision cache** — `(user, domain, url_hash) → Allow/Deny` TTL 60–300s | unified policy engine cache | `proxy_service.rs`, `acl.rs` |
+| P0-6 | Bench profiles: `WORKER_COUNT=1` warm / `4` cold | internal tuning | `compare-squid-bsdm-httparchive.sh` |
+| P0-7 | Spill file `mode(0o600)` + private `CACHE_SPILL_DIR` | security hygiene | `cache_body.rs` |
+
+### P1 — Single-pass policy path (как Single Scan / single-pass)
+
+| ID | Задача | Паттерн | Заметки |
+|----|--------|---------|---------|
+| P1-1 | **Fast path matrix** — явная таблица: HIT / REVALIDATED / negative HIT skip cat+ACL | Zscaler fast path implicit | extend `PERF_FAST_CACHE_HIT` |
+| P1-2 | **Offline categorization** — Shallalist-only on hot path; URLhaus async enrich | cloud intel async | `categorization.rs` |
+| P1-3 | **Kafka fully async** — never block response on producer; drop+metric on full queue | telemetry off hot path | `pipeline.rs` |
+| P1-4 | **ACL read lock** — remove inner Mutex on regex compile cache | read-mostly policy | `acl.rs` (B9) |
+| P1-5 | `x-cache-status: MISS` on first upstream byte | observability | `proxy_service.rs` |
+
+### P2 — Squid parity + enterprise deploy
+
+| ID | Задача | Squid / enterprise | Заметки |
+|----|--------|-------------------|---------|
+| P2-1 | **Rock-equivalent tuning guide** — spill threshold vs object size distribution | Squid `cache_dir rock` | `capacity-planning.md` |
+| P2-2 | **Peer mTLS** | hierarchy security | `peer_fetch.rs` |
+| P2-3 | **HA deployment** — Redis L2 + sticky-less LB + shared spill dir or no-spill | cloud PoP equivalent | docs + compose |
+| P2-4 | OpenSearch Search API (M3) | retro-search differentiator | `cache-indexer` |
+| P2-5 | Web config UI for ACL | Palo Alto console lite | `web-config/` |
+
+### P3 — Threat plane (async, не inline)
+
+| ID | Задача | Лидеры | Заметки |
+|----|--------|--------|---------|
+| P3-1 | ICAP adapter (optional AV/URL) | legacy enterprise | sidecar pattern |
+| P3-2 | Event enrichment: `acl_action`, `threat_sources` | Netskope data lake | M3 schema |
+| P3-3 | Categorization Prometheus metrics | all | M4 |
+| P3-4 | DNS sinkhole module (optional) | Cisco Umbrella layer 1 | separate crate |
+
+### P4+ — Не копировать в v1
+
+CASB, ZTNA, RBI, cloud PoP mesh, commercial threat feeds, ML inline scoring — **вне scope** до M5. BSDM выигрывает **ретропоиском**, а не feature-parity с Zscaler.
+
+---
+
+## Squid rock vs Netskope NewEdge: два разных мира
+
+### Squid rock (ваш bench reference)
+
+Из `scripts/squid-benchmark-tuned.conf`:
+
+```
+workers 4
+cache_dir rock /var/spool/squid-rock 1024    # ~1 GB mmap store
+cache_mem 256 MB
+memory_cache_shared on
+maximum_object_size 10 MB
+```
+
+**Архитектура Squid rock:**
+
+```
+MISS → fetch upstream → write to rock (mmap) + optional hot RAM
+HIT  → serve from RAM cache OR mmap rock (zero page cache hit)
+```
+
+| Свойство | Squid rock |
+|----------|------------|
+| Цель | **maximize cache hit bandwidth** |
+| Шардирование | `workers N` + `memory_cache_shared` |
+| Большие объекты | mmap на FS, не в heap |
+| Policy | minimal (ACL + refresh_pattern) |
+| TLS | bump/ssl_peek или plain bench |
+| Inspection | нет DLP/AV inline |
+
+### Netskope NewEdge single-pass
+
+**Архитектура:**
+
+```
+Client → nearest POP (bare metal)
+       → TLS terminate (MITM)
+       → SINGLE PASS: SWG + CASB + DLP + threat (parallel microservices)
+       → egress with PoP IP
+       → minimal caching (security product, not CDN)
+```
+
+| Свойство | NewEdge |
+|----------|---------|
+| Цель | **maximize inspected throughput** |
+| Шардирование | per-POP horizontal scale |
+| Большие объекты | stream through, не обязательно cache |
+| Policy | identity + context, unified engine |
+| TLS | 100% inspect |
+| Cache | побочный эффект, не core |
+
+### Соответствие BSDM после PR #93
+
+| Слой | Squid rock | NewEdge | BSDM (target) |
+|------|------------|---------|---------------|
+| Object store | `cache_dir rock` | none/minimal | `CachedBody` mmap spill |
+| Hot RAM | `cache_mem 256MB` | connection buffers | inline `<256KB` |
+| Worker model | 4 Squid workers | POP scale-out | `WORKER_COUNT` + `CACHE_SHARDS` |
+| Serve path | mmap → socket | stream → socket | mmap `from_owner` → socket |
+| Policy | off hot path | single-pass parallel | **gap**: auth+ACL+cat sequential |
+| MISS path | fetch→store→serve | stream+inspect | **gap**: buffer full body |
+
+**Вывод:** PR #93 переносит BSDM **rock storage model** в userspace (`memmap2` spill). Это правильно для **Squid-parity cache**. Но gap к Squid на bench (~538 vs 593 Mbit/s) — не только storage, а:
+
+1. **MISS buffering** vs streaming (Squid тоже буферизует, но 20+ лет оптимизации send path)
+2. **Policy on warm HIT** — Squid bench без ACL/cat; BSDM даже с `PERF_FAST_CACHE_HIT` тянет Kafka sample
+3. **Worker/cache sharing** — Squid `memory_cache_shared` vs BSDM `Arc<HttpL1Cache>` (лучше после sharding, но не идентично)
+
+NewEdge patterns для BSDM — **не rock**, а:
+
+- single-pass policy (P0-4, P0-5, P1-1)
+- streaming (P0-3)
+- telemetry off path (P1-3)
+
+---
+
+## Roadmap alignment
+
+```mermaid
+gantt
+  title BSDM backlog vs market patterns
+  dateFormat YYYY-MM
+  section P0 Data plane
+  Tiered sharded L1     :done, p01, 2026-06, 2026-06
+  Streaming MISS        :p03, 2026-07, 2026-07
+  Conn auth + policy cache :p04, 2026-07, 2026-08
+  section P1 Single-pass
+  Fast path matrix      :p11, 2026-08, 2026-08
+  Offline categorization :p12, 2026-08, 2026-09
+  section P2 Enterprise
+  Rock tuning guide     :p21, 2026-07, 2026-07
+  Search API M3         :p24, 2026-08, 2026-09
+  section P3 Threat async
+  ICAP optional         :p31, 2026-09, 2026-10
+```
+
+| Milestone | Market pattern borrowed | BSDM deliverable |
+|-----------|------------------------|------------------|
+| M2 done | Squid hierarchy + rock-like store | L1/L2, ICP, spill |
+| M2.5 (new) | Zscaler/Netskope data plane | P0 streaming + policy cache |
+| M3 | Netskope data lake (async) | OpenSearch retro-search |
+| M4 | PANW threat intel (rules) | beacon heuristics, enrichment |
+| M5 | ML inline scoring (optional) | anomaly score in index |
+
+---
+
+## Конкретные issue-заготовки (для GitHub)
+
+```
+[P0] streaming MISS: tee upstream body to client while populating cache
+[P0] connection-level proxy auth cache (per TcpStream, TTL configurable)
+[P0] policy decision cache: (principal, domain) → AclDecision with TTL
+[P0] spill files: create with mode 0o600
+[P1] PERF_FAST_PATH: document and test matrix (HIT/REVALIDATED/NEGATIVE_HIT)
+[P1] categorization: hot path = Shallalist only; async enrich to Kafka
+[P1] Kafka producer: bounded queue, drop policy, zero await on hot path
+[P2] docs: Squid rock ↔ BSDM spill threshold sizing guide
+[P2] hierarchy: mTLS for peer_fetch
+```
+
+---
+
+## Что не делать (антипаттерны)
+
+| Не копировать | Почему |
+|---------------|--------|
+| 150 PoP global mesh | не self-hosted proxy |
+| Multitenant SaaS control plane | другой продукт |
+| Inline DLP на каждый запрос | latency killer без cloud scale |
+| DNS-first pipeline как Umbrella | другой on-ramp, не forward proxy |
+| Отказ от disk/mmap cache | ваш diff vs cloud SWG — **cache + retro-search** |
+
+---
+
+## Ссылки
+
+- [Zscaler ZIA traffic forwarding (PDF)](https://www.zscaler.com/resources/reference-architectures/traffic-forwarding-in-zscaler-internet-access.pdf)
+- [Netskope NewEdge datasheet (PDF)](https://www.netskope.com/wp-content/uploads/2026/03/2026-03-NewEdge-DS-333-12.pdf)
+- [Netskope single-pass architecture](https://www.netskope.com/blog/optimizing-cloud-security-efficacy-performance-through-a-single-pass-architecture)
+- [Palo Alto Prisma Access Cloud SWG](https://www.paloaltonetworks.com/sase/secure-web-gateway)
+- [Gartner SSE MQ 2025 leaders](https://www.crn.com/news/security/2025/zscaler-netskope-palo-alto-networks-lead-gartner-s-sse-magic-quadrant-for-2025)
+- [ADR 0001 tiered sharded L1](adr/0001-tiered-sharded-l1-cache.md)
+
+*Последнее обновление: 2026-06, BSDM v0.3.0 + PR #93*

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -255,7 +255,7 @@ gantt
 | P1-5 | [#111](https://github.com/onixus/bsdm-proxy/issues/111) x-cache-status MISS | P1 |
 | P2-1 | [#101](https://github.com/onixus/bsdm-proxy/issues/101) Squid rock sizing guide | P2 |
 | P2-2 | [#103](https://github.com/onixus/bsdm-proxy/issues/103) Peer mTLS | P2 |
-| P2-3 | [#107](https://github.com/onixus/bsdm-proxy/issues/107) HA deployment guide | P2 |
+| P2-3 | [#107](https://github.com/onixus/bsdm-proxy/issues/107) HA / k8s deployment | P2 | [k8s-architecture.md](k8s-architecture.md) |
 | P2-4 | [#110](https://github.com/onixus/bsdm-proxy/issues/110) Search API (M3) | P2 |
 | P2-5 | [#112](https://github.com/onixus/bsdm-proxy/issues/112) Web config ACL UI | P2 |
 | P3-1 | [#99](https://github.com/onixus/bsdm-proxy/issues/99) ICAP adapter | P3 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds recommended Kubernetes deployment architecture for BSDM-Proxy based on SWG/market analysis and HTTP Archive bench findings.

## Changes

| Path | Description |
|------|-------------|
| `docs/k8s-architecture.md` | Data plane vs analytics plane, sizing, networking, autoscaling, anti-patterns |
| `charts/bsdm/` | Helm chart skeleton: Deployment, Service, ConfigMap, HPA, PDB, NetworkPolicy, ServiceMonitor |
| `charts/bsdm/values-prod.yaml` | Corporate medium profile (4 replicas, Redis L2, WORKER_COUNT=1) |
| `docker-compose.ha.yml` | Local HA demo without k8s (2 proxies + Redis L2, per-pod spill volumes) |

## Key architecture decisions

- **Deployment** (not StatefulSet), `sessionAffinity: None`
- **Redis L2 required** when `replicas > 1`
- **Spill = emptyDir per pod** — no shared NFS for mmap cache
- **WORKER_COUNT=1** per pod; scale horizontally
- Analytics (Kafka, OpenSearch) in separate `bsdm-analytics` namespace

## Closes

Closes #107

## Test plan

- [x] Helm templates reviewed (structure)
- [ ] `helm template` in CI (follow-up)
- [ ] `docker compose -f docker-compose.ha.yml up` manual smoke
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

