### PR TITLE
docs: ADR 0002 ClickHouse analytics stack

### DIFF
--- a/docker-compose.clickhouse.yml
+++ b/docker-compose.clickhouse.yml
@@ -1,0 +1,152 @@
+# ClickHouse analytics stack for BSDM-Proxy
+#
+# Kafka → (cache-indexer with INDEXER_BACKEND=clickhouse) → ClickHouse
+# Until CH indexer lands (see GitHub issue), use OpenSearch stack for end-to-end indexing:
+#   docker compose up -d
+#
+# This compose validates ClickHouse schema + proxy event production:
+#   docker compose -f docker-compose.clickhouse.yml up -d --build
+#   curl -x http://127.0.0.1:1488 http://httpbin.org/get
+#   curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+#
+# ADR: docs/adr/0002-clickhouse-analytics.md
+
+x-bake:
+  no-cache: false
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.9.8
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
+
+  kafka:
+    image: confluentinc/cp-kafka:7.9.8
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 30s
+
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.12
+    ports:
+      - "8123:8123"   # HTTP
+      - "9000:9000"   # native
+    environment:
+      CLICKHOUSE_DB: bsdm
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      - ./scripts/clickhouse/http_cache.sql:/docker-entrypoint-initdb.d/01-http_cache.sql:ro
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: proxy
+    ports:
+      - "1488:1488"
+      - "9090:9090"
+    environment:
+      - KAFKA_BROKERS=kafka:9092
+      - KAFKA_TOPIC=cache-events
+      - HTTP_PORT=1488
+      - METRICS_PORT=9090
+      - MITM_ENABLED=false
+      - AUTH_ENABLED=false
+      - ACL_ENABLED=false
+      - CATEGORIZATION_ENABLED=false
+      - CACHE_CAPACITY=10000
+      - CACHE_SHARDS=16
+      - WORKER_COUNT=1
+      - RUST_LOG=info,bsdm_proxy=info
+    depends_on:
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9090/health | grep -q ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # cache-indexer with INDEXER_BACKEND=clickhouse — see ADR 0002 / GitHub issue
+  # cache-indexer-ch:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile
+  #     target: cache-indexer
+  #   environment:
+  #     - INDEXER_BACKEND=clickhouse
+  #     - KAFKA_BROKERS=kafka:9092
+  #     - CLICKHOUSE_URL=http://clickhouse:8123
+  #     - CLICKHOUSE_DATABASE=bsdm
+  #     - CLICKHOUSE_TABLE=http_cache
+  #   depends_on:
+  #     kafka:
+  #       condition: service_healthy
+  #     clickhouse:
+  #       condition: service_healthy
+  #   networks:
+  #     - bsdm-ch-net
+
+  grafana:
+    image: grafana/grafana:12.3.8
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana-ch-data:/var/lib/grafana
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+
+networks:
+  bsdm-ch-net:
+    driver: bridge
+
+volumes:
+  clickhouse-data:
+  grafana-ch-data:

--- a/docs/adr/0002-clickhouse-analytics.md
+++ b/docs/adr/0002-clickhouse-analytics.md
@@ -67,3 +67,4 @@ Do not migrate Kafka and OpenSearch simultaneously.
 - [clickhouse-analytics.md](../clickhouse-analytics.md)
 - [roadmap.md](../roadmap.md) M3–M5
 - `bsdm-events::CacheEvent`
+- Implementation: [#114](https://github.com/onixus/bsdm-proxy/issues/114) — cache-indexer ClickHouse backend

--- a/docs/adr/0002-clickhouse-analytics.md
+++ b/docs/adr/0002-clickhouse-analytics.md
@@ -1,0 +1,69 @@
+# ADR 0002: ClickHouse analytics store (OpenSearch successor)
+
+## Status
+
+Proposed (2026-06)
+
+## Context
+
+BSDM analytics pipeline:
+
+```
+proxy → Kafka (CacheEvent JSON) → cache-indexer → OpenSearch → Dashboards
+```
+
+Roadmap M3–M5 workloads:
+
+| Milestone | Query pattern | Best store |
+|-----------|---------------|------------|
+| M3 Retro-search | domain/user + time filter, top-N | Columnar SQL |
+| M4 Threat analytics | windows, periodic patterns, GROUP BY | ClickHouse |
+| M5 ML | batch feature extraction | ClickHouse |
+
+Corporate medium: **~4M events/day**, 42-day retention ([capacity-planning.md](../capacity-planning.md)).
+
+OpenSearch works but is RAM-heavy and optimized for full-text search; BSDM queries are **structured analytics**.
+
+**Kafka vs NATS:** evaluated in parallel — bus unchanged in phase 1 (see Decision 2).
+
+## Decision
+
+### 1. ClickHouse as primary analytics store
+
+- Add `INDEXER_BACKEND=clickhouse` to cache-indexer (OpenSearch remains default during migration).
+- Schema: `scripts/clickhouse/http_cache.sql` — `MergeTree`, daily partitions, 42-day TTL.
+- Dashboards: Grafana + ClickHouse datasource (replace OpenSearch Dashboards for M3).
+
+### 2. Keep Kafka in phase 1–2; NATS optional later
+
+| Bus | When |
+|-----|------|
+| Kafka | Default — multi-consumer M4/M5, existing `rdkafka` integration |
+| NATS JetStream | Optional lab/k8s profile via `EventBus` abstraction (phase 3) |
+
+Do not migrate Kafka and OpenSearch simultaneously.
+
+### 3. Phased migration
+
+1. `docker-compose.clickhouse.yml` + schema (this ADR)
+2. cache-indexer ClickHouse backend + dual-write validation
+3. Search API (#110) on ClickHouse HTTP
+4. Deprecate OpenSearch in default compose
+
+## Consequences
+
+**Positive:** lower cost/RAM, SQL retro-search, M4/M5 fit, simpler Search API.
+
+**Negative:** lose KQL/OSD, rewrite indexer, dual-run during migration, fuzzy URL search weaker.
+
+## Alternatives rejected
+
+- NATS + OpenSearch only — does not fix analytics store mismatch
+- Both bus + store at once — too risky
+- TimescaleDB / Loki — weaker for this event shape and scale
+
+## References
+
+- [clickhouse-analytics.md](../clickhouse-analytics.md)
+- [roadmap.md](../roadmap.md) M3–M5
+- `bsdm-events::CacheEvent`

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -45,7 +45,9 @@ ORDER BY requests DESC
 LIMIT 50;
 ```
 
-## Миграция с OpenSearch
+## Реализация indexer
+
+Отслеживается в [#114](https://github.com/onixus/bsdm-proxy/issues/114) — `INDEXER_BACKEND=clickhouse` в cache-indexer.
 
 | Фаза | Действие |
 |------|----------|

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -1,0 +1,61 @@
+# ClickHouse analytics (M3+)
+
+Стек ретропоиска на ClickHouse вместо OpenSearch. См. [ADR 0002](adr/0002-clickhouse-analytics.md).
+
+## Быстрый старт
+
+```bash
+docker compose -f docker-compose.clickhouse.yml up -d --build
+
+# Проверка схемы
+curl 'http://127.0.0.1:8123/?query=SHOW+TABLES+FROM+bsdm'
+
+# Трафик через прокси (события уходят в Kafka)
+curl -x http://127.0.0.1:1488 http://httpbin.org/get
+
+# После реализации CH indexer — строки появятся в bsdm.http_cache
+curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+```
+
+Grafana: http://localhost:3000 (admin/admin) — добавьте datasource ClickHouse (`http://clickhouse:8123`).
+
+## Схема
+
+`scripts/clickhouse/http_cache.sql` — таблица `bsdm.http_cache`, TTL 42 дня, партиции по дню.
+
+Поля соответствуют `bsdm-events::CacheEvent` (включая `threat_sources`, `acl_action`).
+
+## Примеры SQL (M3)
+
+```sql
+-- Кто ходил на домен за 30 дней
+SELECT ts, username, client_ip, url, method, status, cache_status
+FROM bsdm.http_cache
+WHERE domain = 'example.com'
+  AND ts >= now() - INTERVAL 30 DAY
+ORDER BY ts DESC
+LIMIT 1000;
+
+-- Top domains per user (7 дней)
+SELECT username, domain, count() AS requests, sum(response_size) AS bytes
+FROM bsdm.http_cache
+WHERE ts >= now() - INTERVAL 7 DAY AND username IS NOT NULL
+GROUP BY username, domain
+ORDER BY requests DESC
+LIMIT 50;
+```
+
+## Миграция с OpenSearch
+
+| Фаза | Действие |
+|------|----------|
+| 1 | Этот compose + ADR 0002 |
+| 2 | `INDEXER_BACKEND=clickhouse` в cache-indexer |
+| 3 | Grafana SQL dashboards (замена OSD) |
+| 4 | Search API на ClickHouse HTTP |
+
+Kafka остаётся bus на фазе 1–2; NATS — опционально позже (ADR 0002).
+
+## k8s
+
+См. [k8s-architecture.md](k8s-architecture.md) — в analytics namespace заменить OpenSearch StatefulSet на ClickHouse Operator / Altinity chart.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -110,7 +110,9 @@ gantt
 
 ### Текущий gap
 
-Pipeline Kafka → OpenSearch работает; в v0.3.0+ добавлены `bsdm-events`, `acl_action`, `threat_sources`, события ACL block.
+Pipeline Kafka → OpenSearch работает; **целевой store M3+ — ClickHouse** ([ADR 0002](adr/0002-clickhouse-analytics.md)). В v0.3.0+ добавлены `bsdm-events`, `acl_action`, `threat_sources`, события ACL block.
+
+Текущий gap:
 Остаётся:
 - search API и session correlation
 
@@ -217,6 +219,8 @@ Issues привязывайте к milestones:
 ## Связанные документы
 
 - [architecture.md](architecture.md) — архитектура и блокеры B1–B25
+- [adr/0002-clickhouse-analytics.md](adr/0002-clickhouse-analytics.md) — ClickHouse вместо OpenSearch (M3+)
+- [clickhouse-analytics.md](clickhouse-analytics.md) — compose и SQL примеры
 - [hierarchical-caching.md](hierarchical-caching.md) — дизайн ICP/HTCP (M2)
 - [logging.md](logging.md) — `RUST_LOG` и профили логирования
 - [categorization.md](categorization.md) — threat intel feeds (M1/M4)

--- a/packaging/config/cache-indexer.env.example
+++ b/packaging/config/cache-indexer.env.example
@@ -18,3 +18,12 @@ OPENSEARCH_SSL_VERIFY=true
 # Logging — see docs/logging.md
 RUST_LOG=info,cache_indexer=info
 RUST_BACKTRACE=0
+
+# ClickHouse backend (ADR 0002 — not implemented yet; default opensearch)
+# INDEXER_BACKEND=opensearch
+# INDEXER_BACKEND=clickhouse
+# CLICKHOUSE_URL=http://127.0.0.1:8123
+# CLICKHOUSE_DATABASE=bsdm
+# CLICKHOUSE_TABLE=http_cache
+# CLICKHOUSE_USER=default
+# CLICKHOUSE_PASSWORD=

--- a/scripts/clickhouse/http_cache.sql
+++ b/scripts/clickhouse/http_cache.sql
@@ -1,0 +1,44 @@
+-- BSDM http-cache events (CacheEvent from bsdm-events crate)
+-- Mounted into ClickHouse: /docker-entrypoint-initdb.d/
+
+CREATE DATABASE IF NOT EXISTS bsdm;
+
+CREATE TABLE IF NOT EXISTS bsdm.http_cache
+(
+    event_id String,
+    ts DateTime64(3, 'UTC'),
+    url String,
+    method LowCardinality(String),
+    status UInt16,
+    cache_key String,
+    cache_status LowCardinality(String),
+    user_id Nullable(String),
+    username LowCardinality(Nullable(String)),
+    client_ip IPv4,
+    domain LowCardinality(String),
+    response_size UInt64,
+    request_duration_ms UInt32,
+    content_type LowCardinality(Nullable(String)),
+    user_agent String,
+    categories Array(LowCardinality(String)),
+    threat_sources Array(LowCardinality(String)),
+    acl_action LowCardinality(Nullable(String)),
+    headers String DEFAULT '{}'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(ts)
+ORDER BY (domain, username, ts, event_id)
+TTL ts + INTERVAL 42 DAY
+SETTINGS index_granularity = 8192;
+
+-- M3: who accessed domain X (30 days)
+-- SELECT ts, username, client_ip, url, method, status, cache_status
+-- FROM bsdm.http_cache
+-- WHERE domain = {domain:String} AND ts >= now() - INTERVAL 30 DAY
+-- ORDER BY ts DESC LIMIT 1000;
+
+-- M4: blocked events with threat sources
+-- SELECT ts, username, domain, url, categories, threat_sources, acl_action
+-- FROM bsdm.http_cache
+-- WHERE cache_status = 'DENY' OR acl_action = 'deny'
+--   AND ts >= now() - INTERVAL 7 DAY;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents decision to adopt **ClickHouse** as the primary analytics store for M3–M5 (retro-search, aggregations, ML), while keeping **Kafka** as the event bus in phase 1.

## Changes

| Path | Description |
|------|-------------|
| `docs/adr/0002-clickhouse-analytics.md` | ADR: CH primary store, Kafka kept, NATS optional later, phased migration |
| `docs/clickhouse-analytics.md` | Quickstart, SQL examples, migration phases |
| `docker-compose.clickhouse.yml` | Kafka + ClickHouse + proxy + Grafana (indexer service stub commented) |
| `scripts/clickhouse/http_cache.sql` | `bsdm.http_cache` MergeTree schema (42d TTL, bsdm-events fields) |
| `packaging/config/cache-indexer.env.example` | Future `INDEXER_BACKEND=clickhouse` vars |
| `docs/roadmap.md` | M3 target store note |

## Implementation issue

ClickHouse indexer backend tracked separately (see linked issue).

## Test plan

- [ ] `docker compose -f docker-compose.clickhouse.yml up -d`
- [ ] `curl 'http://127.0.0.1:8123/?query=SHOW+TABLES+FROM+bsdm'` returns `http_cache`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

