### PR TITLE
feat(proxy): streaming MISS — tee upstream to client while caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "bytes",
  "chrono",
  "hex",
+ "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -38,6 +38,7 @@ cargo install oha   # или бинарь с https://github.com/hatoo/oha
 | `HTTP_PRESERVE_HEADER_CASE` | `true` | `false` убирает preserve/title-case в http1 (bench) |
 | `KAFKA_SAMPLE_RATE` | `0` | `N` → 1 из N cache events в Kafka (`0` = все) |
 | `METRICS_SAMPLE_RATE` | `0` | `N` → histograms для 1 из N запросов (`0` = все) |
+| `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS body to client while buffering for L1 |
 
 ## Рекомендуемый bench-профиль
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
 |-----------|--------|-------|------------|
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, ACL, hierarchy, auth, compression | ✅ Done |
-| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~40% |
+| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~55% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, ClickHouse, Search API | ~60% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C detection | ~0% |
@@ -89,12 +89,12 @@ gantt
 - [x] **Tiered L1** — mmap spill + `HttpL1Cache` shards ([#93](https://github.com/onixus/bsdm-proxy/pull/93))
 - [x] **P0 perf** — `response_body()` Raw fast path, `TCP_SNDBUF_BYTES`, bench `WORKER_COUNT` ([#92](https://github.com/onixus/bsdm-proxy/pull/92))
 - [x] **k8s / HA docs** — [k8s-architecture.md](k8s-architecture.md), Helm chart `charts/bsdm/` ([#113](https://github.com/onixus/bsdm-proxy/pull/113))
+- [x] **Streaming MISS** — `TeeMissBody` tees upstream → client while buffering for L1; `STREAMING_MISS_ENABLED` (default `true`) ([#94](https://github.com/onixus/bsdm-proxy/issues/94))
 
 ### В работе (P0)
 
 | Issue | Задача |
 |-------|--------|
-| [#94](https://github.com/onixus/bsdm-proxy/issues/94) | Streaming MISS — tee upstream → client + cache |
 | [#95](https://github.com/onixus/bsdm-proxy/issues/95) | Connection-level proxy auth cache |
 | [#96](https://github.com/onixus/bsdm-proxy/issues/96) | Policy decision cache `(user, domain)` |
 | [#97](https://github.com/onixus/bsdm-proxy/issues/97) | Bench profiles `WORKER_COUNT` warm/cold |

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -32,7 +32,7 @@
 | Sharded L1 / reduced lock contention | multitenant internal | per-POP shards | cloud scale-out | ✅ `HttpL1Cache` (PR #93) | merge #93 |
 | Tiered body storage (inline + spill) | cloud object store | bare-metal optimized | cloud store | ✅ mmap spill (PR #93) | merge #93 |
 | Zero-copy large HIT serve | yes | yes | yes | ✅ `Bytes::from_owner` | — |
-| Streaming MISS (tee upstream→client) | yes | yes | yes | ❌ buffer-then-serve | **P0** `streaming_miss` |
+| Streaming MISS (tee upstream→client) | yes | yes | yes | ✅ `TeeMissBody` + `STREAMING_MISS_ENABLED` | merge #94 |
 | Connection-level auth cache | session at edge | identity on tunnel | GP session | ❌ auth per request | **P0** `conn_auth_cache` |
 | Policy decision cache | context cached at edge | unified policy engine | forwarding profiles | ❌ ACL+cat every request | **P0** `policy_decision_cache` |
 | PERF_FAST_CACHE_HIT (skip policy on HIT) | implicit | implicit | implicit | ✅ env flag | default on bench |

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -153,3 +153,5 @@ RUST_BACKTRACE=0
 # HTTP_PRESERVE_HEADER_CASE=false
 # KAFKA_SAMPLE_RATE=10
 # METRICS_SAMPLE_RATE=100
+# Stream upstream MISS responses to the client while buffering for L1 (default: true)
+# STREAMING_MISS_ENABLED=true

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -14,6 +14,7 @@ hyper = { version = "1.10", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+http-body = "1"
 http-body-util = "0.1"
 quick_cache = "0.7"
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }

--- a/proxy/src/acl_api.rs
+++ b/proxy/src/acl_api.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 
 use crate::acl::{AclAction, AclEngine, AclRule};
 use crate::acl_config::{load_acl_engine_from_file, parse_acl_action};
-use crate::http_types::Body;
+use crate::http_types::{full, Body};
 
 #[derive(Clone)]
 pub struct AclApiConfig {
@@ -192,10 +192,8 @@ fn json_response(status: StatusCode, body: &str) -> Response<Body> {
     Response::builder()
         .status(status)
         .header("Content-Type", "application/json; charset=utf-8")
-        .body(Body::new(Bytes::from(body.to_string())))
-        .unwrap_or_else(|_| {
-            Response::new(Body::new(Bytes::from_static(b"500 Internal Server Error")))
-        })
+        .body(full(Bytes::from(body.to_string())))
+        .unwrap_or_else(|_| Response::new(full(Bytes::from_static(b"500 Internal Server Error"))))
 }
 
 fn escape_json(value: &str) -> String {

--- a/proxy/src/cache.rs
+++ b/proxy/src/cache.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 
 use crate::cache_body::CachedBody;
 use crate::cache_compress::{decode_body, prepare_body_for_cache, BodyEncoding, CompressionConfig};
-use crate::http_types::Body;
+use crate::http_types::{full, Body};
 
 pub const CACHEABLE_METHODS: &[&str] = &["GET", "HEAD"];
 pub const CACHEABLE_STATUS_CODES: &[u16] = &[200, 203, 204, 206, 300, 301, 404, 405, 410, 414, 501];
@@ -92,7 +92,7 @@ impl CachedResponse {
 
     pub fn to_response_with_cache_status(&self, cache_status: &str) -> Response<Body> {
         let body = self.response_body();
-        let mut response = Response::new(Body::new(body));
+        let mut response = Response::new(full(body));
         *response.status_mut() = StatusCode::from_u16(self.status).unwrap_or(StatusCode::OK);
 
         let headers_mut = response.headers_mut();

--- a/proxy/src/cache_freshness.rs
+++ b/proxy/src/cache_freshness.rs
@@ -90,6 +90,21 @@ fn is_negative_status(status: u16) -> bool {
     matches!(status, 403 | 404)
 }
 
+pub fn content_length(headers: &HashMap<String, String>) -> Option<usize> {
+    header_value(headers, "content-length").and_then(|v| v.parse::<usize>().ok())
+}
+
+/// Pre-check cacheability from headers before the body is known (streaming MISS).
+pub fn evaluate_store_precheck(
+    method: &str,
+    status: u16,
+    headers: &HashMap<String, String>,
+    config: &CacheConfig,
+) -> CacheStoreDecision {
+    let size_hint = content_length(headers).unwrap_or(0);
+    evaluate_store(method, status, headers, size_hint, config)
+}
+
 /// Decide whether to store a response and compute freshness metadata.
 pub fn evaluate_store(
     method: &str,
@@ -98,7 +113,10 @@ pub fn evaluate_store(
     body_size: usize,
     config: &CacheConfig,
 ) -> CacheStoreDecision {
-    if !CACHEABLE_METHODS.contains(&method) || body_size > config.max_body_size {
+    if !CACHEABLE_METHODS.contains(&method) {
+        return CacheStoreDecision::bypass();
+    }
+    if body_size > config.max_body_size {
         return CacheStoreDecision::bypass();
     }
 

--- a/proxy/src/http_types.rs
+++ b/proxy/src/http_types.rs
@@ -1,5 +1,19 @@
 //! Shared HTTP body type alias.
 
 use bytes::Bytes;
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::Error;
+use std::convert::Infallible;
 
-pub type Body = http_body_util::Full<Bytes>;
+/// Response body: buffered (`Full`) or streaming (`TeeMissBody`, etc.).
+pub type Body = BoxBody<Bytes, Error>;
+
+pub fn full(bytes: impl Into<Bytes>) -> Body {
+    Full::new(bytes.into())
+        .map_err(|e: Infallible| match e {})
+        .boxed()
+}
+
+pub fn empty() -> Body {
+    full(Bytes::new())
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -30,6 +30,7 @@ pub mod rate_limit;
 pub mod selection;
 pub mod server;
 pub mod sharded_cache;
+pub mod streaming_miss;
 pub mod tls;
 pub mod upstream;
 

--- a/proxy/src/peer_fetch.rs
+++ b/proxy/src/peer_fetch.rs
@@ -1,16 +1,14 @@
 //! Forward HTTP requests to a parent/sibling cache peer (forward proxy).
 
+use crate::http_types::Body as ProxyBody;
 use crate::peers::CachePeer;
-use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tracing::debug;
-
-type Body = Full<Bytes>;
 
 #[derive(Debug)]
 pub enum PeerFetchError {
@@ -36,9 +34,16 @@ impl std::error::Error for PeerFetchError {}
 /// Send an HTTP forward-proxy request through a cache peer.
 pub async fn fetch_via_peer(
     peer: &CachePeer,
-    req: Request<Body>,
+    req: Request<ProxyBody>,
     timeout: Duration,
 ) -> Result<Response<Incoming>, PeerFetchError> {
+    let (parts, body) = req.into_parts();
+    let body_bytes = BodyExt::collect(body)
+        .await
+        .map_err(PeerFetchError::Request)?
+        .to_bytes();
+    let req = Request::from_parts(parts, Full::new(body_bytes));
+
     let addr = format!("{}:{}", peer.config.host, peer.config.port);
     debug!("Fetching via peer {} ({})", peer.id, addr);
 
@@ -70,6 +75,7 @@ pub async fn fetch_via_peer(
 mod tests {
     use super::*;
     use crate::peers::{CachePeer, PeerConfig, PeerType};
+    use bytes::Bytes;
     use http_body_util::BodyExt;
     use hyper::service::service_fn;
     use hyper::{Method, StatusCode};
@@ -119,7 +125,7 @@ mod tests {
         let req = Request::builder()
             .method(Method::GET)
             .uri("http://example.com/via-peer")
-            .body(Full::new(Bytes::new()))
+            .body(crate::http_types::empty())
             .unwrap();
 
         let response = fetch_via_peer(&peer, req, Duration::from_secs(5))

--- a/proxy/src/perf.rs
+++ b/proxy/src/perf.rs
@@ -17,6 +17,8 @@ pub struct PerfConfig {
     pub kafka_sample_rate: u32,
     /// Record detailed request histograms for 1 of N requests (0 = all).
     pub metrics_sample_rate: u32,
+    /// Stream upstream MISS bodies to the client while buffering for cache (#94).
+    pub streaming_miss_enabled: bool,
 }
 
 impl PerfConfig {
@@ -44,12 +46,15 @@ impl PerfConfig {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0);
 
+        let streaming_miss_enabled = env_bool("STREAMING_MISS_ENABLED", true);
+
         Self {
             fast_cache_hit,
             worker_count,
             http_preserve_header_case,
             kafka_sample_rate,
             metrics_sample_rate,
+            streaming_miss_enabled,
         }
     }
 
@@ -154,6 +159,7 @@ mod tests {
             http_preserve_header_case: true,
             kafka_sample_rate: 0,
             metrics_sample_rate: 0,
+            streaming_miss_enabled: true,
         };
         assert!(cfg.should_emit_kafka_event());
         assert!(cfg.record_detailed_metrics());
@@ -167,6 +173,7 @@ mod tests {
             http_preserve_header_case: true,
             kafka_sample_rate: 1,
             metrics_sample_rate: 0,
+            streaming_miss_enabled: true,
         };
         assert!(cfg.should_emit_kafka_event());
     }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -3,6 +3,7 @@
 use base64::engine::general_purpose;
 use base64::Engine;
 use bytes::Bytes;
+use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use hyper::header::{
     HeaderName, HeaderValue, AUTHORIZATION, IF_MODIFIED_SINCE, IF_NONE_MATCH, LOCATION,
@@ -22,11 +23,11 @@ use crate::acl::{AclAction, AclDecision, AclEngine};
 use crate::auth::{AuthManager, ProxyAuthOutcome, UserInfo};
 use crate::cache::{CacheConfig, CachedResponse, CACHEABLE_METHODS};
 use crate::cache_digest::DigestRegistry;
-use crate::cache_freshness::{evaluate_store, refresh_ttl_from_headers};
+use crate::cache_freshness::{evaluate_store, evaluate_store_precheck, refresh_ttl_from_headers};
 use crate::cache_key::http_cache_key;
 use crate::categorization::CategorizationEngine;
 use crate::hierarchy::{HierarchyManager, HierarchyResult};
-use crate::http_types::Body;
+use crate::http_types::{empty, full, Body};
 use crate::l2_cache::RedisL2Cache;
 use crate::metrics::{FastRequestScope, Metrics, RequestMetricsGuard};
 use crate::peer_fetch::fetch_via_peer;
@@ -37,12 +38,173 @@ use crate::pipeline::{
 };
 use crate::rate_limit::{RateLimitViolation, RateLimiter};
 use crate::sharded_cache::HttpL1Cache;
+use crate::streaming_miss::TeeMissBody;
 use crate::tls::CertCache;
 use crate::upstream::{build_upstream_https_connector, UpstreamTlsConfig};
 
 pub struct ProxyPolicy {
     pub acl_engine: Option<Arc<RwLock<AclEngine>>>,
     pub categorization: Option<Arc<CategorizationEngine>>,
+}
+
+/// Cloneable handles for streaming MISS completion (runs after body drained).
+#[derive(Clone)]
+struct MissCompletionHandle {
+    http_cache: Arc<HttpL1Cache>,
+    cache_config: CacheConfig,
+    l2_cache: Option<RedisL2Cache>,
+    hierarchy: Option<Arc<HierarchyManager>>,
+    metrics: Arc<Metrics>,
+    kafka_producer: Option<Arc<FutureProducer>>,
+    kafka_topic: String,
+    perf: PerfConfig,
+    digest_registry: Option<Arc<DigestRegistry>>,
+}
+
+impl MissCompletionHandle {
+    fn store_in_l1_and_l2(&self, cache_key: Arc<str>, cached_response: CachedResponse) {
+        self.http_cache
+            .insert(cache_key.clone(), cached_response.clone());
+        if let Some(registry) = &self.digest_registry {
+            let key = cache_key.to_string();
+            let reg = registry.clone();
+            tokio::spawn(async move {
+                reg.insert_cache_key(&key).await;
+            });
+        }
+        if let Some(l2) = &self.l2_cache {
+            let l2 = l2.clone();
+            tokio::spawn(async move {
+                l2.set(cache_key.as_ref(), &cached_response).await;
+            });
+        }
+    }
+
+    fn send_cache_event(&self, event: CacheEvent) {
+        if !self.perf.should_emit_kafka_event() {
+            return;
+        }
+        if let Some(producer) = self.kafka_producer.clone() {
+            send_to_kafka_async(
+                producer,
+                self.kafka_topic.clone(),
+                self.metrics.clone(),
+                event,
+            );
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn complete_cache_miss(
+        &self,
+        cache_key: Arc<str>,
+        url: &str,
+        method: &str,
+        domain: &str,
+        status: u16,
+        headers_map: &HashMap<String, String>,
+        body_bytes: Bytes,
+        store_decision: &crate::cache_freshness::CacheStoreDecision,
+        stored: bool,
+        user_id: Option<String>,
+        username: Option<String>,
+        client_ip: &str,
+        categories: &[String],
+        threat_sources: &[String],
+        request_start: Instant,
+        request_body_size: usize,
+        hierarchy_peer: Option<Arc<CachePeer>>,
+        mut guard: Option<RequestMetricsGuard>,
+        mut fast_scope: Option<FastRequestScope>,
+    ) {
+        let body_size = body_bytes.len();
+
+        if let (Some(hierarchy), Some(peer)) = (self.hierarchy.clone(), hierarchy_peer) {
+            let bytes = body_size as u64;
+            tokio::spawn(async move {
+                hierarchy.record_peer_hit(&peer, bytes).await;
+            });
+        }
+
+        if stored && store_decision.store {
+            let headers_arc: Arc<[(Arc<str>, Arc<str>)]> = headers_map
+                .iter()
+                .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
+                .collect();
+
+            let cached_response = CachedResponse::from_upstream(
+                status,
+                headers_arc,
+                body_bytes,
+                store_decision.ttl,
+                &self.cache_config.compression,
+                self.cache_config.spill_threshold_bytes,
+                &self.cache_config.spill_dir,
+                store_decision.etag.clone(),
+                store_decision.last_modified.clone(),
+                store_decision.is_negative,
+                store_decision.must_revalidate,
+            );
+            self.store_in_l1_and_l2(cache_key.clone(), cached_response);
+            if let Some(g) = guard.as_mut() {
+                g.set_cache_status(if store_decision.is_negative {
+                    "NEGATIVE_MISS"
+                } else {
+                    "MISS"
+                });
+            }
+        } else {
+            self.metrics.cache_bypasses_total.inc();
+            if let Some(g) = guard.as_mut() {
+                g.set_cache_status("BYPASS");
+            }
+        }
+
+        let cache_status = if stored && store_decision.store {
+            if store_decision.is_negative {
+                "NEGATIVE_MISS"
+            } else {
+                "MISS"
+            }
+        } else {
+            "BYPASS"
+        };
+
+        if self.perf.should_emit_kafka_event() {
+            if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                let event = CacheEvent {
+                    url: url.to_string(),
+                    method: method.to_string(),
+                    status,
+                    cache_key: cache_key.to_string(),
+                    cache_status: cache_status.to_string(),
+                    timestamp: timestamp.as_secs(),
+                    headers: headers_map.clone(),
+                    user_id,
+                    username,
+                    client_ip: client_ip.to_string(),
+                    domain: domain.to_string(),
+                    response_size: body_size as u64,
+                    request_duration_ms: request_start.elapsed().as_millis() as u64,
+                    content_type: headers_map.get("content-type").cloned(),
+                    user_agent: headers_map.get("user-agent").cloned(),
+                    categories: categories.to_vec(),
+                    threat_sources: threat_sources.to_vec(),
+                    acl_action: None,
+                    event_id: new_event_id(),
+                };
+                self.send_cache_event(event);
+            }
+        }
+
+        ProxyService::finish_request_metrics(
+            &mut guard,
+            &mut fast_scope,
+            status,
+            request_body_size,
+            body_size,
+        );
+    }
 }
 
 pub struct ProxyService {
@@ -80,6 +242,20 @@ impl ProxyService {
 
     pub fn http_preserve_header_case(&self) -> bool {
         self.perf.http_preserve_header_case
+    }
+
+    fn miss_completion_handle(&self) -> MissCompletionHandle {
+        MissCompletionHandle {
+            http_cache: self.http_cache.clone(),
+            cache_config: self.cache_config.clone(),
+            l2_cache: self.l2_cache.clone(),
+            hierarchy: self.hierarchy.clone(),
+            metrics: self.metrics.clone(),
+            kafka_producer: self.kafka_producer.clone(),
+            kafka_topic: self.kafka_topic.clone(),
+            perf: self.perf.clone(),
+            digest_registry: self.digest_registry.clone(),
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -401,7 +577,7 @@ impl ProxyService {
         if let Some(lm) = &cached.last_modified {
             builder = builder.header(IF_MODIFIED_SINCE, lm.as_ref());
         }
-        builder.body(Body::new(Bytes::new())).ok()
+        builder.body(empty()).ok()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -498,10 +674,8 @@ impl ProxyService {
                 Response::builder()
                     .status(StatusCode::FORBIDDEN)
                     .header("Content-Type", "text/plain; charset=utf-8")
-                    .body(Body::new(Bytes::from(body)))
-                    .unwrap_or_else(|_| {
-                        Response::new(Body::new(Bytes::from_static(b"403 Forbidden")))
-                    })
+                    .body(full(Bytes::from(body)))
+                    .unwrap_or_else(|_| Response::new(full(Bytes::from_static(b"403 Forbidden"))))
             }
             AclAction::Redirect => {
                 let target = decision
@@ -512,10 +686,10 @@ impl ProxyService {
                 Response::builder()
                     .status(StatusCode::FOUND)
                     .header(LOCATION, target)
-                    .body(Body::new(Bytes::new()))
-                    .unwrap_or_else(|_| Response::new(Body::new(Bytes::new())))
+                    .body(empty())
+                    .unwrap_or_else(|_| Response::new(empty()))
             }
-            AclAction::Allow => Response::new(Body::new(Bytes::new())),
+            AclAction::Allow => Response::new(empty()),
         }
     }
 
@@ -579,12 +753,10 @@ impl ProxyService {
             .status(StatusCode::TOO_MANY_REQUESTS)
             .header("Content-Type", "text/plain; charset=utf-8")
             .header("Retry-After", "1")
-            .body(Body::new(Bytes::from_static(
+            .body(full(Bytes::from_static(
                 b"429 Too Many Requests: rate limit exceeded",
             )))
-            .unwrap_or_else(|_| {
-                Response::new(Body::new(Bytes::from_static(b"429 Too Many Requests")))
-            })
+            .unwrap_or_else(|_| Response::new(full(Bytes::from_static(b"429 Too Many Requests"))))
     }
 
     #[inline]
@@ -682,6 +854,85 @@ impl ProxyService {
             g.finish(status, request_size, response_size);
         } else if let Some(scope) = fast_scope.take() {
             scope.finish(status);
+        }
+    }
+
+    fn headers_map_from_response(response: &Response<Incoming>) -> HashMap<String, String> {
+        response
+            .headers()
+            .iter()
+            .filter_map(|(k, v)| {
+                v.to_str()
+                    .ok()
+                    .map(|v| (k.as_str().to_string(), v.to_string()))
+            })
+            .collect()
+    }
+
+    fn apply_response_headers(headers_map: &HashMap<String, String>, resp: &mut Response<Body>) {
+        for (key, value) in headers_map {
+            if let (Ok(name), Ok(val)) = (
+                HeaderName::from_bytes(key.as_bytes()),
+                HeaderValue::from_str(value),
+            ) {
+                resp.headers_mut().insert(name, val);
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn complete_cache_miss(
+        &self,
+        cache_key: Arc<str>,
+        url: &str,
+        method: &str,
+        domain: &str,
+        status: u16,
+        headers_map: &HashMap<String, String>,
+        body_bytes: Bytes,
+        store_decision: &crate::cache_freshness::CacheStoreDecision,
+        stored: bool,
+        user_id: Option<String>,
+        username: Option<String>,
+        client_ip: &str,
+        categories: &[String],
+        threat_sources: &[String],
+        request_start: Instant,
+        request_body_size: usize,
+        hierarchy_peer: Option<Arc<CachePeer>>,
+        guard: Option<RequestMetricsGuard>,
+        fast_scope: Option<FastRequestScope>,
+    ) -> &'static str {
+        let stored_and_cached = stored && store_decision.store;
+        self.miss_completion_handle().complete_cache_miss(
+            cache_key,
+            url,
+            method,
+            domain,
+            status,
+            headers_map,
+            body_bytes,
+            store_decision,
+            stored,
+            user_id,
+            username,
+            client_ip,
+            categories,
+            threat_sources,
+            request_start,
+            request_body_size,
+            hierarchy_peer,
+            guard,
+            fast_scope,
+        );
+        if stored_and_cached {
+            if store_decision.is_negative {
+                "NEGATIVE_MISS"
+            } else {
+                "MISS"
+            }
+        } else {
+            "BYPASS"
         }
     }
 
@@ -897,20 +1148,21 @@ impl ProxyService {
             Ok(collected) => collected.to_bytes(),
             Err(e) => {
                 error!("Body collection failed: {}", e);
-                let mut resp = Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
+                let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
                 *resp.status_mut() = StatusCode::BAD_REQUEST;
                 Self::finish_request_metrics(&mut guard, &mut fast_scope, 400, 0, 15);
                 return resp;
             }
         };
         let request_body_size = body_bytes.len();
-        let req = Request::from_parts(parts, Body::new(body_bytes.clone()));
+        let req_for_peer = Request::from_parts(parts.clone(), full(body_bytes.clone()));
+        let req = Request::from_parts(parts, full(body_bytes));
 
         let domain = Self::extract_domain(&url);
         let upstream_start = Instant::now();
 
         let peer_fetch = self
-            .try_fetch_via_hierarchy(method, &url, req.clone())
+            .try_fetch_via_hierarchy(method, &url, req_for_peer)
             .await;
         let hierarchy_peer = peer_fetch.as_ref().map(|(peer, _)| peer.clone());
 
@@ -924,25 +1176,94 @@ impl ProxyService {
             Ok(response) => {
                 let upstream_duration = upstream_start.elapsed().as_secs_f64();
                 let status = response.status();
+                let status_code = status.as_u16();
 
                 self.metrics
                     .upstream_requests_total
-                    .with_label_values(&[&domain, &status.as_u16().to_string()])
+                    .with_label_values(&[&domain, &status_code.to_string()])
                     .inc();
                 self.metrics
                     .upstream_duration_seconds
                     .with_label_values(&[&domain])
                     .observe(upstream_duration);
 
-                let headers_map: HashMap<String, String> = response
-                    .headers()
-                    .iter()
-                    .filter_map(|(k, v)| {
-                        v.to_str()
-                            .ok()
-                            .map(|v| (k.as_str().to_string(), v.to_string()))
-                    })
-                    .collect();
+                let headers_map = Self::headers_map_from_response(&response);
+                let store_precheck =
+                    evaluate_store_precheck(method, status_code, &headers_map, &self.cache_config);
+
+                if self.perf.streaming_miss_enabled {
+                    let upstream_body = response.into_body();
+                    let x_cache = if store_precheck.store {
+                        "MISS"
+                    } else {
+                        "BYPASS"
+                    };
+
+                    let handle = self.miss_completion_handle();
+                    let cache_key_cb = cache_key.clone();
+                    let url_cb = url.clone();
+                    let method_cb = method.to_string();
+                    let domain_cb = domain.clone();
+                    let headers_cb = headers_map.clone();
+                    let store_precheck_cb = store_precheck.clone();
+                    let user_id_cb = user_id.clone();
+                    let username_cb = username.clone();
+                    let client_ip_cb = client_ip.clone();
+                    let categories_cb = categories.clone();
+                    let threat_sources_cb = threat_sources.clone();
+                    let hierarchy_peer_cb = hierarchy_peer.clone();
+                    let mut guard_cb = guard.take();
+                    let mut fast_scope_cb = fast_scope.take();
+
+                    let tee = TeeMissBody::new(
+                        upstream_body,
+                        store_precheck.store,
+                        self.cache_config.max_body_size,
+                        move |body_bytes, stored| {
+                            let final_decision = if stored {
+                                evaluate_store(
+                                    &method_cb,
+                                    status_code,
+                                    &headers_cb,
+                                    body_bytes.len(),
+                                    &handle.cache_config,
+                                )
+                            } else {
+                                crate::cache_freshness::CacheStoreDecision::bypass()
+                            };
+                            handle.complete_cache_miss(
+                                cache_key_cb,
+                                &url_cb,
+                                &method_cb,
+                                &domain_cb,
+                                status_code,
+                                &headers_cb,
+                                body_bytes,
+                                &final_decision,
+                                stored && final_decision.store,
+                                user_id_cb,
+                                username_cb,
+                                &client_ip_cb,
+                                &categories_cb,
+                                &threat_sources_cb,
+                                request_start,
+                                request_body_size,
+                                hierarchy_peer_cb,
+                                guard_cb.take(),
+                                fast_scope_cb.take(),
+                            );
+                            let _ = store_precheck_cb;
+                        },
+                    );
+
+                    let mut resp = Response::new(tee.boxed());
+                    *resp.status_mut() = status;
+                    Self::apply_response_headers(&headers_map, &mut resp);
+                    if let Ok(val) = HeaderValue::from_str(x_cache) {
+                        resp.headers_mut().insert("x-cache-status", val);
+                    }
+                    return resp;
+                }
 
                 let body_bytes = match http_body_util::BodyExt::collect(response.into_body()).await
                 {
@@ -953,8 +1274,7 @@ impl ProxyService {
                             .upstream_errors_total
                             .with_label_values(&[&domain, "body_read"])
                             .inc();
-                        let mut resp =
-                            Response::new(Body::new(Bytes::from_static(b"502 Bad Gateway")));
+                        let mut resp = Response::new(full(Bytes::from_static(b"502 Bad Gateway")));
                         *resp.status_mut() = StatusCode::BAD_GATEWAY;
                         Self::finish_request_metrics(
                             &mut guard,
@@ -966,103 +1286,42 @@ impl ProxyService {
                         return resp;
                     }
                 };
-                let body_size = body_bytes.len();
-
-                if let (Some(hierarchy), Some(peer)) =
-                    (self.hierarchy.as_ref(), hierarchy_peer.as_ref())
-                {
-                    hierarchy.record_peer_hit(peer, body_size as u64).await;
-                }
 
                 let store_decision = evaluate_store(
                     method,
-                    status.as_u16(),
+                    status_code,
                     &headers_map,
-                    body_size,
+                    body_bytes.len(),
                     &self.cache_config,
                 );
-                let cache_status = if store_decision.store {
-                    let headers_arc: Arc<[(Arc<str>, Arc<str>)]> = headers_map
-                        .iter()
-                        .map(|(k, v)| (Arc::from(k.as_str()), Arc::from(v.as_str())))
-                        .collect();
-
-                    let cached_response = CachedResponse::from_upstream(
-                        status.as_u16(),
-                        headers_arc,
-                        body_bytes.clone(),
-                        store_decision.ttl,
-                        &self.cache_config.compression,
-                        self.cache_config.spill_threshold_bytes,
-                        &self.cache_config.spill_dir,
-                        store_decision.etag,
-                        store_decision.last_modified,
-                        store_decision.is_negative,
-                        store_decision.must_revalidate,
-                    );
-                    self.store_in_l1_and_l2(cache_key.clone(), cached_response);
-                    if let Some(g) = guard.as_mut() {
-                        g.set_cache_status(if store_decision.is_negative {
-                            "NEGATIVE_MISS"
-                        } else {
-                            "MISS"
-                        });
-                    }
-                    if store_decision.is_negative {
-                        "NEGATIVE_MISS"
-                    } else {
-                        "MISS"
-                    }
-                } else {
-                    self.metrics.cache_bypasses_total.inc();
-                    if let Some(g) = guard.as_mut() {
-                        g.set_cache_status("BYPASS");
-                    }
-                    "BYPASS"
-                };
-
-                if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                    let event = CacheEvent {
-                        url: url.clone(),
-                        method: method.to_string(),
-                        status: status.as_u16(),
-                        cache_key: cache_key.to_string(),
-                        cache_status: cache_status.to_string(),
-                        timestamp: timestamp.as_secs(),
-                        headers: headers_map.clone(),
-                        user_id,
-                        username,
-                        client_ip,
-                        domain,
-                        response_size: body_size as u64,
-                        request_duration_ms: request_start.elapsed().as_millis() as u64,
-                        content_type: headers_map.get("content-type").cloned(),
-                        user_agent: headers_map.get("user-agent").cloned(),
-                        categories: categories.clone(),
-                        threat_sources: threat_sources.clone(),
-                        acl_action: None,
-                        event_id: new_event_id(),
-                    };
-                    self.send_cache_event(event);
-                }
-
-                let mut resp = Response::new(Body::new(body_bytes));
-                *resp.status_mut() = status;
-                for (key, value) in headers_map {
-                    if let (Ok(name), Ok(val)) = (
-                        HeaderName::from_bytes(key.as_bytes()),
-                        HeaderValue::from_str(&value),
-                    ) {
-                        resp.headers_mut().insert(name, val);
-                    }
-                }
-                Self::finish_request_metrics(
-                    &mut guard,
-                    &mut fast_scope,
-                    status.as_u16(),
+                let cache_status = self.complete_cache_miss(
+                    cache_key,
+                    &url,
+                    method,
+                    &domain,
+                    status_code,
+                    &headers_map,
+                    body_bytes.clone(),
+                    &store_decision,
+                    store_decision.store,
+                    user_id,
+                    username,
+                    &client_ip,
+                    &categories,
+                    &threat_sources,
+                    request_start,
                     request_body_size,
-                    body_size,
+                    hierarchy_peer,
+                    guard.take(),
+                    fast_scope.take(),
                 );
+
+                let mut resp = Response::new(full(body_bytes));
+                *resp.status_mut() = status;
+                Self::apply_response_headers(&headers_map, &mut resp);
+                if let Ok(val) = HeaderValue::from_str(cache_status) {
+                    resp.headers_mut().insert("x-cache-status", val);
+                }
                 resp
             }
             Err(e) => {
@@ -1071,7 +1330,7 @@ impl ProxyService {
                     .upstream_errors_total
                     .with_label_values(&[&domain, "connection"])
                     .inc();
-                let mut response = Response::new(Body::new(Bytes::from_static(b"502 Bad Gateway")));
+                let mut response = Response::new(full(Bytes::from_static(b"502 Bad Gateway")));
                 *response.status_mut() = StatusCode::BAD_GATEWAY;
                 Self::finish_request_metrics(
                     &mut guard,

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -24,7 +24,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::acl_api::AclApiState;
 use crate::auth::UserInfo;
-use crate::http_types::Body;
+use crate::http_types::{empty, full};
 use crate::metrics::Metrics;
 use crate::pipeline::{new_event_id, CacheEvent};
 use crate::proxy_service::ProxyService;
@@ -118,10 +118,10 @@ pub async fn metrics_server(
                                                 .status(StatusCode::OK)
                                                 .header("Content-Type", "text/plain; version=0.0.4")
                                                 .header("Content-Length", body.len().to_string())
-                                                .body(Body::new(Bytes::from(body)))
+                                                .body(full(Bytes::from(body)))
                                                 .unwrap_or_else(|e| {
                                                     error!("Failed to build metrics response: {}", e);
-                                                    Response::new(Body::new(Bytes::from_static(
+                                                    Response::new(full(Bytes::from_static(
                                                         b"500 Internal Server Error",
                                                     )))
                                                 })
@@ -130,11 +130,11 @@ pub async fn metrics_server(
                                             error!("Failed to export metrics: {}", e);
                                             Response::builder()
                                                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                                .body(Body::new(Bytes::from_static(
+                                                .body(full(Bytes::from_static(
                                                     b"500 Internal Server Error",
                                                 )))
                                                 .unwrap_or_else(|_| {
-                                                    Response::new(Body::new(Bytes::from_static(
+                                                    Response::new(full(Bytes::from_static(
                                                         b"500 Internal Server Error",
                                                     )))
                                                 })
@@ -143,11 +143,11 @@ pub async fn metrics_server(
                                             error!("Metrics export panicked: {:?}", panic_info);
                                             Response::builder()
                                                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                                .body(Body::new(Bytes::from_static(
+                                                .body(full(Bytes::from_static(
                                                     b"500 Panic in metrics export",
                                                 )))
                                                 .unwrap_or_else(|_| {
-                                                    Response::new(Body::new(Bytes::from_static(
+                                                    Response::new(full(Bytes::from_static(
                                                         b"500 Internal Server Error",
                                                     )))
                                                 })
@@ -159,9 +159,9 @@ pub async fn metrics_server(
                                     Response::builder()
                                         .status(StatusCode::OK)
                                         .header("Content-Type", "application/json")
-                                        .body(Body::new(Bytes::from_static(b"{\"status\":\"ok\"}")))
+                                        .body(full(Bytes::from_static(b"{\"status\":\"ok\"}")))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Body::new(Bytes::from_static(
+                                            Response::new(full(Bytes::from_static(
                                                 b"{\"status\":\"ok\"}",
                                             )))
                                         })
@@ -172,11 +172,11 @@ pub async fn metrics_server(
                                         Response::builder()
                                             .status(StatusCode::SERVICE_UNAVAILABLE)
                                             .header("Content-Type", "application/json")
-                                            .body(Body::new(Bytes::from_static(
+                                            .body(full(Bytes::from_static(
                                                 b"{\"status\":\"draining\"}",
                                             )))
                                             .unwrap_or_else(|_| {
-                                                Response::new(Body::new(Bytes::from_static(
+                                                Response::new(full(Bytes::from_static(
                                                     b"{\"status\":\"draining\"}",
                                                 )))
                                             })
@@ -185,11 +185,11 @@ pub async fn metrics_server(
                                         Response::builder()
                                             .status(StatusCode::OK)
                                             .header("Content-Type", "application/json")
-                                            .body(Body::new(Bytes::from_static(
+                                            .body(full(Bytes::from_static(
                                                 b"{\"status\":\"ready\"}",
                                             )))
                                             .unwrap_or_else(|_| {
-                                                Response::new(Body::new(Bytes::from_static(
+                                                Response::new(full(Bytes::from_static(
                                                     b"{\"status\":\"ready\"}",
                                                 )))
                                             })
@@ -199,9 +199,9 @@ pub async fn metrics_server(
                                     warn!("Unknown metrics endpoint: {}", path);
                                     Response::builder()
                                         .status(StatusCode::NOT_FOUND)
-                                        .body(Body::new(Bytes::from_static(b"404 Not Found")))
+                                        .body(full(Bytes::from_static(b"404 Not Found")))
                                         .unwrap_or_else(|_| {
-                                            Response::new(Body::new(Bytes::from_static(b"404 Not Found")))
+                                            Response::new(full(Bytes::from_static(b"404 Not Found")))
                                         })
                                 }
                             };
@@ -369,7 +369,7 @@ async fn handle_connect_mitm(
                 Ok(req) => req,
                 Err(e) => {
                     error!("Failed to rewrite MITM request for {}: {}", authority, e);
-                    let mut resp = Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
+                    let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
                     *resp.status_mut() = StatusCode::BAD_REQUEST;
                     return Ok::<_, Infallible>(resp);
                 }
@@ -412,8 +412,7 @@ pub async fn handle_connection(
                     Some(auth) => auth.as_str().to_string(),
                     None => {
                         error!("CONNECT without authority");
-                        let mut resp =
-                            Response::new(Body::new(Bytes::from_static(b"400 Bad Request")));
+                        let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
                         *resp.status_mut() = StatusCode::BAD_REQUEST;
                         return Ok::<_, Infallible>(resp);
                     }
@@ -481,10 +480,10 @@ pub async fn handle_connection(
 
                 let response = Response::builder()
                     .status(StatusCode::OK)
-                    .body(Body::new(Bytes::new()))
+                    .body(empty())
                     .unwrap_or_else(|e| {
                         error!("Failed to build response: {}", e);
-                        let mut resp = Response::new(Body::new(Bytes::new()));
+                        let mut resp = Response::new(empty());
                         *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
                         resp
                     });

--- a/proxy/src/streaming_miss.rs
+++ b/proxy/src/streaming_miss.rs
@@ -1,0 +1,150 @@
+//! Streaming cache MISS: tee upstream response frames to the client while buffering for L1.
+
+use bytes::{Bytes, BytesMut};
+use http_body::{Body, Frame, SizeHint};
+use hyper::body::Incoming;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::{Context, Poll};
+
+type MissCompleteFn = Box<dyn FnOnce(Bytes, bool) + Send>;
+type MissCompleteSlot = Mutex<Option<MissCompleteFn>>;
+
+/// Buffers upstream body frames and forwards them unchanged to the client.
+pub struct TeeMissBody<B> {
+    upstream: B,
+    acc: BytesMut,
+    attempt_cache: bool,
+    max_body: usize,
+    finished: bool,
+    on_complete: MissCompleteSlot,
+}
+
+impl<B> TeeMissBody<B>
+where
+    B: Body<Data = Bytes, Error = hyper::Error> + Unpin,
+{
+    pub fn new(
+        upstream: B,
+        attempt_cache: bool,
+        max_body: usize,
+        on_complete: impl FnOnce(Bytes, bool) + Send + 'static,
+    ) -> Self {
+        Self {
+            upstream,
+            acc: BytesMut::new(),
+            attempt_cache,
+            max_body,
+            finished: false,
+            on_complete: Mutex::new(Some(Box::new(on_complete))),
+        }
+    }
+}
+
+impl<B> Body for TeeMissBody<B>
+where
+    B: Body<Data = Bytes, Error = hyper::Error> + Unpin,
+{
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.finished {
+            return Poll::Ready(None);
+        }
+
+        let this = self.as_mut().get_mut();
+        match Pin::new(&mut this.upstream).poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(chunk) = frame.data_ref() {
+                    if this.attempt_cache {
+                        if this.acc.len() + chunk.len() > this.max_body {
+                            this.attempt_cache = false;
+                            this.acc.clear();
+                        } else {
+                            this.acc.extend_from_slice(chunk);
+                        }
+                    }
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+            Poll::Ready(None) => {
+                this.finished = true;
+                let body = if this.attempt_cache {
+                    std::mem::take(&mut this.acc).freeze()
+                } else {
+                    Bytes::new()
+                };
+                let cached = this.attempt_cache;
+                if let Ok(mut slot) = this.on_complete.lock() {
+                    if let Some(on_complete) = slot.take() {
+                        on_complete(body, cached);
+                    }
+                }
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.finished || self.upstream.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.upstream.size_hint()
+    }
+}
+
+pub type StreamingMissBody = TeeMissBody<Incoming>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::{BodyExt, Full};
+    use std::convert::Infallible;
+    use std::sync::{Arc, Mutex};
+
+    fn test_upstream(payload: Bytes) -> impl Body<Data = Bytes, Error = hyper::Error> + Unpin {
+        Full::new(payload).map_err(|e: Infallible| match e {})
+    }
+
+    #[tokio::test]
+    async fn tees_chunks_and_completes() {
+        let payload = Bytes::from_static(b"hello-stream");
+        let upstream = test_upstream(payload.clone());
+        let seen = Arc::new(Mutex::new((Bytes::new(), false)));
+        let seen2 = seen.clone();
+
+        let body = TeeMissBody::new(upstream, true, 1024, move |buf, cached| {
+            *seen2.lock().unwrap() = (buf, cached);
+        });
+
+        let collected = body.collect().await.expect("collect").to_bytes();
+        assert_eq!(collected, payload);
+
+        let (buf, cached) = seen.lock().unwrap().clone();
+        assert!(cached);
+        assert_eq!(buf, payload);
+    }
+
+    #[tokio::test]
+    async fn disables_cache_when_max_exceeded() {
+        let payload = Bytes::from_static(b"0123456789");
+        let upstream = test_upstream(payload.clone());
+        let seen = Arc::new(Mutex::new(false));
+        let seen2 = seen.clone();
+
+        let body = TeeMissBody::new(upstream, true, 4, move |_buf, cached| {
+            *seen2.lock().unwrap() = cached;
+        });
+
+        let collected = body.collect().await.expect("collect").to_bytes();
+        assert_eq!(collected, payload);
+        assert!(!*seen.lock().unwrap());
+    }
+}

--- a/proxy/src/streaming_miss.rs
+++ b/proxy/src/streaming_miss.rs
@@ -3,48 +3,137 @@
 use bytes::{Bytes, BytesMut};
 use http_body::{Body, Frame, SizeHint};
 use hyper::body::Incoming;
+use std::future::poll_fn;
 use std::pin::Pin;
 use std::sync::Mutex;
 use std::task::{Context, Poll};
+use tokio::sync::mpsc;
 
-type MissCompleteFn = Box<dyn FnOnce(Bytes, bool) + Send>;
-type MissCompleteSlot = Mutex<Option<MissCompleteFn>>;
+type FrameResult = Result<Frame<Bytes>, hyper::Error>;
 
 /// Buffers upstream body frames and forwards them unchanged to the client.
-pub struct TeeMissBody<B> {
-    upstream: B,
-    acc: BytesMut,
-    attempt_cache: bool,
-    max_body: usize,
+///
+/// Upstream is drained in a background task so L1 storage completes once the
+/// origin response is fully received, even if the client has not read the body yet.
+pub struct TeeMissBody {
+    rx: mpsc::Receiver<FrameResult>,
     finished: bool,
-    on_complete: MissCompleteSlot,
 }
 
-impl<B> TeeMissBody<B>
-where
-    B: Body<Data = Bytes, Error = hyper::Error> + Unpin,
-{
+impl TeeMissBody {
     pub fn new(
-        upstream: B,
+        upstream: Incoming,
         attempt_cache: bool,
         max_body: usize,
         on_complete: impl FnOnce(Bytes, bool) + Send + 'static,
     ) -> Self {
-        Self {
-            upstream,
-            acc: BytesMut::new(),
-            attempt_cache,
-            max_body,
-            finished: false,
-            on_complete: Mutex::new(Some(Box::new(on_complete))),
-        }
+        Self::from_upstream(upstream, attempt_cache, max_body, on_complete)
+    }
+
+    #[cfg(test)]
+    fn from_upstream<B>(
+        upstream: B,
+        attempt_cache: bool,
+        max_body: usize,
+        on_complete: impl FnOnce(Bytes, bool) + Send + 'static,
+    ) -> Self
+    where
+        B: Body<Data = Bytes, Error = hyper::Error> + Unpin + Send + 'static,
+    {
+        spawn_upstream_drain(upstream, attempt_cache, max_body, on_complete)
+    }
+
+    #[cfg(not(test))]
+    fn from_upstream(
+        upstream: Incoming,
+        attempt_cache: bool,
+        max_body: usize,
+        on_complete: impl FnOnce(Bytes, bool) + Send + 'static,
+    ) -> Self {
+        spawn_upstream_drain(upstream, attempt_cache, max_body, on_complete)
     }
 }
 
-impl<B> Body for TeeMissBody<B>
+fn spawn_upstream_drain<B>(
+    upstream: B,
+    attempt_cache: bool,
+    max_body: usize,
+    on_complete: impl FnOnce(Bytes, bool) + Send + 'static,
+) -> TeeMissBody
 where
-    B: Body<Data = Bytes, Error = hyper::Error> + Unpin,
+    B: Body<Data = Bytes, Error = hyper::Error> + Unpin + Send + 'static,
 {
+    let (tx, rx) = mpsc::channel::<FrameResult>(16);
+    let on_complete = Mutex::new(Some(Box::new(on_complete)));
+
+    tokio::spawn(async move {
+        let mut upstream = upstream;
+        let mut acc = BytesMut::new();
+        let mut attempt_cache = attempt_cache;
+        let mut client_gone = false;
+
+        loop {
+            let frame = poll_fn(|cx| Pin::new(&mut upstream).poll_frame(cx)).await;
+            match frame {
+                Some(Ok(frame)) => {
+                    if let Some(chunk) = frame.data_ref() {
+                        if attempt_cache {
+                            if acc.len() + chunk.len() > max_body {
+                                attempt_cache = false;
+                                acc.clear();
+                            } else {
+                                acc.extend_from_slice(chunk);
+                            }
+                        }
+                    }
+
+                    if !client_gone {
+                        let forward = if let Some(chunk) = frame.data_ref() {
+                            Frame::data(chunk.clone())
+                        } else if frame.is_trailers() {
+                            match frame.into_trailers() {
+                                Ok(trailers) => Frame::trailers(trailers),
+                                Err(_) => {
+                                    client_gone = true;
+                                    continue;
+                                }
+                            }
+                        } else {
+                            continue;
+                        };
+
+                        if tx.send(Ok(forward)).await.is_err() {
+                            client_gone = true;
+                        }
+                    }
+                }
+                Some(Err(e)) => {
+                    let _ = tx.send(Err(e)).await;
+                    break;
+                }
+                None => break,
+            }
+        }
+
+        if let Ok(mut slot) = on_complete.lock() {
+            if let Some(on_complete) = slot.take() {
+                let body = if attempt_cache {
+                    acc.freeze()
+                } else {
+                    Bytes::new()
+                };
+                on_complete(body, attempt_cache);
+            }
+        }
+    });
+
+    TeeMissBody {
+        rx,
+        finished: false,
+    }
+}
+
+impl Body for TeeMissBody {
     type Data = Bytes;
     type Error = hyper::Error;
 
@@ -56,35 +145,10 @@ where
             return Poll::Ready(None);
         }
 
-        let this = self.as_mut().get_mut();
-        match Pin::new(&mut this.upstream).poll_frame(cx) {
-            Poll::Ready(Some(Ok(frame))) => {
-                if let Some(chunk) = frame.data_ref() {
-                    if this.attempt_cache {
-                        if this.acc.len() + chunk.len() > this.max_body {
-                            this.attempt_cache = false;
-                            this.acc.clear();
-                        } else {
-                            this.acc.extend_from_slice(chunk);
-                        }
-                    }
-                }
-                Poll::Ready(Some(Ok(frame)))
-            }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(frame)) => Poll::Ready(Some(frame)),
             Poll::Ready(None) => {
-                this.finished = true;
-                let body = if this.attempt_cache {
-                    std::mem::take(&mut this.acc).freeze()
-                } else {
-                    Bytes::new()
-                };
-                let cached = this.attempt_cache;
-                if let Ok(mut slot) = this.on_complete.lock() {
-                    if let Some(on_complete) = slot.take() {
-                        on_complete(body, cached);
-                    }
-                }
+                self.finished = true;
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,
@@ -92,24 +156,24 @@ where
     }
 
     fn is_end_stream(&self) -> bool {
-        self.finished || self.upstream.is_end_stream()
+        self.finished
     }
 
     fn size_hint(&self) -> SizeHint {
-        self.upstream.size_hint()
+        SizeHint::new()
     }
 }
-
-pub type StreamingMissBody = TeeMissBody<Incoming>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http_body_util::{BodyExt, Full};
+    use http_body_util::{combinators::MapErr, BodyExt, Full};
     use std::convert::Infallible;
     use std::sync::{Arc, Mutex};
 
-    fn test_upstream(payload: Bytes) -> impl Body<Data = Bytes, Error = hyper::Error> + Unpin {
+    type TestUpstream = MapErr<Full<Bytes>, fn(Infallible) -> hyper::Error>;
+
+    fn test_upstream(payload: Bytes) -> TestUpstream {
         Full::new(payload).map_err(|e: Infallible| match e {})
     }
 
@@ -120,7 +184,7 @@ mod tests {
         let seen = Arc::new(Mutex::new((Bytes::new(), false)));
         let seen2 = seen.clone();
 
-        let body = TeeMissBody::new(upstream, true, 1024, move |buf, cached| {
+        let body = TeeMissBody::from_upstream(upstream, true, 1024, move |buf, cached| {
             *seen2.lock().unwrap() = (buf, cached);
         });
 
@@ -139,12 +203,27 @@ mod tests {
         let seen = Arc::new(Mutex::new(false));
         let seen2 = seen.clone();
 
-        let body = TeeMissBody::new(upstream, true, 4, move |_buf, cached| {
+        let body = TeeMissBody::from_upstream(upstream, true, 4, move |_buf, cached| {
             *seen2.lock().unwrap() = cached;
         });
 
         let collected = body.collect().await.expect("collect").to_bytes();
         assert_eq!(collected, payload);
         assert!(!*seen.lock().unwrap());
+    }
+
+    #[tokio::test]
+    async fn caches_before_client_drains_body() {
+        let payload = Bytes::from_static(b"cache-on-headers");
+        let upstream = test_upstream(payload.clone());
+        let cached = Arc::new(Mutex::new(false));
+        let cached2 = cached.clone();
+
+        let _body = TeeMissBody::from_upstream(upstream, true, 1024, move |_buf, stored| {
+            *cached2.lock().unwrap() = stored;
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(*cached.lock().unwrap());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#94 Streaming MISS**: on cache MISS, upstream response frames are streamed to the client immediately while `TeeMissBody` buffers them for L1 storage.

- `TeeMissBody` — background upstream drain + mpsc tee to client
- `MissCompletionHandle` — cloneable handle for post-stream cache store, Kafka events, and metrics
- `STREAMING_MISS_ENABLED` (default `true`); when `false`, falls back to collect-then-serve
- `evaluate_store_precheck()` — header-only cacheability check before body size is known
- Response body type unified as `BoxBody` via `full()` / `empty()` helpers

**Fix (741d72a):** upstream is drained in a spawned task so L1 is populated once the origin response is fully received, even if the client has not read the body yet. Fixes `e2e_cache_hit_on_repeat_request`.

Closes #94

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

All tests pass including `e2e_cache_hit_on_repeat_request`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

