### PR TITLE
feat(proxy): connection-level proxy auth cache (#95)

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -94,7 +94,11 @@ Successful authentications are cached to reduce load on authentication servers:
 
 ```bash
 export AUTH_CACHE_TTL=300  # seconds (default: 5 minutes)
+# Per-TCP-connection auth cache for HTTP keep-alive (0 = disabled)
+export AUTH_CONN_CACHE_TTL_SECONDS=300
 ```
+
+On keep-alive connections, a successful `Proxy-Authorization` is reused for subsequent requests on the same TCP socket without re-running LDAP/crypto. Set `AUTH_CONN_CACHE_TTL_SECONDS=0` to disable.
 
 NTLM/Kerberos sessions are also keyed by client IP for the handshake duration.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
 |-----------|--------|-------|------------|
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, ACL, hierarchy, auth, compression | ✅ Done |
-| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~55% |
+| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~65% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, ClickHouse, Search API | ~60% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C detection | ~0% |
@@ -90,12 +90,12 @@ gantt
 - [x] **P0 perf** — `response_body()` Raw fast path, `TCP_SNDBUF_BYTES`, bench `WORKER_COUNT` ([#92](https://github.com/onixus/bsdm-proxy/pull/92))
 - [x] **k8s / HA docs** — [k8s-architecture.md](k8s-architecture.md), Helm chart `charts/bsdm/` ([#113](https://github.com/onixus/bsdm-proxy/pull/113))
 - [x] **Streaming MISS** — `TeeMissBody` tees upstream → client while buffering for L1; `STREAMING_MISS_ENABLED` (default `true`) ([#94](https://github.com/onixus/bsdm-proxy/issues/94))
+- [x] **Connection auth cache** — per-TCP keep-alive `Proxy-Authorization` reuse; `AUTH_CONN_CACHE_TTL_SECONDS` ([#95](https://github.com/onixus/bsdm-proxy/issues/95))
 
 ### В работе (P0)
 
 | Issue | Задача |
 |-------|--------|
-| [#95](https://github.com/onixus/bsdm-proxy/issues/95) | Connection-level proxy auth cache |
 | [#96](https://github.com/onixus/bsdm-proxy/issues/96) | Policy decision cache `(user, domain)` |
 | [#97](https://github.com/onixus/bsdm-proxy/issues/97) | Bench profiles `WORKER_COUNT` warm/cold |
 | [#98](https://github.com/onixus/bsdm-proxy/issues/98) | Spill files `mode 0o600` |

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -33,7 +33,7 @@
 | Tiered body storage (inline + spill) | cloud object store | bare-metal optimized | cloud store | ✅ mmap spill (PR #93) | merge #93 |
 | Zero-copy large HIT serve | yes | yes | yes | ✅ `Bytes::from_owner` | — |
 | Streaming MISS (tee upstream→client) | yes | yes | yes | ✅ `TeeMissBody` + `STREAMING_MISS_ENABLED` | merge #94 |
-| Connection-level auth cache | session at edge | identity on tunnel | GP session | ❌ auth per request | **P0** `conn_auth_cache` |
+| Connection-level auth cache | session at edge | identity on tunnel | GP session | ✅ `ConnAuthCache` + `AUTH_CONN_CACHE_TTL_SECONDS` | merge #95 |
 | Policy decision cache | context cached at edge | unified policy engine | forwarding profiles | ❌ ACL+cat every request | **P0** `policy_decision_cache` |
 | PERF_FAST_CACHE_HIT (skip policy on HIT) | implicit | implicit | implicit | ✅ env flag | default on bench |
 | Multi-worker accept (SO_REUSEPORT) | internal | internal | internal | ✅ `WORKER_COUNT` | tune 1 vs 4 profiles |

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -47,6 +47,7 @@ SHUTDOWN_TIMEOUT_SECONDS=30
 
 # Proxy authentication
 AUTH_ENABLED=false
+# AUTH_CONN_CACHE_TTL_SECONDS=300
 # AUTH_BACKEND=basic   # default
 # AUTH_BACKEND=ldap    # requires build with --features auth-ldap
 # AUTH_BACKEND=basic    # basic (default), ldap, ntlm, kerberos

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -198,6 +198,8 @@ pub struct AuthConfig {
     pub backend: AuthBackend,
     pub realm: String,
     pub cache_ttl: Duration,
+    /// Per-TCP-connection auth cache TTL (`AUTH_CONN_CACHE_TTL_SECONDS`; `0` = disabled).
+    pub conn_cache_ttl: Duration,
     #[cfg(feature = "auth-ldap")]
     pub ldap: Option<LdapConfig>,
     #[cfg(feature = "auth-ntlm")]
@@ -213,6 +215,7 @@ impl Default for AuthConfig {
             backend: AuthBackend::Basic,
             realm: "BSDM-Proxy".to_string(),
             cache_ttl: Duration::from_secs(300),
+            conn_cache_ttl: Duration::from_secs(300),
             #[cfg(feature = "auth-ldap")]
             ldap: None,
             #[cfg(feature = "auth-ntlm")]
@@ -227,6 +230,72 @@ impl Default for AuthConfig {
 struct HandshakeSession {
     session: SspiSession,
     created_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct ConnAuthEntry {
+    user: UserInfo,
+    cred_fingerprint: Option<String>,
+    authenticated_at: Instant,
+}
+
+/// Per-TCP-connection proxy auth cache for HTTP keep-alive.
+#[derive(Debug)]
+pub struct ConnAuthCache {
+    ttl: Duration,
+    inner: RwLock<Option<ConnAuthEntry>>,
+}
+
+impl ConnAuthCache {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            inner: RwLock::new(None),
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        !self.ttl.is_zero()
+    }
+
+    pub async fn get(&self, cred_fingerprint: Option<&str>) -> Option<UserInfo> {
+        if !self.enabled() {
+            return None;
+        }
+        let guard = self.inner.read().await;
+        let entry = guard.as_ref()?;
+        if entry.authenticated_at.elapsed() > self.ttl {
+            return None;
+        }
+        match (cred_fingerprint, entry.cred_fingerprint.as_deref()) {
+            (None, _) => Some(entry.user.clone()),
+            (Some(fp), Some(cached)) if fp == cached => Some(entry.user.clone()),
+            (Some(_), Some(_)) => None,
+            (Some(_), None) => Some(entry.user.clone()),
+        }
+    }
+
+    pub async fn store(&self, user: UserInfo, cred_fingerprint: Option<String>) {
+        if !self.enabled() {
+            return;
+        }
+        let mut guard = self.inner.write().await;
+        *guard = Some(ConnAuthEntry {
+            user,
+            cred_fingerprint,
+            authenticated_at: Instant::now(),
+        });
+    }
+
+    pub async fn invalidate(&self) {
+        let mut guard = self.inner.write().await;
+        *guard = None;
+    }
+}
+
+fn proxy_auth_fingerprint<T>(req: &Request<T>) -> Option<String> {
+    let value = req.headers().get(PROXY_AUTHORIZATION)?.to_str().ok()?;
+    Some(CachedUser::hash_password(value))
 }
 
 /// Authentication manager
@@ -290,6 +359,10 @@ impl AuthManager {
         self.config.enabled
     }
 
+    pub fn conn_cache_ttl(&self) -> Duration {
+        self.config.conn_cache_ttl
+    }
+
     /// Extract credentials from request
     pub fn extract_credentials<T>(&self, req: &Request<T>) -> Option<(String, String)> {
         let auth_header = req.headers().get(PROXY_AUTHORIZATION)?;
@@ -331,12 +404,21 @@ impl AuthManager {
     /// Handle proxy authentication including multi-round NTLM / Kerberos.
     pub async fn handle_proxy_auth<T>(
         &self,
-        #[allow(unused_variables)] client_key: &str,
+        _client_key: &str,
         req: &Request<T>,
+        conn_auth: Option<&ConnAuthCache>,
     ) -> ProxyAuthOutcome {
         #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
         if self.uses_sspi_handshake() {
-            return self.handle_sspi_auth(client_key, req).await;
+            return self.handle_sspi_auth(client_key, req, conn_auth).await;
+        }
+
+        let cred_fp = proxy_auth_fingerprint(req);
+        if let Some(cache) = conn_auth {
+            if let Some(user) = cache.get(cred_fp.as_deref()).await {
+                debug!("Connection auth cache hit for {}", user.username);
+                return ProxyAuthOutcome::Authenticated(user);
+            }
         }
 
         let Some((username, password)) = self.extract_credentials(req) else {
@@ -346,8 +428,16 @@ impl AuthManager {
         };
 
         match self.authenticate(&username, &password).await {
-            Ok(user) => ProxyAuthOutcome::Authenticated(user),
+            Ok(user) => {
+                if let Some(cache) = conn_auth {
+                    cache.store(user.clone(), cred_fp).await;
+                }
+                ProxyAuthOutcome::Authenticated(user)
+            }
             Err(e) => {
+                if let Some(cache) = conn_auth {
+                    cache.invalidate().await;
+                }
                 warn!("Proxy authentication failed for {}: {}", username, e);
                 ProxyAuthOutcome::Challenge {
                     authenticate_header: self.initial_auth_header(),
@@ -357,7 +447,12 @@ impl AuthManager {
     }
 
     #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
-    async fn handle_sspi_auth<T>(&self, client_key: &str, req: &Request<T>) -> ProxyAuthOutcome {
+    async fn handle_sspi_auth<T>(
+        &self,
+        client_key: &str,
+        req: &Request<T>,
+        conn_auth: Option<&ConnAuthCache>,
+    ) -> ProxyAuthOutcome {
         let Some(engine) = &self.sspi_engine else {
             return ProxyAuthOutcome::Challenge {
                 authenticate_header: self.initial_auth_header(),
@@ -370,6 +465,12 @@ impl AuthManager {
             .map(|(_, bytes)| bytes);
 
         if token.is_none() {
+            if let Some(cache) = conn_auth {
+                if let Some(user) = cache.get(None).await {
+                    debug!("Connection auth cache hit for {}", user.username);
+                    return ProxyAuthOutcome::Authenticated(user);
+                }
+            }
             if let Some(cached) = self.principal_cache.read().await.get(client_key).cloned() {
                 if cached.authenticated_at.elapsed() < self.config.cache_ttl {
                     return ProxyAuthOutcome::Authenticated(cached);
@@ -428,6 +529,9 @@ impl AuthManager {
                     .write()
                     .await
                     .insert(client_key.to_string(), user.clone());
+                if let Some(cache) = conn_auth {
+                    cache.store(user.clone(), None).await;
+                }
                 ProxyAuthOutcome::Authenticated(user)
             }
             Ok(SspiStepResult::Challenge { token_b64 }) => ProxyAuthOutcome::Challenge {
@@ -435,6 +539,9 @@ impl AuthManager {
             },
             Ok(SspiStepResult::Failed(reason)) => {
                 self.handshake_sessions.write().await.remove(client_key);
+                if let Some(cache) = conn_auth {
+                    cache.invalidate().await;
+                }
                 warn!("SSPI authentication failed for {}: {}", client_key, reason);
                 ProxyAuthOutcome::Challenge {
                     authenticate_header: self.initial_auth_header(),
@@ -927,5 +1034,106 @@ mod tests {
 
         let cached = manager.get_cached_user("testuser").await;
         assert!(cached.unwrap().is_expired());
+    }
+
+    fn basic_proxy_request(user: &str, pass: &str) -> Request<()> {
+        let token = general_purpose::STANDARD.encode(format!("{user}:{pass}"));
+        Request::builder()
+            .uri("http://example.com/")
+            .header(PROXY_AUTHORIZATION, format!("Basic {token}"))
+            .body(())
+            .unwrap()
+    }
+
+    fn bare_proxy_request() -> Request<()> {
+        Request::builder()
+            .uri("http://example.com/")
+            .body(())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn conn_auth_cache_hit_without_proxy_authorization_header() {
+        let config = AuthConfig {
+            enabled: true,
+            backend: AuthBackend::Basic,
+            ..Default::default()
+        };
+        let manager = AuthManager::new(config);
+        let conn = ConnAuthCache::new(Duration::from_secs(60));
+        let secret = unit_test_secret();
+
+        let first = manager
+            .handle_proxy_auth(
+                "conn-1",
+                &basic_proxy_request("alice", &secret),
+                Some(&conn),
+            )
+            .await;
+        assert!(matches!(first, ProxyAuthOutcome::Authenticated(_)));
+
+        let second = manager
+            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn))
+            .await;
+        match second {
+            ProxyAuthOutcome::Authenticated(user) => assert_eq!(user.username, "alice"),
+            other => panic!("expected authenticated cache hit, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn conn_auth_cache_reauths_when_credentials_change() {
+        let config = AuthConfig {
+            enabled: true,
+            backend: AuthBackend::Basic,
+            ..Default::default()
+        };
+        let manager = AuthManager::new(config);
+        let conn = ConnAuthCache::new(Duration::from_secs(60));
+        let secret = unit_test_secret();
+
+        let first = manager
+            .handle_proxy_auth(
+                "conn-1",
+                &basic_proxy_request("alice", &secret),
+                Some(&conn),
+            )
+            .await;
+        assert!(matches!(first, ProxyAuthOutcome::Authenticated(_)));
+
+        let changed = manager
+            .handle_proxy_auth("conn-1", &basic_proxy_request("bob", &secret), Some(&conn))
+            .await;
+        match changed {
+            ProxyAuthOutcome::Authenticated(user) => assert_eq!(user.username, "bob"),
+            other => panic!("expected re-auth with new credentials, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn conn_auth_cache_miss_after_invalidate() {
+        let config = AuthConfig {
+            enabled: true,
+            backend: AuthBackend::Basic,
+            ..Default::default()
+        };
+        let manager = AuthManager::new(config);
+        let conn = ConnAuthCache::new(Duration::from_secs(60));
+        let secret = unit_test_secret();
+
+        manager
+            .handle_proxy_auth(
+                "conn-1",
+                &basic_proxy_request("alice", &secret),
+                Some(&conn),
+            )
+            .await;
+
+        conn.invalidate().await;
+
+        let follow_up = manager
+            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn))
+            .await;
+        assert!(matches!(follow_up, ProxyAuthOutcome::Challenge { .. }));
     }
 }

--- a/proxy/src/auth_config.rs
+++ b/proxy/src/auth_config.rs
@@ -135,12 +135,17 @@ pub fn load_auth_config() -> AuthConfig {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(300);
+    let conn_cache_ttl_secs = std::env::var("AUTH_CONN_CACHE_TTL_SECONDS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(300);
 
     AuthConfig {
         enabled,
         backend,
         realm,
         cache_ttl: Duration::from_secs(cache_ttl_secs),
+        conn_cache_ttl: Duration::from_secs(conn_cache_ttl_secs),
         #[cfg(feature = "auth-ldap")]
         ldap: load_ldap_config(enabled, backend),
         #[cfg(feature = "auth-ntlm")]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -42,7 +42,7 @@ pub use acl_config::{load_acl_engine_from_file, parse_acl_action};
 pub use auth::KerberosConfig;
 #[cfg(feature = "auth-ntlm")]
 pub use auth::NtlmConfig;
-pub use auth::{AuthBackend, AuthConfig, AuthManager, ProxyAuthOutcome, UserInfo};
+pub use auth::{AuthBackend, AuthConfig, AuthManager, ConnAuthCache, ProxyAuthOutcome, UserInfo};
 pub use bsdm_events::CacheEvent;
 pub use cache::{CacheConfig, CachedResponse};
 pub use cache_body::CachedBody;

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -697,6 +697,7 @@ impl ProxyService {
         &self,
         req: &Request<Incoming>,
         client_ip: &str,
+        conn_auth: Option<&crate::auth::ConnAuthCache>,
     ) -> Result<Option<Arc<UserInfo>>, Response<Body>> {
         let Some(auth) = &self.auth else {
             return Ok(None);
@@ -705,12 +706,15 @@ impl ProxyService {
             return Ok(None);
         }
 
-        match auth.handle_proxy_auth(client_ip, req).await {
+        match auth.handle_proxy_auth(client_ip, req, conn_auth).await {
             ProxyAuthOutcome::Anonymous => Ok(None),
             ProxyAuthOutcome::Authenticated(user) => Ok(Some(Arc::new(user))),
             ProxyAuthOutcome::Challenge {
                 authenticate_header,
             } => {
+                if let Some(cache) = conn_auth {
+                    cache.invalidate().await;
+                }
                 tracing::debug!("Proxy authentication challenge issued");
                 Err(auth.create_auth_challenge_response(authenticate_header))
             }

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use std::panic;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Instant, SystemTime};
+use std::time::{Duration, Instant, SystemTime};
 
 use bytes::Bytes;
 use hyper::body::Incoming;
@@ -23,6 +23,7 @@ use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
 
 use crate::acl_api::AclApiState;
+use crate::auth::ConnAuthCache;
 use crate::auth::UserInfo;
 use crate::http_types::{empty, full};
 use crate::metrics::Metrics;
@@ -399,12 +400,18 @@ pub async fn handle_connection(
     tune_client_tcp(&stream, addr);
     let io = TokioIo::new(stream);
     let preserve_headers = service.http_preserve_header_case();
+    let conn_auth_ttl = service
+        .auth()
+        .map(|auth| auth.conn_cache_ttl())
+        .unwrap_or(Duration::ZERO);
+    let conn_auth = Arc::new(ConnAuthCache::new(conn_auth_ttl));
 
     let svc = service_fn(move |req: Request<Incoming>| {
         let service = service.clone();
         let client_ip = client_ip.clone();
         let request_start = Instant::now();
         let tasks = tasks.clone();
+        let conn_auth = conn_auth.clone();
 
         async move {
             if req.method() == Method::CONNECT {
@@ -418,7 +425,10 @@ pub async fn handle_connection(
                     }
                 };
 
-                let proxy_user = match service.authenticate_proxy(&req, &client_ip).await {
+                let proxy_user = match service
+                    .authenticate_proxy(&req, &client_ip, Some(&conn_auth))
+                    .await
+                {
                     Ok(user) => user,
                     Err(resp) => return Ok(resp),
                 };
@@ -490,7 +500,10 @@ pub async fn handle_connection(
                 return Ok::<_, Infallible>(response);
             }
 
-            let proxy_user = match service.authenticate_proxy(&req, &client_ip).await {
+            let proxy_user = match service
+                .authenticate_proxy(&req, &client_ip, Some(&conn_auth))
+                .await
+            {
                 Ok(user) => user,
                 Err(resp) => return Ok(resp),
             };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **#95 Connection-level proxy auth cache**: successful `Proxy-Authorization` is cached per TCP connection so subsequent HTTP keep-alive requests reuse identity without re-running auth/LDAP.

- `ConnAuthCache` — per-connection state in `server.rs` (one per `handle_connection`)
- `AUTH_CONN_CACHE_TTL_SECONDS` (default `300`; `0` = disabled)
- Cache hit when `Proxy-Authorization` is absent on follow-up requests
- Re-auth when credentials fingerprint changes mid-connection
- Invalidate on 407 challenge / auth failure
- SSPI (NTLM/Kerberos): conn cache checked before client-IP `principal_cache`

Closes #95

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

New unit tests: `conn_auth_cache_hit_without_proxy_authorization_header`, `conn_auth_cache_reauths_when_credentials_change`, `conn_auth_cache_miss_after_invalidate`.

## Checklist

- [x] CI-ready
- [x] Docs: `docs/authentication.md`, `docs/roadmap.md`, env example
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

