### PR TITLE
feat(cache): spill files mode 0o600 and private CACHE_SPILL_DIR (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `CACHE_CAPACITY` | `10000` | Размер L1-кеша (на шард) |
 | `CACHE_SHARDS` | `16` | Число шардов L1 (`quick_cache` на шард) |
 | `CACHE_SPILL_THRESHOLD_BYTES` | `262144` | Тела ≥ порога — в mmap spill (`0` = только inline) |
-| `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог spill-файлов для крупных тел |
+| `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог spill-файлов (dir `0o700`, files `0o600` на Unix) |
 | `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS → client при записи в L1 |
 | `CACHE_TTL_SECONDS` | `3600` | Fallback TTL кеша (сек), если нет `max-age` |
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
@@ -379,7 +379,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 |-----------|--------|-------|--------|
 | **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability | ✅ Done |
 | **M2** Squid parity | v0.3.x | L2, ACL API, NTLM/Kerberos, hierarchy Phase 4 | ✅ Done |
-| **M2.5** Data plane | v0.3.1 | Tiered L1, streaming MISS, auth/policy cache, bench | ~85% |
+| **M2.5** Data plane | v0.3.1 | Tiered L1, streaming MISS, auth/policy cache, bench | ~95% |
 | **M3** Retro-search | v0.4.x | OpenSearch/ClickHouse, dashboards, Search API | ~60% |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | ~5% |
 | **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | ~0% |
@@ -389,7 +389,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 - [x] Tiered L1 (mmap spill + shards), P0 perf, k8s/Helm docs
 - [x] Streaming MISS, connection auth cache, policy decision cache
 - [x] HTTP Archive bench profiles (`BENCH_PROFILE=warm|cold`)
-- [ ] Spill files `mode 0o600` ([#98](https://github.com/onixus/bsdm-proxy/issues/98))
+- [x] Spill files `mode 0o600` + private `CACHE_SPILL_DIR` ([#98](https://github.com/onixus/bsdm-proxy/issues/98))
 
 **Gate M2.5:** warm goodput на HTTP Archive sites bench ≥ Squid −5%.
 

--- a/docs/k8s-architecture.md
+++ b/docs/k8s-architecture.md
@@ -117,7 +117,7 @@ securityContext:
   fsGroup: 65532
 ```
 
-Spill files: `mode 0o600` (см. [#98](https://github.com/onixus/bsdm-proxy/issues/98)).
+Spill files: `mode 0o600`, directory `0o700` (см. `ensure_private_spill_dir` в `cache_body.rs`, [#98](https://github.com/onixus/bsdm-proxy/issues/98)).
 
 ---
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -34,7 +34,7 @@ cargo install oha   # или бинарь с https://github.com/hatoo/oha
 | `TCP_SNDBUF_BYTES` | `524288` | SO_SNDBUF на клиентских соединениях (`0` = не менять) |
 | `CACHE_SHARDS` | `16` | Число шардов L1 (`quick_cache` на шард); снижает contention при `WORKER_COUNT>1` |
 | `CACHE_SPILL_THRESHOLD_BYTES` | `262144` | Тела ≥ порога пишутся в mmap spill (`0` = только inline) |
-| `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог временных spill-файлов для крупных тел |
+| `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог spill-файлов (dir `0o700`, files `0o600` на Unix) |
 | `HTTP_PRESERVE_HEADER_CASE` | `true` | `false` убирает preserve/title-case в http1 (bench) |
 | `KAFKA_SAMPLE_RATE` | `0` | `N` → 1 из N cache events в Kafka (`0` = все) |
 | `METRICS_SAMPLE_RATE` | `0` | `N` → histograms для 1 из N запросов (`0` = все) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
 |-----------|--------|-------|------------|
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, ACL, hierarchy, auth, compression | ✅ Done |
-| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~85% |
+| [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~95% |
 | [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, ClickHouse, Search API | ~60% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C detection | ~0% |
@@ -93,12 +93,11 @@ gantt
 - [x] **Connection auth cache** — per-TCP keep-alive `Proxy-Authorization` reuse; `AUTH_CONN_CACHE_TTL_SECONDS` ([#95](https://github.com/onixus/bsdm-proxy/issues/95))
 - [x] **Policy decision cache** — `(principal, domain)` ACL+cat; `POLICY_DECISION_CACHE_TTL_SECONDS`; flush on ACL reload ([#96](https://github.com/onixus/bsdm-proxy/issues/96))
 - [x] **HTTP Archive bench profiles** — `BENCH_PROFILE=warm|cold` → `WORKER_COUNT` 1/4; `bench-profile.sh` ([#97](https://github.com/onixus/bsdm-proxy/issues/97))
+- [x] **Spill file permissions** — `CACHE_SPILL_DIR` `0o700`, spill files `0o600` on Unix ([#98](https://github.com/onixus/bsdm-proxy/issues/98))
 
 ### В работе (P0)
 
-| Issue | Задача |
-|-------|--------|
-| [#98](https://github.com/onixus/bsdm-proxy/issues/98) | Spill files `mode 0o600` |
+_Нет открытых P0 — gate M2.5: warm goodput HTTP Archive ≥ Squid −5%._
 
 ### P1 (single-pass hot path)
 

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -47,7 +47,7 @@
 | Паттерн | Zscaler | Netskope | Palo Alto | BSDM | Backlog |
 |---------|---------|----------|-----------|------|---------|
 | L1 RAM cache | minimal | minimal | minimal | ✅ sharded quick_cache | — |
-| Disk / mmap spill (rock-like) | internal | internal | internal | ✅ `CACHE_SPILL_*` | chmod 0600 spill |
+| Disk / mmap spill (rock-like) | internal | internal | internal | ✅ `CACHE_SPILL_*` + `0o600` spill |
 | L2 shared cache (Redis) | cloud internal | cloud internal | cloud internal | ✅ Redis L2 | — |
 | Parent/sibling hierarchy | limited | limited | limited | ✅ ICP/HTCP/digest | mTLS peers **P2** |
 | Negative cache | yes | yes | yes | ✅ `NEGATIVE_CACHE_*` | — |
@@ -96,7 +96,7 @@
 | P0-4 | **Connection-level auth** — cache `Proxy-Authorization` outcome per TCP conn | identity on tunnel (ZCC/GP) | `server.rs`, `auth.rs` |
 | P0-5 | **Policy decision cache** — `(user, domain, url_hash) → Allow/Deny` TTL 60–300s | unified policy engine cache | `proxy_service.rs`, `acl.rs` |
 | P0-6 | Bench profiles: `WORKER_COUNT=1` warm / `4` cold | internal tuning | ✅ `bench-profile.sh` |
-| P0-7 | Spill file `mode(0o600)` + private `CACHE_SPILL_DIR` | security hygiene | `cache_body.rs` |
+| P0-7 | Spill file `mode(0o600)` + private `CACHE_SPILL_DIR` | security hygiene | ✅ `cache_body.rs` |
 
 ### P1 — Single-pass policy path (как Single Scan / single-pass)
 
@@ -247,7 +247,7 @@ gantt
 | P0-4 | [#95](https://github.com/onixus/bsdm-proxy/issues/95) Connection-level auth cache | P0 |
 | P0-5 | [#96](https://github.com/onixus/bsdm-proxy/issues/96) Policy decision cache | P0 | ✅ |
 | P0-6 | [#97](https://github.com/onixus/bsdm-proxy/issues/97) Bench profiles WORKER_COUNT | P0 | ✅ |
-| P0-7 | [#98](https://github.com/onixus/bsdm-proxy/issues/98) Spill files mode 0o600 | P0 |
+| P0-7 | [#98](https://github.com/onixus/bsdm-proxy/issues/98) Spill files mode 0o600 | P0 | ✅ |
 | P1-1 | [#100](https://github.com/onixus/bsdm-proxy/issues/100) PERF fast path matrix | P1 |
 | P1-2 | [#104](https://github.com/onixus/bsdm-proxy/issues/104) Offline categorization | P1 |
 | P1-3 | [#106](https://github.com/onixus/bsdm-proxy/issues/106) Kafka bounded queue | P1 |

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -19,6 +19,7 @@ CACHE_HONOR_CACHE_CONTROL=true
 # L1 sharding and tiered body storage (large bodies mmap-spilled to disk)
 CACHE_SHARDS=16
 CACHE_SPILL_THRESHOLD_BYTES=262144
+# Private spill dir (created 0o700; spill files 0o600). Use a dedicated path in production.
 # CACHE_SPILL_DIR=/var/cache/bsdm-proxy/spill
 
 # Corporate medium (5000 users, 300 servers) — uncomment for production:

--- a/proxy/src/cache_body.rs
+++ b/proxy/src/cache_body.rs
@@ -9,6 +9,30 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 static SPILL_SEQ: AtomicU64 = AtomicU64::new(0);
 
+/// Create `CACHE_SPILL_DIR` if missing and restrict to owner-only (`0o700` on Unix).
+pub fn ensure_private_spill_dir(spill_dir: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(spill_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(spill_dir)?.permissions();
+        perms.set_mode(0o700);
+        fs::set_permissions(spill_dir, perms)?;
+    }
+    Ok(())
+}
+
+fn open_new_spill_file(path: &Path) -> std::io::Result<File> {
+    let mut opts = OpenOptions::new();
+    opts.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
 /// Owns a spill file, its mmap mapping, and removes the file on drop.
 struct MmapOwner {
     _file: File,
@@ -56,15 +80,12 @@ impl CachedBody {
 
     /// Write `data` to a spill file and mmap it read-only.
     pub fn spill(data: &[u8], spill_dir: &Path) -> std::io::Result<Self> {
-        fs::create_dir_all(spill_dir)?;
+        ensure_private_spill_dir(spill_dir)?;
         let id = SPILL_SEQ.fetch_add(1, Ordering::Relaxed);
         let path = spill_dir.join(format!("body-{id:016x}.bin"));
         let spill_result: std::io::Result<Self> = (|| {
             {
-                let mut file = OpenOptions::new()
-                    .create_new(true)
-                    .write(true)
-                    .open(&path)?;
+                let mut file = open_new_spill_file(&path)?;
                 file.write_all(data)?;
                 file.sync_all()?;
             }
@@ -118,5 +139,40 @@ mod tests {
         let b = Bytes::from_static(b"small");
         let body = CachedBody::maybe_spill(b.clone(), dir.path(), 1024).unwrap();
         assert!(!body.is_mmap());
+    }
+
+    #[test]
+    fn ensure_private_spill_dir_restricts_mode() {
+        let parent = tempdir().unwrap();
+        let spill_dir = parent.path().join("spill");
+        ensure_private_spill_dir(&spill_dir).unwrap();
+        assert!(spill_dir.is_dir());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&spill_dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700);
+        }
+    }
+
+    #[test]
+    fn spill_file_is_owner_read_write_only() {
+        let dir = tempdir().unwrap();
+        let payload: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
+        let _body = CachedBody::spill(&payload, dir.path()).unwrap();
+        let spill_file = fs::read_dir(dir.path())
+            .unwrap()
+            .find_map(|e| e.ok())
+            .expect("spill file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = spill_file.metadata().unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = spill_file;
+        }
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -46,7 +46,7 @@ pub use auth::NtlmConfig;
 pub use auth::{AuthBackend, AuthConfig, AuthManager, ConnAuthCache, ProxyAuthOutcome, UserInfo};
 pub use bsdm_events::CacheEvent;
 pub use cache::{CacheConfig, CachedResponse};
-pub use cache_body::CachedBody;
+pub use cache_body::{ensure_private_spill_dir, CachedBody};
 pub use cache_compress::{BodyEncoding, CompressionConfig};
 pub use cache_digest::DigestRegistry;
 pub use cache_key::http_cache_key;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -3,13 +3,13 @@ mod policy_config;
 
 use auth_config::load_auth_config;
 use bsdm_proxy::{
-    bind_http_listeners, build_hierarchy_manager, handle_connection, htcp_peer_port,
-    htcp_server_bind_addr, http_cache_key, icp_server_bind_addr, load_hierarchy_config,
-    metrics_server, run_peer_discovery, should_start_htcp_server, should_start_icp_server,
-    wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache, HtcpServer, IcpServer,
-    L2CacheConfig, Metrics, PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig,
-    PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig, RedisL2Cache,
-    UpstreamTlsConfig, ensure_private_spill_dir,
+    bind_http_listeners, build_hierarchy_manager, ensure_private_spill_dir, handle_connection,
+    htcp_peer_port, htcp_server_bind_addr, http_cache_key, icp_server_bind_addr,
+    load_hierarchy_config, metrics_server, run_peer_discovery, should_start_htcp_server,
+    should_start_icp_server, wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache,
+    HtcpServer, IcpServer, L2CacheConfig, Metrics, PeerDiscoveryConfig, PerfConfig,
+    PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig,
+    RedisL2Cache, UpstreamTlsConfig,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,7 +9,7 @@ use bsdm_proxy::{
     wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache, HtcpServer, IcpServer,
     L2CacheConfig, Metrics, PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig,
     PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig, RedisL2Cache,
-    UpstreamTlsConfig,
+    UpstreamTlsConfig, ensure_private_spill_dir,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -136,6 +136,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kafka_brokers = std::env::var("KAFKA_BROKERS").ok();
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
     let cache_config = CacheConfig::from_env();
+    if cache_config.spill_threshold_bytes > 0 {
+        if let Err(e) = ensure_private_spill_dir(&cache_config.spill_dir) {
+            warn!(
+                "CACHE_SPILL_DIR {:?} init failed: {} — large bodies may stay inline",
+                cache_config.spill_dir, e
+            );
+        }
+    }
 
     let l2_config = L2CacheConfig::from_env();
     let l2_cache = if l2_config.enabled {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Закрывает последний P0 milestone M2.5 — безопасные права на tiered L1 spill storage.

- `ensure_private_spill_dir()` — каталог `CACHE_SPILL_DIR` создаётся/нормализуется с `0o700` (Unix)
- Spill-файлы создаются через `open_new_spill_file()` с `0o600`
- Инициализация spill dir при старте proxy, если `CACHE_SPILL_THRESHOLD_BYTES > 0`
- Unit-тесты на mode dir/file (Unix)
- Docs: `performance.md`, `roadmap.md`, `swg-backlog-mapping.md`, `k8s-architecture.md`, `README.md`, env example

Closes #98

## Testing

```bash
cargo test -p bsdm-proxy cache_body::
cargo clippy -p bsdm-proxy --all-targets -- -D warnings
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена
- [x] `docs/roadmap.md` — P0 M2.5 закрыты

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

