### PR TITLE
feat(cache-indexer): ClickHouse backend INDEXER_BACKEND=clickhouse (#114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
 name = "bsdm-events"
 version = "0.3.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
 ]
@@ -425,6 +426,7 @@ dependencies = [
  "bytes",
  "opensearch",
  "rdkafka",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ opensearch = "2.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bytes = "1.12"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 
 # Копируем весь workspace
 COPY Cargo.toml Cargo.lock ./
+COPY bsdm-events ./bsdm-events
 COPY proxy ./proxy
 COPY cache-indexer ./cache-indexer
 

--- a/bsdm-events/Cargo.toml
+++ b/bsdm-events/Cargo.toml
@@ -9,3 +9,4 @@ repository = "https://github.com/onixus/bsdm-proxy"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }

--- a/bsdm-events/src/clickhouse.rs
+++ b/bsdm-events/src/clickhouse.rs
@@ -1,0 +1,156 @@
+//! `CacheEvent` → ClickHouse `http_cache` row mapping (JSONEachRow INSERT).
+
+use crate::{document_id, CacheEvent};
+use chrono::{TimeZone, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+/// Row shape for `bsdm.http_cache` (`scripts/clickhouse/http_cache.sql`).
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct HttpCacheRow {
+    pub event_id: String,
+    pub ts: String,
+    pub url: String,
+    pub method: String,
+    pub status: u16,
+    pub cache_key: String,
+    pub cache_status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    pub client_ip: String,
+    pub domain: String,
+    pub response_size: u64,
+    pub request_duration_ms: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    pub user_agent: String,
+    pub categories: Vec<String>,
+    pub threat_sources: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acl_action: Option<String>,
+    pub headers: String,
+}
+
+/// Map proxy `CacheEvent` JSON to a ClickHouse JSONEachRow document.
+pub fn cache_event_to_row(event: &CacheEvent) -> HttpCacheRow {
+    HttpCacheRow {
+        event_id: if event.event_id.is_empty() {
+            document_id(event)
+        } else {
+            event.event_id.clone()
+        },
+        ts: epoch_secs_to_clickhouse_ts(event.timestamp),
+        url: event.url.clone(),
+        method: event.method.clone(),
+        status: event.status,
+        cache_key: event.cache_key.clone(),
+        cache_status: event.cache_status.clone(),
+        user_id: event.user_id.clone(),
+        username: event.username.clone(),
+        client_ip: normalize_ipv4(&event.client_ip),
+        domain: event.domain.clone(),
+        response_size: event.response_size,
+        request_duration_ms: event.request_duration_ms.min(u32::MAX as u64) as u32,
+        content_type: event.content_type.clone(),
+        user_agent: event.user_agent.clone().unwrap_or_default(),
+        categories: event.categories.clone(),
+        threat_sources: event.threat_sources.clone(),
+        acl_action: event.acl_action.clone(),
+        headers: headers_json(&event.headers),
+    }
+}
+
+/// Serialize events as newline-delimited JSON for `INSERT ... FORMAT JSONEachRow`.
+pub fn json_each_row_lines(events: &[CacheEvent]) -> Result<String, serde_json::Error> {
+    let mut lines = String::new();
+    for event in events {
+        let row = cache_event_to_row(event);
+        lines.push_str(&serde_json::to_string(&row)?);
+        lines.push('\n');
+    }
+    Ok(lines)
+}
+
+fn epoch_secs_to_clickhouse_ts(secs: u64) -> String {
+    let dt = Utc
+        .timestamp_opt(secs as i64, 0)
+        .single()
+        .unwrap_or_else(|| Utc.timestamp_opt(0, 0).unwrap());
+    format!(
+        "{}.{:03}",
+        dt.format("%Y-%m-%d %H:%M:%S"),
+        dt.timestamp_subsec_millis()
+    )
+}
+
+fn headers_json(headers: &HashMap<String, String>) -> String {
+    if headers.is_empty() {
+        return "{}".to_string();
+    }
+    serde_json::to_string(headers).unwrap_or_else(|_| "{}".to_string())
+}
+
+fn normalize_ipv4(ip: &str) -> String {
+    ip.parse::<Ipv4Addr>()
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|_| "0.0.0.0".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn sample_event() -> CacheEvent {
+        CacheEvent {
+            url: "https://example.com/path".to_string(),
+            method: "GET".to_string(),
+            status: 200,
+            cache_key: "key1".to_string(),
+            cache_status: "MISS".to_string(),
+            timestamp: 1_700_000_001,
+            headers: HashMap::from([("X-Test".to_string(), "1".to_string())]),
+            user_id: Some("uid".to_string()),
+            username: Some("alice".to_string()),
+            client_ip: "10.0.0.5".to_string(),
+            domain: "example.com".to_string(),
+            response_size: 4096,
+            request_duration_ms: 42,
+            content_type: Some("text/html".to_string()),
+            user_agent: Some("curl/8".to_string()),
+            categories: vec!["news".to_string()],
+            threat_sources: vec!["shallalist".to_string()],
+            acl_action: Some("allow".to_string()),
+            event_id: "evt-ch-1".to_string(),
+        }
+    }
+
+    #[test]
+    fn row_maps_fields() {
+        let row = cache_event_to_row(&sample_event());
+        assert_eq!(row.event_id, "evt-ch-1");
+        assert_eq!(row.ts, "2023-11-14 22:13:21.000");
+        assert_eq!(row.client_ip, "10.0.0.5");
+        assert_eq!(row.request_duration_ms, 42);
+        assert_eq!(row.headers, r#"{"X-Test":"1"}"#);
+    }
+
+    #[test]
+    fn invalid_ipv4_falls_back_to_zero() {
+        let mut event = sample_event();
+        event.client_ip = "::1".to_string();
+        assert_eq!(cache_event_to_row(&event).client_ip, "0.0.0.0");
+    }
+
+    #[test]
+    fn json_each_row_produces_ndjson() {
+        let lines = json_each_row_lines(&[sample_event()]).unwrap();
+        assert!(lines.ends_with('\n'));
+        assert!(lines.contains("\"event_id\":\"evt-ch-1\""));
+        let parsed: HttpCacheRow = serde_json::from_str(lines.trim()).unwrap();
+        assert_eq!(parsed.domain, "example.com");
+    }
+}

--- a/bsdm-events/src/lib.rs
+++ b/bsdm-events/src/lib.rs
@@ -1,4 +1,8 @@
-//! Shared cache event schema for the Kafka → OpenSearch pipeline.
+//! Shared cache event schema for the Kafka → indexer pipeline.
+
+mod clickhouse;
+
+pub use clickhouse::{cache_event_to_row, json_each_row_lines, HttpCacheRow};
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]
-description = "Kafka to OpenSearch indexer for HTTP cache events"
+description = "Kafka to OpenSearch / ClickHouse indexer for HTTP cache events"
 repository = "https://github.com/onixus/bsdm-proxy"
-keywords = ["kafka", "opensearch", "indexer", "cache"]
+keywords = ["kafka", "opensearch", "clickhouse", "indexer", "cache"]
 categories = ["database", "network-programming"]
 
 [[bin]]
@@ -20,6 +20,7 @@ rdkafka = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 opensearch = { workspace = true }
+reqwest = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 bytes = { workspace = true }

--- a/cache-indexer/src/clickhouse.rs
+++ b/cache-indexer/src/clickhouse.rs
@@ -1,0 +1,204 @@
+//! ClickHouse backend for cache-indexer (`INDEXER_BACKEND=clickhouse`).
+
+use bsdm_events::json_each_row_lines;
+use bsdm_events::CacheEvent;
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use reqwest::Client;
+use tracing::{error, info, warn};
+
+use crate::kafka::create_consumer;
+
+pub struct ClickHouseConfig {
+    pub url: String,
+    pub database: String,
+    pub table: String,
+    pub user: Option<String>,
+    pub password: Option<String>,
+}
+
+pub struct ClickHouseIndexer {
+    client: Client,
+    consumer: StreamConsumer,
+    config: ClickHouseConfig,
+}
+
+impl ClickHouseIndexer {
+    pub async fn new(
+        kafka_brokers: &str,
+        kafka_topic: &str,
+        kafka_group: &str,
+        config: ClickHouseConfig,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let consumer = create_consumer(kafka_brokers, kafka_topic, kafka_group)?;
+        let client = Client::builder().build()?;
+        let indexer = Self {
+            client,
+            consumer,
+            config,
+        };
+        indexer.ensure_ready().await?;
+        Ok(indexer)
+    }
+
+    async fn ensure_ready(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let ping_url = format!("{}/ping", self.config.url.trim_end_matches('/'));
+        let mut req = self.client.get(&ping_url);
+        if let (Some(user), Some(password)) = (&self.config.user, &self.config.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        if !response.status().is_success() {
+            return Err(format!("ClickHouse ping failed: HTTP {}", response.status()).into());
+        }
+
+        let query = format!(
+            "SELECT 1 FROM system.tables WHERE database = '{}' AND name = '{}'",
+            self.config.database, self.config.table
+        );
+        let body = self.query(&query).await?;
+        if body.trim() != "1" {
+            return Err(format!(
+                "ClickHouse table {}.{} not found (run scripts/clickhouse/http_cache.sql)",
+                self.config.database, self.config.table
+            )
+            .into());
+        }
+
+        info!(
+            "ClickHouse ready: {}.{}, url={}",
+            self.config.database, self.config.table, self.config.url
+        );
+        Ok(())
+    }
+
+    async fn query(&self, sql: &str) -> Result<String, Box<dyn std::error::Error>> {
+        let base = self.config.url.trim_end_matches('/');
+        let mut req = self.client.post(base).query(&[("query", sql)]).body("");
+        if let (Some(user), Some(password)) = (&self.config.user, &self.config.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if status.is_success() {
+            Ok(body)
+        } else {
+            Err(format!("ClickHouse query failed (HTTP {status}): {body}").into())
+        }
+    }
+
+    async fn insert_batch(&self, events: &[CacheEvent]) -> Result<(), Box<dyn std::error::Error>> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let body = json_each_row_lines(events)?;
+        let sql = format!(
+            "INSERT INTO {}.{} FORMAT JSONEachRow",
+            self.config.database, self.config.table
+        );
+        let base = self.config.url.trim_end_matches('/');
+        let mut req = self
+            .client
+            .post(base)
+            .query(&[("query", &sql)])
+            .header("Content-Type", "application/json")
+            .body(body);
+        if let (Some(user), Some(password)) = (&self.config.user, &self.config.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+
+        let response = req.send().await?;
+        let status = response.status();
+        if status.is_success() {
+            info!("Inserted {} events into ClickHouse", events.len());
+            Ok(())
+        } else {
+            let err_body = response.text().await.unwrap_or_default();
+            error!("ClickHouse insert failed (HTTP {}): {}", status, err_body);
+            Err(format!("ClickHouse insert failed: {err_body}").into())
+        }
+    }
+
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut batch: Vec<CacheEvent> = Vec::new();
+        let batch_size = 50;
+        let batch_timeout = std::time::Duration::from_secs(5);
+        let mut last_commit = tokio::time::Instant::now();
+
+        loop {
+            match tokio::time::timeout(batch_timeout, self.consumer.recv()).await {
+                Ok(Ok(message)) => {
+                    if let Some(payload) = message.payload() {
+                        match serde_json::from_slice::<CacheEvent>(payload) {
+                            Ok(event) => {
+                                batch.push(event);
+                                if batch.len() >= batch_size {
+                                    self.insert_batch(&batch).await?;
+                                    batch.clear();
+                                    self.consumer.commit_consumer_state(CommitMode::Async)?;
+                                    last_commit = tokio::time::Instant::now();
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse event: {} - Payload: {}",
+                                    e,
+                                    String::from_utf8_lossy(payload)
+                                );
+                            }
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    error!("Kafka error: {}", e);
+                }
+                Err(_) => {
+                    if !batch.is_empty() {
+                        self.insert_batch(&batch).await?;
+                        batch.clear();
+                        self.consumer.commit_consumer_state(CommitMode::Async)?;
+                        last_commit = tokio::time::Instant::now();
+                    }
+                }
+            }
+
+            if last_commit.elapsed() > std::time::Duration::from_secs(30) && !batch.is_empty() {
+                self.insert_batch(&batch).await?;
+                batch.clear();
+                self.consumer.commit_consumer_state(CommitMode::Async)?;
+                last_commit = tokio::time::Instant::now();
+            }
+        }
+    }
+}
+
+pub fn load_config_from_env() -> ClickHouseConfig {
+    ClickHouseConfig {
+        url: std::env::var("CLICKHOUSE_URL")
+            .unwrap_or_else(|_| "http://clickhouse:8123".to_string()),
+        database: std::env::var("CLICKHOUSE_DATABASE").unwrap_or_else(|_| "bsdm".to_string()),
+        table: std::env::var("CLICKHOUSE_TABLE").unwrap_or_else(|_| "http_cache".to_string()),
+        user: std::env::var("CLICKHOUSE_USER").ok(),
+        password: std::env::var("CLICKHOUSE_PASSWORD").ok(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_config_defaults() {
+        let cfg = ClickHouseConfig {
+            url: "http://localhost:8123".to_string(),
+            database: "bsdm".to_string(),
+            table: "http_cache".to_string(),
+            user: None,
+            password: None,
+        };
+        assert_eq!(cfg.database, "bsdm");
+        assert_eq!(cfg.table, "http_cache");
+    }
+}

--- a/cache-indexer/src/kafka.rs
+++ b/cache-indexer/src/kafka.rs
@@ -1,0 +1,25 @@
+//! Shared Kafka consumer setup for cache-indexer backends.
+
+use rdkafka::{
+    config::ClientConfig,
+    consumer::{Consumer, StreamConsumer},
+};
+use tracing::info;
+
+pub fn create_consumer(
+    kafka_brokers: &str,
+    kafka_topic: &str,
+    kafka_group: &str,
+) -> Result<StreamConsumer, Box<dyn std::error::Error>> {
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("group.id", kafka_group)
+        .set("bootstrap.servers", kafka_brokers)
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .set("session.timeout.ms", "30000")
+        .create()?;
+
+    consumer.subscribe(&[kafka_topic])?;
+    info!("Subscribed to Kafka topic: {}", kafka_topic);
+    Ok(consumer)
+}

--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -1,378 +1,29 @@
-use bsdm_events::{
-    document_id, index_mappings, index_template_body, ism_policy_body, CacheEvent,
-    DEFAULT_ISM_DELETE_DAYS, DEFAULT_ISM_HOT_DAYS, DEFAULT_ISM_POLICY_ID,
-};
-use opensearch::{
-    auth::Credentials,
-    cert::CertificateValidation,
-    http::headers::HeaderMap,
-    http::request::JsonBody,
-    http::transport::{SingleNodeConnectionPool, TransportBuilder},
-    http::Method,
-    indices::{IndicesCreateParts, IndicesExistsParts},
-    BulkParts, OpenSearch,
-};
-use rdkafka::{
-    config::ClientConfig,
-    consumer::{CommitMode, Consumer, StreamConsumer},
-    message::Message,
-};
-use serde_json::json;
-use std::time::Duration;
-use tracing::{error, info, warn};
+mod clickhouse;
+mod kafka;
+mod opensearch;
 
-struct IndexerConfig {
-    index_name: String,
-    index_pattern: String,
-    ism_enabled: bool,
-    ism_policy_id: String,
-    ism_hot_days: u32,
-    ism_delete_days: u32,
+use bsdm_events::{DEFAULT_ISM_DELETE_DAYS, DEFAULT_ISM_HOT_DAYS, DEFAULT_ISM_POLICY_ID};
+use clickhouse::{load_config_from_env, ClickHouseIndexer};
+use opensearch::OpenSearchIndexer;
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IndexerBackend {
+    OpenSearch,
+    ClickHouse,
 }
 
-struct Indexer {
-    opensearch: OpenSearch,
-    consumer: StreamConsumer,
-    config: IndexerConfig,
+fn parse_backend_name(name: &str) -> IndexerBackend {
+    match name.to_ascii_lowercase().as_str() {
+        "clickhouse" | "ch" => IndexerBackend::ClickHouse,
+        _ => IndexerBackend::OpenSearch,
+    }
 }
 
-impl Indexer {
-    #[allow(clippy::too_many_arguments)]
-    async fn new(
-        kafka_brokers: &str,
-        opensearch_url: &str,
-        opensearch_username: Option<String>,
-        opensearch_password: Option<String>,
-        ssl_verify: bool,
-        kafka_topic: &str,
-        kafka_group: &str,
-        index_name: &str,
-        ism_enabled: bool,
-        ism_policy_id: String,
-        ism_hot_days: u32,
-        ism_delete_days: u32,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let consumer: StreamConsumer = ClientConfig::new()
-            .set("group.id", kafka_group)
-            .set("bootstrap.servers", kafka_brokers)
-            .set("enable.auto.commit", "false")
-            .set("auto.offset.reset", "earliest")
-            .set("session.timeout.ms", "30000")
-            .create()?;
-
-        consumer.subscribe(&[kafka_topic])?;
-        info!("Subscribed to Kafka topic: {}", kafka_topic);
-
-        let mut transport_builder =
-            TransportBuilder::new(SingleNodeConnectionPool::new(opensearch_url.parse()?));
-
-        if let (Some(username), Some(password)) = (opensearch_username, opensearch_password) {
-            info!("Using authentication for OpenSearch: {}", username);
-            transport_builder = transport_builder.auth(Credentials::Basic(username, password));
-        }
-
-        if !ssl_verify {
-            warn!("SSL certificate verification is disabled!");
-            transport_builder = transport_builder.cert_validation(CertificateValidation::None);
-        }
-
-        let transport = transport_builder.build()?;
-        let opensearch = OpenSearch::new(transport);
-        let index_pattern = format!("{index_name}*");
-
-        Ok(Self {
-            opensearch,
-            consumer,
-            config: IndexerConfig {
-                index_name: index_name.to_string(),
-                index_pattern,
-                ism_enabled,
-                ism_policy_id,
-                ism_hot_days,
-                ism_delete_days,
-            },
-        })
-    }
-
-    async fn send_json(
-        &self,
-        method: Method,
-        path: &str,
-        body: serde_json::Value,
-    ) -> Result<opensearch::http::response::Response, opensearch::Error> {
-        self.opensearch
-            .send(
-                method,
-                path,
-                HeaderMap::new(),
-                None::<&()>,
-                Some(JsonBody::new(body)),
-                None,
-            )
-            .await
-    }
-
-    async fn ensure_index_template(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let template_name = "bsdm-http-cache";
-        let body = index_template_body(&self.config.index_pattern);
-
-        match self
-            .opensearch
-            .indices()
-            .put_index_template(opensearch::indices::IndicesPutIndexTemplateParts::Name(
-                template_name,
-            ))
-            .body(body)
-            .send()
-            .await
-        {
-            Ok(response) if response.status_code().is_success() => {
-                info!(
-                    "Index template '{}' applied for pattern '{}'",
-                    template_name, self.config.index_pattern
-                );
-                Ok(())
-            }
-            Ok(response) => {
-                warn!(
-                    "Index template upsert returned status {}",
-                    response.status_code()
-                );
-                Ok(())
-            }
-            Err(e) => {
-                warn!("Failed to upsert index template: {}", e);
-                Ok(())
-            }
-        }
-    }
-
-    async fn ensure_ism_policy(&self) -> Result<(), Box<dyn std::error::Error>> {
-        if !self.config.ism_enabled {
-            info!("OpenSearch ISM disabled");
-            return Ok(());
-        }
-
-        let policy = ism_policy_body(
-            &self.config.index_pattern,
-            &self.config.ism_policy_id,
-            self.config.ism_hot_days,
-            self.config.ism_delete_days,
-        );
-        let path = format!("/_plugins/_ism/policies/{}", self.config.ism_policy_id);
-
-        match self.send_json(Method::Put, &path, policy).await {
-            Ok(response) if response.status_code().is_success() => {
-                info!(
-                    "ISM policy '{}' applied (hot={}d, delete={}d)",
-                    self.config.ism_policy_id,
-                    self.config.ism_hot_days,
-                    self.config.ism_delete_days
-                );
-                Ok(())
-            }
-            Ok(response) => {
-                warn!(
-                    "ISM policy upsert returned status {}",
-                    response.status_code()
-                );
-                Ok(())
-            }
-            Err(e) => {
-                warn!("Failed to upsert ISM policy: {}", e);
-                Ok(())
-            }
-        }
-    }
-
-    async fn attach_ism_policy_to_index(&self) -> Result<(), Box<dyn std::error::Error>> {
-        if !self.config.ism_enabled {
-            return Ok(());
-        }
-
-        let path = format!("/_plugins/_ism/add/{}", self.config.index_name);
-        let body = json!({ "policy_id": self.config.ism_policy_id });
-
-        match self.send_json(Method::Post, &path, body).await {
-            Ok(response) if response.status_code().is_success() => {
-                info!(
-                    "ISM policy '{}' attached to index '{}'",
-                    self.config.ism_policy_id, self.config.index_name
-                );
-                Ok(())
-            }
-            Ok(response) => {
-                warn!(
-                    "ISM attach for index '{}' returned status {}",
-                    self.config.index_name,
-                    response.status_code()
-                );
-                Ok(())
-            }
-            Err(e) => {
-                warn!(
-                    "Failed to attach ISM policy to index '{}': {}",
-                    self.config.index_name, e
-                );
-                Ok(())
-            }
-        }
-    }
-
-    async fn ensure_index_exists(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut settings = json!({
-            "number_of_shards": 1,
-            "number_of_replicas": 0
-        });
-        if self.config.ism_enabled {
-            settings["plugins.index_state_management.policy_id"] = json!(self.config.ism_policy_id);
-        }
-
-        let index_body = json!({
-            "mappings": index_mappings(),
-            "settings": settings
-        });
-
-        match self
-            .opensearch
-            .indices()
-            .exists(IndicesExistsParts::Index(&[&self.config.index_name]))
-            .send()
-            .await
-        {
-            Ok(response) if response.status_code().is_success() => {
-                info!("Index '{}' already exists", self.config.index_name);
-                return Ok(());
-            }
-            Ok(_) => {}
-            Err(e) => warn!("Error checking index existence: {}", e),
-        }
-
-        match self
-            .opensearch
-            .indices()
-            .create(IndicesCreateParts::Index(&self.config.index_name))
-            .body(index_body)
-            .send()
-            .await
-        {
-            Ok(_) => {
-                info!("Created index '{}'", self.config.index_name);
-                Ok(())
-            }
-            Err(e) => {
-                error!("Failed to create index: {}", e);
-                Err(Box::new(e))
-            }
-        }
-    }
-
-    async fn process_events(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut batch: Vec<CacheEvent> = Vec::new();
-        let batch_size = 50;
-        let batch_timeout = Duration::from_secs(5);
-        let mut last_commit = tokio::time::Instant::now();
-
-        loop {
-            match tokio::time::timeout(batch_timeout, self.consumer.recv()).await {
-                Ok(Ok(message)) => {
-                    if let Some(payload) = message.payload() {
-                        match serde_json::from_slice::<CacheEvent>(payload) {
-                            Ok(event) => {
-                                batch.push(event);
-
-                                if batch.len() >= batch_size {
-                                    self.index_batch(&batch).await?;
-                                    batch.clear();
-                                    self.consumer.commit_consumer_state(CommitMode::Async)?;
-                                    last_commit = tokio::time::Instant::now();
-                                }
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Failed to parse event: {} - Payload: {}",
-                                    e,
-                                    String::from_utf8_lossy(payload)
-                                );
-                            }
-                        }
-                    }
-                }
-                Ok(Err(e)) => {
-                    error!("Kafka error: {}", e);
-                }
-                Err(_) => {
-                    if !batch.is_empty() {
-                        self.index_batch(&batch).await?;
-                        batch.clear();
-                        self.consumer.commit_consumer_state(CommitMode::Async)?;
-                        last_commit = tokio::time::Instant::now();
-                    }
-                }
-            }
-
-            if last_commit.elapsed() > Duration::from_secs(30) && !batch.is_empty() {
-                self.index_batch(&batch).await?;
-                batch.clear();
-                self.consumer.commit_consumer_state(CommitMode::Async)?;
-                last_commit = tokio::time::Instant::now();
-            }
-        }
-    }
-
-    async fn index_batch(&self, events: &[CacheEvent]) -> Result<(), Box<dyn std::error::Error>> {
-        if events.is_empty() {
-            return Ok(());
-        }
-
-        let mut body_lines: Vec<String> = Vec::new();
-
-        for event in events {
-            let action = json!({
-                "index": {
-                    "_index": &self.config.index_name,
-                    "_id": document_id(event)
-                }
-            });
-            body_lines.push(serde_json::to_string(&action)?);
-            body_lines.push(serde_json::to_string(&event)?);
-        }
-
-        let body_str = body_lines.join("\n") + "\n";
-        let body = vec![body_str.into_bytes()];
-
-        match self
-            .opensearch
-            .bulk(BulkParts::None)
-            .body(body)
-            .send()
-            .await
-        {
-            Ok(response) if response.status_code().is_success() => {
-                info!("Indexed {} events to OpenSearch", events.len());
-                Ok(())
-            }
-            Ok(response) => {
-                warn!(
-                    "Bulk index returned non-success status: {}",
-                    response.status_code()
-                );
-                Ok(())
-            }
-            Err(e) => {
-                error!("Failed to bulk index: {}", e);
-                Err(Box::new(e))
-            }
-        }
-    }
-
-    async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
-        self.ensure_ism_policy().await?;
-        self.ensure_index_template().await?;
-        self.ensure_index_exists().await?;
-        self.attach_ism_policy_to_index().await?;
-        self.process_events().await
-    }
+fn parse_backend() -> IndexerBackend {
+    parse_backend_name(
+        &std::env::var("INDEXER_BACKEND").unwrap_or_else(|_| "opensearch".to_string()),
+    )
 }
 
 fn parse_env_u32(name: &str, default: u32) -> u32 {
@@ -399,58 +50,79 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let kafka_brokers = std::env::var("KAFKA_BROKERS").unwrap_or_else(|_| "kafka:9092".to_string());
-    let opensearch_url =
-        std::env::var("OPENSEARCH_URL").unwrap_or_else(|_| "http://opensearch:9200".to_string());
-    let opensearch_username = std::env::var("OPENSEARCH_USERNAME").ok();
-    let opensearch_password = std::env::var("OPENSEARCH_PASSWORD").ok();
-    let ssl_verify = std::env::var("OPENSEARCH_SSL_VERIFY")
-        .unwrap_or_else(|_| "true".to_string())
-        .parse::<bool>()
-        .unwrap_or(true);
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
     let kafka_group =
         std::env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "cache-indexer-group".to_string());
-    let index_name = std::env::var("OPENSEARCH_INDEX").unwrap_or_else(|_| "http-cache".to_string());
-    let ism_enabled = parse_env_bool("OPENSEARCH_ISM_ENABLED", true);
-    let ism_policy_id = std::env::var("OPENSEARCH_ISM_POLICY_ID")
-        .unwrap_or_else(|_| DEFAULT_ISM_POLICY_ID.to_string());
-    let ism_hot_days = parse_env_u32("OPENSEARCH_ISM_HOT_DAYS", DEFAULT_ISM_HOT_DAYS);
-    let ism_delete_days = parse_env_u32("OPENSEARCH_ISM_DELETE_DAYS", DEFAULT_ISM_DELETE_DAYS);
+    let backend = parse_backend();
 
-    info!("Starting cache-indexer");
+    info!("Starting cache-indexer (backend={:?})", backend);
     info!("Kafka brokers: {}", kafka_brokers);
-    info!("OpenSearch URL: {}", opensearch_url);
-    info!("SSL verification: {}", ssl_verify);
     info!("Kafka topic: {}", kafka_topic);
     info!("Kafka group: {}", kafka_group);
-    info!("OpenSearch index: {}", index_name);
-    info!(
-        "OpenSearch ISM: enabled={}, policy={}, hot={}d, delete={}d",
-        ism_enabled, ism_policy_id, ism_hot_days, ism_delete_days
-    );
 
-    let indexer = Indexer::new(
-        &kafka_brokers,
-        &opensearch_url,
-        opensearch_username,
-        opensearch_password,
-        ssl_verify,
-        &kafka_topic,
-        &kafka_group,
-        &index_name,
-        ism_enabled,
-        ism_policy_id,
-        ism_hot_days,
-        ism_delete_days,
-    )
-    .await?;
+    match backend {
+        IndexerBackend::ClickHouse => {
+            let ch_config = load_config_from_env();
+            info!("ClickHouse URL: {}", ch_config.url);
+            info!(
+                "ClickHouse table: {}.{}",
+                ch_config.database, ch_config.table
+            );
+            let indexer =
+                ClickHouseIndexer::new(&kafka_brokers, &kafka_topic, &kafka_group, ch_config)
+                    .await?;
+            indexer.run().await
+        }
+        IndexerBackend::OpenSearch => {
+            let opensearch_url = std::env::var("OPENSEARCH_URL")
+                .unwrap_or_else(|_| "http://opensearch:9200".to_string());
+            let opensearch_username = std::env::var("OPENSEARCH_USERNAME").ok();
+            let opensearch_password = std::env::var("OPENSEARCH_PASSWORD").ok();
+            let ssl_verify = std::env::var("OPENSEARCH_SSL_VERIFY")
+                .unwrap_or_else(|_| "true".to_string())
+                .parse::<bool>()
+                .unwrap_or(true);
+            let index_name =
+                std::env::var("OPENSEARCH_INDEX").unwrap_or_else(|_| "http-cache".to_string());
+            let ism_enabled = parse_env_bool("OPENSEARCH_ISM_ENABLED", true);
+            let ism_policy_id = std::env::var("OPENSEARCH_ISM_POLICY_ID")
+                .unwrap_or_else(|_| DEFAULT_ISM_POLICY_ID.to_string());
+            let ism_hot_days = parse_env_u32("OPENSEARCH_ISM_HOT_DAYS", DEFAULT_ISM_HOT_DAYS);
+            let ism_delete_days =
+                parse_env_u32("OPENSEARCH_ISM_DELETE_DAYS", DEFAULT_ISM_DELETE_DAYS);
 
-    indexer.run().await
+            info!("OpenSearch URL: {}", opensearch_url);
+            info!("SSL verification: {}", ssl_verify);
+            info!("OpenSearch index: {}", index_name);
+            info!(
+                "OpenSearch ISM: enabled={}, policy={}, hot={}d, delete={}d",
+                ism_enabled, ism_policy_id, ism_hot_days, ism_delete_days
+            );
+
+            let indexer = OpenSearchIndexer::new(
+                &kafka_brokers,
+                &opensearch_url,
+                opensearch_username,
+                opensearch_password,
+                ssl_verify,
+                &kafka_topic,
+                &kafka_group,
+                &index_name,
+                ism_enabled,
+                ism_policy_id,
+                ism_hot_days,
+                ism_delete_days,
+            )
+            .await?;
+            indexer.run().await
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bsdm_events::{document_id, CacheEvent};
     use std::collections::HashMap;
 
     fn sample_event(event_id: &str) -> CacheEvent {
@@ -521,5 +193,12 @@ mod tests {
     fn parse_env_bool_defaults() {
         assert!(parse_env_bool("MISSING_VAR", true));
         assert!(!parse_env_bool("MISSING_VAR", false));
+    }
+
+    #[test]
+    fn parse_backend_variants() {
+        assert_eq!(parse_backend_name("clickhouse"), IndexerBackend::ClickHouse);
+        assert_eq!(parse_backend_name("ch"), IndexerBackend::ClickHouse);
+        assert_eq!(parse_backend_name("opensearch"), IndexerBackend::OpenSearch);
     }
 }

--- a/cache-indexer/src/opensearch.rs
+++ b/cache-indexer/src/opensearch.rs
@@ -1,0 +1,361 @@
+//! OpenSearch backend for cache-indexer (default `INDEXER_BACKEND=opensearch`).
+
+use bsdm_events::{document_id, index_mappings, index_template_body, ism_policy_body, CacheEvent};
+use opensearch::{
+    auth::Credentials,
+    cert::CertificateValidation,
+    http::headers::HeaderMap,
+    http::request::JsonBody,
+    http::transport::{SingleNodeConnectionPool, TransportBuilder},
+    http::Method,
+    indices::{IndicesCreateParts, IndicesExistsParts},
+    BulkParts, OpenSearch,
+};
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use serde_json::json;
+use tracing::{error, info, warn};
+
+use crate::kafka::create_consumer;
+
+struct IndexerConfig {
+    index_name: String,
+    index_pattern: String,
+    ism_enabled: bool,
+    ism_policy_id: String,
+    ism_hot_days: u32,
+    ism_delete_days: u32,
+}
+
+pub struct OpenSearchIndexer {
+    opensearch: OpenSearch,
+    consumer: StreamConsumer,
+    config: IndexerConfig,
+}
+
+impl OpenSearchIndexer {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        kafka_brokers: &str,
+        opensearch_url: &str,
+        opensearch_username: Option<String>,
+        opensearch_password: Option<String>,
+        ssl_verify: bool,
+        kafka_topic: &str,
+        kafka_group: &str,
+        index_name: &str,
+        ism_enabled: bool,
+        ism_policy_id: String,
+        ism_hot_days: u32,
+        ism_delete_days: u32,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let consumer = create_consumer(kafka_brokers, kafka_topic, kafka_group)?;
+        info!("Subscribed to Kafka topic: {}", kafka_topic);
+
+        let mut transport_builder =
+            TransportBuilder::new(SingleNodeConnectionPool::new(opensearch_url.parse()?));
+
+        if let (Some(username), Some(password)) = (opensearch_username, opensearch_password) {
+            info!("Using authentication for OpenSearch: {}", username);
+            transport_builder = transport_builder.auth(Credentials::Basic(username, password));
+        }
+
+        if !ssl_verify {
+            warn!("SSL certificate verification is disabled!");
+            transport_builder = transport_builder.cert_validation(CertificateValidation::None);
+        }
+
+        let transport = transport_builder.build()?;
+        let opensearch = OpenSearch::new(transport);
+        let index_pattern = format!("{index_name}*");
+
+        Ok(Self {
+            opensearch,
+            consumer,
+            config: IndexerConfig {
+                index_name: index_name.to_string(),
+                index_pattern,
+                ism_enabled,
+                ism_policy_id,
+                ism_hot_days,
+                ism_delete_days,
+            },
+        })
+    }
+
+    async fn send_json(
+        &self,
+        method: Method,
+        path: &str,
+        body: serde_json::Value,
+    ) -> Result<opensearch::http::response::Response, opensearch::Error> {
+        self.opensearch
+            .send(
+                method,
+                path,
+                HeaderMap::new(),
+                None::<&()>,
+                Some(JsonBody::new(body)),
+                None,
+            )
+            .await
+    }
+
+    async fn ensure_index_template(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let template_name = "bsdm-http-cache";
+        let body = index_template_body(&self.config.index_pattern);
+
+        match self
+            .opensearch
+            .indices()
+            .put_index_template(opensearch::indices::IndicesPutIndexTemplateParts::Name(
+                template_name,
+            ))
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) if response.status_code().is_success() => {
+                info!(
+                    "Index template '{}' applied for pattern '{}'",
+                    template_name, self.config.index_pattern
+                );
+                Ok(())
+            }
+            Ok(response) => {
+                warn!(
+                    "Index template upsert returned status {}",
+                    response.status_code()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Failed to upsert index template: {}", e);
+                Ok(())
+            }
+        }
+    }
+
+    async fn ensure_ism_policy(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if !self.config.ism_enabled {
+            info!("OpenSearch ISM disabled");
+            return Ok(());
+        }
+
+        let policy = ism_policy_body(
+            &self.config.index_pattern,
+            &self.config.ism_policy_id,
+            self.config.ism_hot_days,
+            self.config.ism_delete_days,
+        );
+        let path = format!("/_plugins/_ism/policies/{}", self.config.ism_policy_id);
+
+        match self.send_json(Method::Put, &path, policy).await {
+            Ok(response) if response.status_code().is_success() => {
+                info!(
+                    "ISM policy '{}' applied (hot={}d, delete={}d)",
+                    self.config.ism_policy_id,
+                    self.config.ism_hot_days,
+                    self.config.ism_delete_days
+                );
+                Ok(())
+            }
+            Ok(response) => {
+                warn!(
+                    "ISM policy upsert returned status {}",
+                    response.status_code()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!("Failed to upsert ISM policy: {}", e);
+                Ok(())
+            }
+        }
+    }
+
+    async fn attach_ism_policy_to_index(&self) -> Result<(), Box<dyn std::error::Error>> {
+        if !self.config.ism_enabled {
+            return Ok(());
+        }
+
+        let path = format!("/_plugins/_ism/add/{}", self.config.index_name);
+        let body = json!({ "policy_id": self.config.ism_policy_id });
+
+        match self.send_json(Method::Post, &path, body).await {
+            Ok(response) if response.status_code().is_success() => {
+                info!(
+                    "ISM policy '{}' attached to index '{}'",
+                    self.config.ism_policy_id, self.config.index_name
+                );
+                Ok(())
+            }
+            Ok(response) => {
+                warn!(
+                    "ISM attach for index '{}' returned status {}",
+                    self.config.index_name,
+                    response.status_code()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to attach ISM policy to index '{}': {}",
+                    self.config.index_name, e
+                );
+                Ok(())
+            }
+        }
+    }
+
+    async fn ensure_index_exists(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut settings = json!({
+            "number_of_shards": 1,
+            "number_of_replicas": 0
+        });
+        if self.config.ism_enabled {
+            settings["plugins.index_state_management.policy_id"] = json!(self.config.ism_policy_id);
+        }
+
+        let index_body = json!({
+            "mappings": index_mappings(),
+            "settings": settings
+        });
+
+        match self
+            .opensearch
+            .indices()
+            .exists(IndicesExistsParts::Index(&[&self.config.index_name]))
+            .send()
+            .await
+        {
+            Ok(response) if response.status_code().is_success() => {
+                info!("Index '{}' already exists", self.config.index_name);
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(e) => warn!("Error checking index existence: {}", e),
+        }
+
+        match self
+            .opensearch
+            .indices()
+            .create(IndicesCreateParts::Index(&self.config.index_name))
+            .body(index_body)
+            .send()
+            .await
+        {
+            Ok(_) => {
+                info!("Created index '{}'", self.config.index_name);
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to create index: {}", e);
+                Err(Box::new(e))
+            }
+        }
+    }
+
+    async fn index_batch(&self, events: &[CacheEvent]) -> Result<(), Box<dyn std::error::Error>> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let mut body_lines: Vec<String> = Vec::new();
+
+        for event in events {
+            let action = json!({
+                "index": {
+                    "_index": &self.config.index_name,
+                    "_id": document_id(event)
+                }
+            });
+            body_lines.push(serde_json::to_string(&action)?);
+            body_lines.push(serde_json::to_string(&event)?);
+        }
+
+        let body_str = body_lines.join("\n") + "\n";
+        let body = vec![body_str.into_bytes()];
+
+        match self
+            .opensearch
+            .bulk(BulkParts::None)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(response) if response.status_code().is_success() => {
+                info!("Indexed {} events to OpenSearch", events.len());
+                Ok(())
+            }
+            Ok(response) => {
+                warn!(
+                    "Bulk index returned non-success status: {}",
+                    response.status_code()
+                );
+                Ok(())
+            }
+            Err(e) => {
+                error!("Failed to bulk index: {}", e);
+                Err(Box::new(e))
+            }
+        }
+    }
+
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        self.ensure_ism_policy().await?;
+        self.ensure_index_template().await?;
+        self.ensure_index_exists().await?;
+        self.attach_ism_policy_to_index().await?;
+
+        let mut batch: Vec<CacheEvent> = Vec::new();
+        let batch_size = 50;
+        let batch_timeout = std::time::Duration::from_secs(5);
+        let mut last_commit = tokio::time::Instant::now();
+
+        loop {
+            match tokio::time::timeout(batch_timeout, self.consumer.recv()).await {
+                Ok(Ok(message)) => {
+                    if let Some(payload) = message.payload() {
+                        match serde_json::from_slice::<CacheEvent>(payload) {
+                            Ok(event) => {
+                                batch.push(event);
+                                if batch.len() >= batch_size {
+                                    self.index_batch(&batch).await?;
+                                    batch.clear();
+                                    self.consumer.commit_consumer_state(CommitMode::Async)?;
+                                    last_commit = tokio::time::Instant::now();
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse event: {} - Payload: {}",
+                                    e,
+                                    String::from_utf8_lossy(payload)
+                                );
+                            }
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    error!("Kafka error: {}", e);
+                }
+                Err(_) => {
+                    if !batch.is_empty() {
+                        self.index_batch(&batch).await?;
+                        batch.clear();
+                        self.consumer.commit_consumer_state(CommitMode::Async)?;
+                        last_commit = tokio::time::Instant::now();
+                    }
+                }
+            }
+
+            if last_commit.elapsed() > std::time::Duration::from_secs(30) && !batch.is_empty() {
+                self.index_batch(&batch).await?;
+                batch.clear();
+                self.consumer.commit_consumer_state(CommitMode::Async)?;
+                last_commit = tokio::time::Instant::now();
+            }
+        }
+    }
+}

--- a/cache-indexer/tests/integration_test.rs
+++ b/cache-indexer/tests/integration_test.rs
@@ -7,6 +7,37 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_clickhouse_row_mapping() {
+        let event = CacheEvent {
+            url: "https://example.com/api".to_string(),
+            method: "GET".to_string(),
+            status: 200,
+            cache_key: "abc123".to_string(),
+            cache_status: "MISS".to_string(),
+            timestamp: 1234567890,
+            headers: HashMap::new(),
+            user_id: None,
+            username: Some("alice".to_string()),
+            client_ip: "10.0.0.1".to_string(),
+            domain: "example.com".to_string(),
+            response_size: 128,
+            request_duration_ms: 12,
+            content_type: Some("application/json".to_string()),
+            user_agent: None,
+            categories: vec!["malware".to_string()],
+            threat_sources: vec!["urlhaus".to_string()],
+            acl_action: None,
+            event_id: "evt-1".to_string(),
+        };
+
+        let row = bsdm_events::cache_event_to_row(&event);
+        assert_eq!(row.event_id, "evt-1");
+        assert_eq!(row.username.as_deref(), Some("alice"));
+        let lines = bsdm_events::json_each_row_lines(&[event]).unwrap();
+        assert!(lines.contains("\"domain\":\"example.com\""));
+    }
+
+    #[test]
     fn test_cache_event_serialization() {
         let mut headers = HashMap::new();
         headers.insert("Content-Type".to_string(), "application/json".to_string());

--- a/docker-compose.clickhouse.yml
+++ b/docker-compose.clickhouse.yml
@@ -1,13 +1,13 @@
 # ClickHouse analytics stack for BSDM-Proxy
 #
-# Kafka → (cache-indexer with INDEXER_BACKEND=clickhouse) → ClickHouse
-# Until CH indexer lands (see GitHub issue), use OpenSearch stack for end-to-end indexing:
-#   docker compose up -d
+# Kafka → cache-indexer (INDEXER_BACKEND=clickhouse) → ClickHouse
 #
-# This compose validates ClickHouse schema + proxy event production:
+# End-to-end CH stack:
 #   docker compose -f docker-compose.clickhouse.yml up -d --build
 #   curl -x http://127.0.0.1:1488 http://httpbin.org/get
 #   curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+#
+# Default stack (OpenSearch): docker compose up -d
 #
 # ADR: docs/adr/0002-clickhouse-analytics.md
 
@@ -106,25 +106,28 @@ services:
       timeout: 5s
       retries: 5
 
-  # cache-indexer with INDEXER_BACKEND=clickhouse — see ADR 0002 / GitHub issue
-  # cache-indexer-ch:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile
-  #     target: cache-indexer
-  #   environment:
-  #     - INDEXER_BACKEND=clickhouse
-  #     - KAFKA_BROKERS=kafka:9092
-  #     - CLICKHOUSE_URL=http://clickhouse:8123
-  #     - CLICKHOUSE_DATABASE=bsdm
-  #     - CLICKHOUSE_TABLE=http_cache
-  #   depends_on:
-  #     kafka:
-  #       condition: service_healthy
-  #     clickhouse:
-  #       condition: service_healthy
-  #   networks:
-  #     - bsdm-ch-net
+  cache-indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: cache-indexer
+    environment:
+      - INDEXER_BACKEND=clickhouse
+      - KAFKA_BROKERS=kafka:9092
+      - KAFKA_TOPIC=cache-events
+      - KAFKA_GROUP_ID=cache-indexer-ch-group
+      - CLICKHOUSE_URL=http://clickhouse:8123
+      - CLICKHOUSE_DATABASE=bsdm
+      - CLICKHOUSE_TABLE=http_cache
+      - RUST_LOG=info,cache_indexer=info
+    depends_on:
+      kafka:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - bsdm-ch-net
+    restart: unless-stopped
 
   grafana:
     image: grafana/grafana:12.3.8

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -47,12 +47,29 @@ LIMIT 50;
 
 ## Реализация indexer
 
-Отслеживается в [#114](https://github.com/onixus/bsdm-proxy/issues/114) — `INDEXER_BACKEND=clickhouse` в cache-indexer.
+Реализовано в cache-indexer: `INDEXER_BACKEND=clickhouse` ([#114](https://github.com/onixus/bsdm-proxy/issues/114)).
+
+```bash
+# Полный стек (proxy → Kafka → cache-indexer → ClickHouse)
+docker compose -f docker-compose.clickhouse.yml up -d --build
+
+curl -x http://127.0.0.1:1488 http://httpbin.org/get
+sleep 5
+curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+```
+
+| Переменная | Default | Описание |
+|------------|---------|----------|
+| `INDEXER_BACKEND` | `opensearch` | `clickhouse` или `ch` для CH backend |
+| `CLICKHOUSE_URL` | `http://clickhouse:8123` | HTTP interface |
+| `CLICKHOUSE_DATABASE` | `bsdm` | База |
+| `CLICKHOUSE_TABLE` | `http_cache` | Таблица |
+| `CLICKHOUSE_USER` / `CLICKHOUSE_PASSWORD` | — | Basic auth (опц.) |
 
 | Фаза | Действие |
 |------|----------|
 | 1 | Этот compose + ADR 0002 |
-| 2 | `INDEXER_BACKEND=clickhouse` в cache-indexer |
+| 2 | ✅ `INDEXER_BACKEND=clickhouse` в cache-indexer |
 | 3 | Grafana SQL dashboards (замена OSD) |
 | 4 | Search API на ClickHouse HTTP |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,7 +23,7 @@
 | [M1 — Foundation](#m1--foundation-v02x) | v0.2.x | Ядро прокси, ACL, категоризация, observability | ✅ Done |
 | [M2 — Squid parity](#m2--squid-parity-v03x) | v0.3.x | L2, ACL, hierarchy, auth, compression | ✅ Done |
 | [M2.5 — Data plane](#m25--data-plane-throughput-v031) | v0.3.1 | Tiered L1, perf, streaming, policy cache | ~95% |
-| [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, ClickHouse, Search API | ~60% |
+| [M3 — Retro-search](#m3--retro-search-v04x) | v0.4.x | Индексация, дашборды, ClickHouse, Search API | ~70% |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C heuristics | ~5% |
 | [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing ML, C&C detection | ~0% |
 
@@ -131,7 +131,7 @@ proxy → Kafka → cache-indexer → OpenSearch (interim) / ClickHouse (target)
 - [x] **OpenSearch retention** — ISM 14d hot → delete 42d ([#91](https://github.com/onixus/bsdm-proxy/pull/91))
 - [x] **OpenSearch Dashboards** — saved searches, playbook «traffic to domain», **BSDM HTTP Traffic** dashboard
 - [x] **ClickHouse foundation** — schema, `docker-compose.clickhouse.yml` ([#115](https://github.com/onixus/bsdm-proxy/pull/115))
-- [ ] **ClickHouse indexer** — `INDEXER_BACKEND=clickhouse` ([#114](https://github.com/onixus/bsdm-proxy/issues/114))
+- [x] **ClickHouse indexer** — `INDEXER_BACKEND=clickhouse`, JSONEachRow INSERT ([#114](https://github.com/onixus/bsdm-proxy/issues/114))
 - [ ] **Search API** — thin REST (ClickHouse HTTP) ([#110](https://github.com/onixus/bsdm-proxy/issues/110))
 - [ ] **Session correlation** — `session_id`, redirect chains
 - [ ] **Экспорт** — CSV/JSON для SOC

--- a/packaging/config/cache-indexer.env.example
+++ b/packaging/config/cache-indexer.env.example
@@ -19,7 +19,7 @@ OPENSEARCH_SSL_VERIFY=true
 RUST_LOG=info,cache_indexer=info
 RUST_BACKTRACE=0
 
-# ClickHouse backend (ADR 0002 — not implemented yet; default opensearch)
+# ClickHouse backend (ADR 0002)
 # INDEXER_BACKEND=opensearch
 # INDEXER_BACKEND=clickhouse
 # CLICKHOUSE_URL=http://127.0.0.1:8123


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements ClickHouse analytics backend for `cache-indexer` (ADR 0002, M3).

- `INDEXER_BACKEND=clickhouse` (or `ch`) switches from OpenSearch to ClickHouse HTTP INSERT
- `bsdm-events::clickhouse` — `CacheEvent` → `HttpCacheRow` JSONEachRow mapping (`ts`, `headers`, IPv4 normalize)
- `cache-indexer` split into `opensearch.rs` + `clickhouse.rs` + shared `kafka.rs`
- `docker-compose.clickhouse.yml` — enabled `cache-indexer` service for end-to-end stack
- Dockerfile: copy `bsdm-events` workspace crate

Closes #114

## Usage

```bash
docker compose -f docker-compose.clickhouse.yml up -d --build
curl -x http://127.0.0.1:1488 http://httpbin.org/get
curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
```

## Testing

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --all -- --check
```

## Checklist

- [ ] CI зелёный
- [x] Документация обновлена (`clickhouse-analytics.md`, `roadmap.md`, env example)
- [x] OpenSearch path unchanged (`INDEXER_BACKEND` default `opensearch`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

