### PR TITLE
Phase 3: ClickHouse default compose + legacy OpenSearch profile (#132, #133)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Cursor Cloud specific instructions
 
 BSDM-Proxy is a single Rust/Cargo product: a caching HTTPS forward proxy with MITM
-TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → OpenSearch
+TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → ClickHouse
 analytics pipeline. The Cargo workspace has three crates: `proxy/` (bin `proxy`),
 `cache-indexer/` (bin `cache-indexer`), and `e2e/` (test harness). Standard build,
 lint, test, and run commands live in `README.md` and `docs/development.md` — use those
@@ -30,5 +30,5 @@ Running and testing:
   (or the built `./target/debug/proxy`). Verify with `curl http://127.0.0.1:9090/health`
   and `curl -x http://127.0.0.1:1488 http://httpbin.org/get`. HTTPS through MITM:
   `curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/uuid`.
-- The full Docker stack (`docker-compose.yml`: Kafka, OpenSearch, Prometheus, Grafana) is
+- The full Docker stack (`docker-compose.yml`: Kafka, ClickHouse, Prometheus, Grafana) is
   optional and only needed to exercise the analytics pipeline / dashboards end to end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to BSDM-Proxy are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Default Docker stack** — `docker compose up` uses ClickHouse + Grafana CH dashboards + Search API instead of OpenSearch ([#132](https://github.com/onixus/bsdm-proxy/issues/132))
+- OpenSearch, OpenSearch Dashboards moved to `--profile legacy-opensearch` (deprecated, removal target **v0.5.0**) ([#133](https://github.com/onixus/bsdm-proxy/issues/133))
+- `docker-compose.clickhouse.yml` marked deprecated — use main compose
+
 ## [0.3.0] - 2026-06-30
 
 Milestone **M2 — Squid parity**: hierarchy Phase 4, enterprise auth (NTLM/Kerberos), ACL API, negative caching.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **B**usiness **S**ecure **D**ata **M**onitoring Proxy
 
-Высокопроизводительный кеширующий HTTPS-прокси на [Hyper](https://hyper.rs/) с [quick_cache](https://crates.io/crates/quick_cache), MITM TLS, аутентификацией, ACL и интеграцией с Kafka, OpenSearch, Prometheus и Grafana.
+Высокопроизводительный кеширующий HTTPS-прокси на [Hyper](https://hyper.rs/) с [quick_cache](https://crates.io/crates/quick_cache), MITM TLS, аутентификацией, ACL и интеграцией с Kafka, ClickHouse, Prometheus и Grafana.
 
 [![Build Status](https://github.com/onixus/bsdm-proxy/actions/workflows/rust.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/rust.yml)
 [![E2E Tests](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml)
@@ -22,7 +22,7 @@
 | **Безопасность** | Proxy-auth (Basic / LDAP / NTLM / Kerberos), **connection-level auth cache**, ACL + REST API, **policy decision cache**, категоризация URL, rate limiting |
 | **Производительность** | Multi-worker accept (`WORKER_COUNT`), perf fast path (`PERF_FAST_CACHE_HIT`), HTTP Archive bench profiles (`BENCH_PROFILE=warm\|cold`) |
 | **Наблюдаемость** | Prometheus (20+ метрик), Grafana, `/health`, `/ready`, `/metrics` |
-| **Аналитика** | Kafka → cache-indexer → OpenSearch (целевой store: ClickHouse) |
+| **Аналитика** | Kafka → cache-indexer → ClickHouse (Search API + Grafana) |
 | **Эксплуатация** | Graceful shutdown, Helm chart `charts/bsdm/`, release-пакет + systemd |
 
 ## Архитектура
@@ -50,7 +50,7 @@
              │ Cache-Indexer  │        │ Prometheus  │   │  Grafana    │
              └──────┬─────────┘        └─────────────┘   └─────────────┘
              ┌──────▼─────────┐
-             │  OpenSearch    │
+             │  ClickHouse    │
              └────────────────┘
 ```
 
@@ -61,11 +61,11 @@
 | **proxy** | 1488 | HTTPS-прокси, MITM, кеш L1, иерархия (опционально) |
 | **ICP** | 3130 | UDP-запросы между cache peers (при `HIERARCHY_ENABLED=true`) |
 | **metrics** | 9090 | `/health`, `/ready`, `/metrics` |
-| **cache-indexer** | — | Kafka → OpenSearch |
+| **cache-indexer** | 8080 | Kafka → ClickHouse, `/api/search` |
 | **Kafka** | 9092 | Очередь событий кеша |
-| **OpenSearch** | 9200 | Поиск и аналитика |
+| **ClickHouse** | 8123 / 9000 | Аналитика HTTP-трафика |
 | **Prometheus** | 9091 | Сбор метрик |
-| **Grafana** | 3000 | Дашборды (`admin` / `admin`) |
+| **Grafana** | 3000 | Дашборды proxy + HTTP Traffic (`admin` / `admin`) |
 
 ## Быстрый старт (Docker)
 
@@ -106,6 +106,19 @@ sudo security add-trusted-cert -d -r trustRoot \
 curl -x http://localhost:1488 https://httpbin.org/get
 curl http://localhost:9090/health
 curl http://localhost:9090/metrics | grep bsdm_proxy
+
+# Analytics (after ~5s)
+curl 'http://localhost:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+curl 'http://localhost:8080/api/search?limit=5'
+```
+
+Grafana: http://localhost:3000 → **BSDM HTTP Traffic (ClickHouse)** и **BSDM Proxy Dashboard**.
+
+**Legacy OpenSearch** (deprecated, removal target v0.5.0):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.legacy-opensearch.yml \
+  --profile legacy-opensearch up -d --build
 ```
 
 ## Установка (native package)
@@ -293,7 +306,11 @@ BENCH_PROFILE=cold ./scripts/compare-squid-bsdm-httparchive.sh
 | `KAFKA_BROKERS` | `kafka:9092` | Брокеры Kafka |
 | `KAFKA_TOPIC` | `cache-events` | Топик |
 | `KAFKA_GROUP_ID` | `cache-indexer-group` | Consumer group |
-| `OPENSEARCH_URL` | `http://opensearch:9200` | URL OpenSearch |
+| `INDEXER_BACKEND` | `clickhouse` (compose) | `clickhouse`, `dual`, `opensearch` (legacy) |
+| `CLICKHOUSE_URL` | `http://clickhouse:8123` | HTTP interface ClickHouse |
+| `METRICS_PORT` | `8080` | `/metrics`, `/health`, `/api/search` |
+
+→ [docs/search-api.md](docs/search-api.md) · [docs/clickhouse-analytics.md](docs/clickhouse-analytics.md)
 
 ## Мониторинг
 
@@ -318,7 +335,7 @@ histogram_quantile(0.95,
 )
 ```
 
-Grafana: http://localhost:3000 → **BSDM Proxy Dashboard** (7 панелей, auto-provisioned).
+Grafana: http://localhost:3000 → **BSDM Proxy Dashboard** (Prometheus) и **BSDM HTTP Traffic (ClickHouse)**.
 
 ## Тестирование
 
@@ -380,7 +397,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test) и [e2e.ym
 | **M1** Foundation | v0.2.x | Прокси, ACL, категоризация, observability | ✅ Done |
 | **M2** Squid parity | v0.3.x | L2, ACL API, NTLM/Kerberos, hierarchy Phase 4 | ✅ Done |
 | **M2.5** Data plane | v0.3.1 | Tiered L1, streaming MISS, auth/policy cache, bench | ~95% |
-| **M3** Retro-search | v0.4.x | OpenSearch/ClickHouse, dashboards, Search API | ~60% |
+| **M3** Retro-search | v0.4.x | ClickHouse, Grafana, Search API | ~75% |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C heuristics | ~5% |
 | **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | ~0% |
 

--- a/docker-compose.clickhouse.yml
+++ b/docker-compose.clickhouse.yml
@@ -1,13 +1,15 @@
-# ClickHouse analytics stack for BSDM-Proxy
+# ClickHouse analytics stack for BSDM-Proxy (slim profile)
 #
-# Kafka → cache-indexer (INDEXER_BACKEND=clickhouse) → ClickHouse
+# **Deprecated:** default `docker compose up` now includes ClickHouse, Grafana CH
+# dashboards, and Search API. Use this file only for a minimal CH-only lab stack
+# without Prometheus proxy metrics or MITM proxy defaults.
 #
-# End-to-end CH stack:
-#   docker compose -f docker-compose.clickhouse.yml up -d --build
-#   curl -x http://127.0.0.1:1488 http://httpbin.org/get
+# Preferred:
+#   docker compose up -d --build
 #   curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
 #
-# Default stack (OpenSearch): docker compose up -d
+# This file:
+#   docker compose -f docker-compose.clickhouse.yml up -d --build
 #
 # ADR: docs/adr/0002-clickhouse-analytics.md
 

--- a/docker-compose.legacy-opensearch.yml
+++ b/docker-compose.legacy-opensearch.yml
@@ -1,0 +1,32 @@
+# Legacy OpenSearch stack override (Phase 3 cutover).
+#
+# Restores OpenSearch + Dashboards indexer path for one release cycle.
+# Target removal: v0.5.0 (see docs/clickhouse-analytics.md).
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.legacy-opensearch.yml \
+#     --profile legacy-opensearch up -d --build
+#
+# OpenSearch Dashboards: http://localhost:5601
+
+services:
+  cache-indexer:
+    environment:
+      - INDEXER_BACKEND=opensearch
+      - KAFKA_BROKERS=kafka:9092
+      - KAFKA_TOPIC=cache-events
+      - KAFKA_GROUP_ID=cache-indexer-legacy-group
+      - OPENSEARCH_URL=http://opensearch:9200
+      - OPENSEARCH_INDEX=http-cache
+      - OPENSEARCH_ISM_ENABLED=true
+      - OPENSEARCH_ISM_HOT_DAYS=14
+      - OPENSEARCH_ISM_DELETE_DAYS=42
+      - METRICS_PORT=8080
+      - SEARCH_API_ENABLED=false
+      - RUST_LOG=info,cache_indexer=debug
+      - RUST_BACKTRACE=1
+    depends_on:
+      kafka:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,33 @@ services:
       retries: 12
       start_period: 30s
 
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.12
+    ports:
+      - "8123:8123"
+      - "9000:9000"
+    environment:
+      CLICKHOUSE_DB: bsdm
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+    volumes:
+      - clickhouse-data:/var/lib/clickhouse
+      - ./scripts/clickhouse/http_cache.sql:/docker-entrypoint-initdb.d/01-http_cache.sql:ro
+    networks:
+      - bsdm-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "clickhouse-client --query 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
   opensearch:
+    profiles: ["legacy-opensearch"]
     image: opensearchproject/opensearch:3.7.0
     environment:
       - cluster.name=opensearch-cluster
@@ -67,6 +93,7 @@ services:
       retries: 10
 
   opensearch-dashboards:
+    profiles: ["legacy-opensearch"]
     image: opensearchproject/opensearch-dashboards:3.7.0
     ports:
       - "5601:5601"
@@ -87,6 +114,7 @@ services:
       retries: 20
 
   dashboards-setup:
+    profiles: ["legacy-opensearch"]
     image: curlimages/curl:8.5.0
     depends_on:
       opensearch-dashboards:
@@ -149,21 +177,24 @@ services:
       context: .
       dockerfile: Dockerfile
       target: cache-indexer
+    ports:
+      - "8080:8080"
     environment:
+      - INDEXER_BACKEND=clickhouse
       - KAFKA_BROKERS=kafka:9092
-      - OPENSEARCH_URL=http://opensearch:9200
-      - OPENSEARCH_INDEX=http-cache
-      - OPENSEARCH_ISM_ENABLED=true
-      - OPENSEARCH_ISM_HOT_DAYS=14
-      - OPENSEARCH_ISM_DELETE_DAYS=42
       - KAFKA_TOPIC=cache-events
       - KAFKA_GROUP_ID=cache-indexer-group
+      - CLICKHOUSE_URL=http://clickhouse:8123
+      - CLICKHOUSE_DATABASE=bsdm
+      - CLICKHOUSE_TABLE=http_cache
+      - METRICS_PORT=8080
+      - SEARCH_API_ENABLED=true
       - RUST_LOG=info,cache_indexer=debug
       - RUST_BACKTRACE=1
     depends_on:
       kafka:
         condition: service_healthy
-      opensearch:
+      clickhouse:
         condition: service_healthy
     networks:
       - bsdm-net
@@ -202,7 +233,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_SECURITY_ADMIN_USER=admin
       - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_INSTALL_PLUGINS=grafana-piechart-panel
+      - GF_INSTALL_PLUGINS=grafana-piechart-panel,grafana-clickhouse-datasource
       - GF_SERVER_ROOT_URL=http://localhost:3000
     volumes:
       - grafana-data:/var/lib/grafana
@@ -213,6 +244,7 @@ services:
     restart: unless-stopped
     depends_on:
       - prometheus
+      - clickhouse
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
       interval: 10s
@@ -224,6 +256,8 @@ networks:
     driver: bridge
 
 volumes:
+  clickhouse-data:
+    driver: local
   opensearch-data:
     driver: local
   prometheus-data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,8 @@
 
 | Документ | Описание |
 |----------|----------|
-| [docker-compose.yml](../docker-compose.yml) | Полный стек (proxy, Kafka, OpenSearch, monitoring) |
-| [docker-compose.clickhouse.yml](../docker-compose.clickhouse.yml) | ClickHouse analytics stack (Grafana + Search API) |
+| [docker-compose.yml](../docker-compose.yml) | Полный стек (proxy, Kafka, ClickHouse, monitoring) |
+| [docker-compose.legacy-opensearch.yml](../docker-compose.legacy-opensearch.yml) | Legacy OpenSearch override (deprecated) |
 | [docker-compose.redis-l2.yml](../docker-compose.redis-l2.yml) | Демо Redis L2 (2 proxy + Redis) |
 | [OPENSEARCH_UPGRADE.md](../OPENSEARCH_UPGRADE.md) | Обновление OpenSearch |
 | [web-config/README.md](../web-config/README.md) | Web UI для генерации конфигурации |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ flowchart TB
   subgraph pipeline [Analytics pipeline]
     KAFKA[Kafka cache-events]
     IDX[cache-indexer]
-    OS[(OpenSearch http-cache)]
+    CH[(ClickHouse http_cache)]
   end
 
   subgraph observability [Observability]
@@ -57,7 +57,7 @@ flowchart TB
   PEER --> UP
   CACHE --> UP
   MAIN --> TLS
-  MAIN --> KPROD --> KAFKA --> IDX --> OS
+  MAIN --> KPROD --> KAFKA --> IDX --> CH
   MET --> PROM --> GRAF
 ```
 
@@ -122,7 +122,7 @@ TCP accept
 CacheEvent (main.rs)
   → Kafka topic "cache-events" (hardcoded, acks=0)
   → cache-indexer consumer
-  → OpenSearch bulk index "http-cache"
+  → ClickHouse INSERT `bsdm.http_cache`
 ```
 
 ```mermaid
@@ -130,19 +130,19 @@ sequenceDiagram
   participant P as proxy
   participant K as Kafka
   participant I as cache-indexer
-  participant O as OpenSearch
+  participant C as ClickHouse
 
   P->>P: handle_request completes
   P-->>K: CacheEvent JSON (async, acks=0)
   Note over P,K: categories sent by proxy
   K->>I: consume batch
-  I->>O: bulk index
-  Note over I,O: categories NOT in indexer schema
+  I->>C: JSONEachRow insert
+  Note over I,C: full CacheEvent schema in CH
 ```
 
 **Поля `CacheEvent` (proxy):** url, method, status, cache_key, cache_status, user, client_ip, domain, timing, UA, content_type, **categories**
 
-**Поля indexer:** те же, кроме **categories** — теряются при десериализации.
+**Поля indexer:** полная схема `CacheEvent` в ClickHouse (`categories`, `threat_sources`, `acl_action`).
 
 ---
 
@@ -165,7 +165,7 @@ proxy/
 │   ├── policy_config.rs ← env loading
 │   └── auth_config.rs
 cache-indexer/
-└── src/main.rs          ← Kafka → OpenSearch
+└── src/main.rs          ← Kafka → ClickHouse (default) / OpenSearch (legacy)
 e2e/                     ← smoke + E2E harness
 ```
 

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -5,7 +5,7 @@
 ## Быстрый старт
 
 ```bash
-docker compose -f docker-compose.clickhouse.yml up -d --build
+docker compose up -d --build
 
 # Проверка схемы
 curl 'http://127.0.0.1:8123/?query=SHOW+TABLES+FROM+bsdm'
@@ -13,8 +13,8 @@ curl 'http://127.0.0.1:8123/?query=SHOW+TABLES+FROM+bsdm'
 # Трафик через прокси (события уходят в Kafka)
 curl -x http://127.0.0.1:1488 http://httpbin.org/get
 
-# После реализации CH indexer — строки появятся в bsdm.http_cache
 curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
+curl 'http://127.0.0.1:8080/api/search?limit=5'
 ```
 
 Grafana: http://localhost:3000 (admin/admin) — datasource ClickHouse и dashboard **BSDM HTTP Traffic (ClickHouse)** поднимаются автоматически из `grafana/clickhouse/`.
@@ -79,14 +79,15 @@ curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
 | 1 | Этот compose + ADR 0002 |
 | 2 | ✅ `INDEXER_BACKEND=clickhouse` в cache-indexer |
 | 2b | ✅ `INDEXER_BACKEND=dual` + reconciliation script |
-| 2 | Grafana SQL dashboards (CH compose) — [#129](https://github.com/onixus/bsdm-proxy/issues/129) |
-| 3 | Search API на ClickHouse — [#130](https://github.com/onixus/bsdm-proxy/issues/130), [search-api.md](search-api.md) |
+| 2 | ✅ Grafana CH dashboards + Search API ([#129](https://github.com/onixus/bsdm-proxy/issues/129), [#130](https://github.com/onixus/bsdm-proxy/issues/130)) |
+| 3 | ✅ Default `docker compose up` на ClickHouse ([#132](https://github.com/onixus/bsdm-proxy/issues/132)) |
+| 4 | Legacy OpenSearch profile (removal v0.5.0) |
 
 Kafka остаётся bus на фазе 1–2; NATS — опционально позже (ADR 0002).
 
 ## Миграция (dual-write)
 
-Пока default compose на OpenSearch, для валидации CH:
+Для валидации CH перед cutover (нужны OS + CH + Kafka):
 
 ```bash
 # cache-indexer с dual-write (нужны OS + CH + Kafka)
@@ -104,6 +105,19 @@ chmod +x scripts/reconcile-os-ch-events.sh
 Метрики: `cache_indexer_inserts_total{backend}`, `cache_indexer_insert_errors_total{backend}`, `cache_indexer_batch_duration_seconds`.
 
 Epic: [#125](https://github.com/onixus/bsdm-proxy/issues/125).
+
+## Legacy OpenSearch (deprecated)
+
+Default compose использует ClickHouse. OpenSearch + Dashboards доступны один релизный цикл:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.legacy-opensearch.yml \
+  --profile legacy-opensearch up -d --build
+```
+
+Env: `packaging/config/cache-indexer.legacy-opensearch.env`. **Планируемое удаление: v0.5.0** (Phase 4 — [#134](https://github.com/onixus/bsdm-proxy/issues/134)).
+
+Slim CH-only lab: `docker-compose.clickhouse.yml` (deprecated, см. заголовок файла).
 
 ## k8s
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,16 +114,15 @@ _Нет открытых P0 — gate M2.5: warm goodput HTTP Archive ≥ Squid �
 ### Архитектура
 
 ```
-proxy → Kafka → cache-indexer → OpenSearch (interim) / ClickHouse (target)
+proxy → Kafka → cache-indexer → ClickHouse
 ```
 
-**Целевой store:** ClickHouse ([ADR 0002](adr/0002-clickhouse-analytics.md)). OpenSearch остаётся в default compose до завершения миграции.
+**Default compose:** ClickHouse + Grafana SQL dashboards + Search API ([#125](https://github.com/onixus/bsdm-proxy/issues/125)). OpenSearch доступен через `--profile legacy-opensearch` (deprecated, removal v0.5.0).
 
 ### Текущий gap
 
 - Search API и session correlation
-- ClickHouse indexer ([#114](https://github.com/onixus/bsdm-proxy/issues/114))
-- Grafana SQL dashboards (замена OSD long-term)
+- Session correlation (`session_id`, redirect chains)
 
 ### Задачи
 
@@ -132,7 +131,8 @@ proxy → Kafka → cache-indexer → OpenSearch (interim) / ClickHouse (target)
 - [x] **OpenSearch Dashboards** — saved searches, playbook «traffic to domain», **BSDM HTTP Traffic** dashboard
 - [x] **ClickHouse foundation** — schema, `docker-compose.clickhouse.yml` ([#115](https://github.com/onixus/bsdm-proxy/pull/115))
 - [x] **ClickHouse indexer** — `INDEXER_BACKEND=clickhouse`, JSONEachRow INSERT ([#114](https://github.com/onixus/bsdm-proxy/issues/114))
-- [ ] **Search API** — thin REST (ClickHouse HTTP) ([#110](https://github.com/onixus/bsdm-proxy/issues/110))
+- [x] **Grafana + Search API** — CH dashboards, `/api/search` ([#129](https://github.com/onixus/bsdm-proxy/issues/129), [#130](https://github.com/onixus/bsdm-proxy/issues/130))
+- [x] **Default compose on ClickHouse** — `docker compose up` ([#132](https://github.com/onixus/bsdm-proxy/issues/132))
 - [ ] **Session correlation** — `session_id`, redirect chains
 - [ ] **Экспорт** — CSV/JSON для SOC
 

--- a/grafana/dashboards/bsdm-http-traffic-ch.json
+++ b/grafana/dashboards/bsdm-http-traffic-ch.json
@@ -1,0 +1,311 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "sql",
+          "rawSql": "SELECT\n  toStartOfHour(ts) AS time,\n  count() AS \"Requests\"\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\nGROUP BY time\nORDER BY time",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "right", "showLegend": true },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT cache_status, count() AS count\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\nGROUP BY cache_status\nORDER BY count DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache status breakdown",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT count() AS blocked\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND (acl_action = 'deny' OR acl_action = 'redirect')",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked requests",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 8 },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT domain, count() AS requests, sum(response_size) AS bytes\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\nGROUP BY domain\nORDER BY requests DESC\nLIMIT 10",
+          "refId": "A"
+        }
+      ],
+      "title": "Top domains",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT username, domain, count() AS requests, sum(response_size) AS bytes\nFROM bsdm.http_cache\nWHERE ts >= now() - INTERVAL 7 DAY\n  AND username IS NOT NULL\nGROUP BY username, domain\nORDER BY requests DESC\nLIMIT 50",
+          "refId": "A"
+        }
+      ],
+      "title": "Top domains per user (7d)",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 6,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT arrayJoin(threat_sources) AS threat_source, count() AS events\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND length(threat_sources) > 0\nGROUP BY threat_source\nORDER BY events DESC\nLIMIT 15",
+          "refId": "A"
+        }
+      ],
+      "title": "Threat sources",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT ts, username, client_ip, domain, url, method, status, cache_status, acl_action, threat_sources\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND (length('${domain}') = 0 OR domain = '${domain}')\nORDER BY ts DESC\nLIMIT 500",
+          "refId": "A"
+        }
+      ],
+      "title": "Traffic to domain ($domain)",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 34 },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT ts, username, client_ip, domain, url, acl_action, cache_status, categories, threat_sources\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND (acl_action IN ('deny', 'redirect') OR length(threat_sources) > 0)\nORDER BY ts DESC\nLIMIT 200",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked / threat events",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["bsdm", "http-cache", "clickhouse"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "example.com", "value": "example.com" },
+        "hide": 0,
+        "label": "Domain",
+        "name": "domain",
+        "options": [
+          { "selected": true, "text": "example.com", "value": "example.com" }
+        ],
+        "query": "example.com",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": { "from": "now-30d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "BSDM HTTP Traffic (ClickHouse)",
+  "uid": "bsdm-http-traffic-ch",
+  "version": 1
+}

--- a/grafana/datasources.yml
+++ b/grafana/datasources.yml
@@ -8,3 +8,18 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+
+  - name: ClickHouse
+    uid: clickhouse
+    type: grafana-clickhouse-datasource
+    access: proxy
+    editable: false
+    jsonData:
+      host: clickhouse
+      port: 9000
+      protocol: native
+      username: default
+      defaultDatabase: bsdm
+      defaultTable: http_cache
+      dialTimeout: 10
+      queryTimeout: 60

--- a/packaging/config/cache-indexer.env.example
+++ b/packaging/config/cache-indexer.env.example
@@ -20,7 +20,6 @@ RUST_LOG=info,cache_indexer=info
 RUST_BACKTRACE=0
 
 # ClickHouse backend (ADR 0002)
-# INDEXER_BACKEND=opensearch
 # INDEXER_BACKEND=clickhouse
 # INDEXER_BACKEND=dual
 # DUAL_WRITE_CH_FAIL_POLICY=warn

--- a/packaging/config/cache-indexer.legacy-opensearch.env
+++ b/packaging/config/cache-indexer.legacy-opensearch.env
@@ -1,0 +1,11 @@
+# Legacy OpenSearch indexer — use with docker-compose.legacy-opensearch.yml
+#   docker compose -f docker-compose.yml -f docker-compose.legacy-opensearch.yml \
+#     --profile legacy-opensearch up -d
+
+INDEXER_BACKEND=opensearch
+OPENSEARCH_URL=http://opensearch:9200
+OPENSEARCH_INDEX=http-cache
+OPENSEARCH_ISM_ENABLED=true
+OPENSEARCH_ISM_HOT_DAYS=14
+OPENSEARCH_ISM_DELETE_DAYS=42
+SEARCH_API_ENABLED=false

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -13,6 +13,13 @@ scrape_configs:
           service: 'proxy'
           component: 'bsdm-proxy'
     
+  - job_name: 'cache-indexer'
+    static_configs:
+      - targets: ['cache-indexer:8080']
+        labels:
+          service: 'cache-indexer'
+          component: 'bsdm-indexer'
+
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 3 of OpenSearch → ClickHouse migration ([#125](https://github.com/onixus/bsdm-proxy/issues/125)): **ClickHouse is now the default analytics store** in `docker-compose.yml`.

## Связанные issue

- Closes #132
- Closes #133
- Epic: #125

## Changes

### Default stack (`docker-compose.yml`)
- Added **ClickHouse** service + `clickhouse-data` volume
- **cache-indexer**: `INDEXER_BACKEND=clickhouse`, Search API on `:8080`
- **Grafana**: `grafana-clickhouse-datasource` plugin + **BSDM HTTP Traffic (ClickHouse)** dashboard
- **Prometheus**: scrape `cache-indexer:8080`
- Removed OpenSearch from default path

### Legacy OpenSearch (#133)
- `opensearch`, `opensearch-dashboards`, `dashboards-setup` → `profiles: [legacy-opensearch]`
- `docker-compose.legacy-opensearch.yml` — override for OS indexer
- `packaging/config/cache-indexer.legacy-opensearch.env`
- Documented deprecation; **removal target v0.5.0**

### Docs
- README quick start with CH analytics checks
- `docs/architecture.md`, `roadmap.md`, `clickhouse-analytics.md`, CHANGELOG
- `docker-compose.clickhouse.yml` marked deprecated (slim lab only)

## Testing

```bash
cargo test -p cache-indexer
cargo clippy -p cache-indexer --all-targets -- -D warnings
```

Manual:
```bash
docker compose up -d --build
curl -x http://127.0.0.1:1488 http://httpbin.org/get
curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
./scripts/test-search-api.sh
```

## Checklist

- [x] Документация обновлена
- [ ] CI зелёный
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

