### PR TITLE
docs: update NOTICE and add licensing guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR 0002 status → Accepted
 - `docker-compose.clickhouse.yml`, `grafana/clickhouse/` duplicate, `README.md_old`, `SDBM/`, `.github/issue-bodies/ch-*.md`
 
+### Added
+
+- `docs/licensing.md` — license audit and compliance guide
+- Updated `NOTICE` — current Rust deps, Docker images, AGPL notes (removed Pingora/OpenSearch)
+
 ## [0.3.0] - 2026-06-30
 
 Milestone **M2 — Squid parity**: hierarchy Phase 4, enterprise auth (NTLM/Kerberos), ACL API, negative caching.

--- a/NOTICE
+++ b/NOTICE
@@ -5,82 +5,120 @@ This project is licensed under the MIT License.
 See the LICENSE file for details.
 
 ================================================================================
-THIRD-PARTY COMPONENTS
+THIRD-PARTY SOFTWARE
 ================================================================================
 
-This project uses the following third-party components:
+BSDM-Proxy bundles or depends on third-party open-source software listed below.
+For a full transitive dependency report, run:
+
+    cargo install cargo-license
+    cargo license --avoid-dev-deps --avoid-build-deps
+
+See also: docs/licensing.md
 
 --------------------------------------------------------------------------------
-Apache-2.0 Licensed Components
+Rust crates — direct dependencies (default build)
 --------------------------------------------------------------------------------
 
-1. Pingora (CloudFlare, Inc.)
-   Copyright (c) 2024 CloudFlare, Inc.
-   Licensed under the Apache License, Version 2.0
-   https://github.com/cloudflare/pingora
+HTTP & async runtime
+  hyper              MIT           https://github.com/hyperium/hyper
+  hyper-util         MIT           https://github.com/hyperium/hyper
+  tokio              MIT           https://github.com/tokio-rs/tokio
+  tokio-util         MIT           https://github.com/tokio-rs/tokio
+  bytes              MIT           https://github.com/tokio-rs/bytes
 
-2. OpenSearch Rust Client
-   Copyright OpenSearch Contributors
-   Licensed under the Apache License, Version 2.0
-   https://github.com/opensearch-project/opensearch-rs
+TLS
+  rustls             Apache-2.0 OR ISC OR MIT   https://github.com/rustls/rustls
+  rustls-pemfile     Apache-2.0 OR ISC OR MIT   https://github.com/rustls/pemfile
+  tokio-rustls       Apache-2.0 OR MIT          https://github.com/rustls/tokio-rustls
+  hyper-rustls       Apache-2.0 OR ISC OR MIT   https://github.com/rustls/hyper-rustls
+  ring               Apache-2.0 AND ISC         https://github.com/briansmith/ring
+  rcgen              Apache-2.0 OR MIT          https://github.com/rustls/rcgen
 
---------------------------------------------------------------------------------
-Dual Licensed Components (Apache-2.0 OR MIT)
---------------------------------------------------------------------------------
+Caching & storage
+  quick_cache        MIT           https://github.com/arthurprs/quick-cache
+  redis              BSD-3-Clause  https://github.com/redis-rs/redis-rs
+  memmap2            Apache-2.0 OR MIT   https://github.com/RazrFalcon/memmap2
+  zstd / zstd-sys    MIT / Apache-2.0 OR MIT   https://github.com/gyscos/zstd-rs
+  brotli             BSD-3-Clause AND MIT    https://github.com/gyscos/brotli
 
-3. rdkafka - Rust Kafka Client
-   Copyright (c) 2017-2024 Federico Giraud and contributors
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/fede1024/rust-rdkafka
+Messaging & analytics pipeline
+  rdkafka            MIT           https://github.com/fede1024/rust-rdkafka
+  rdkafka-sys        MIT           https://github.com/fede1024/rust-rdkafka
+  reqwest            Apache-2.0 OR MIT   https://github.com/seanmonstar/reqwest
 
-4. serde - Serialization framework
-   Copyright (c) 2014-2024 Erick Tryzelaar and David Tolnay
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/serde-rs/serde
+Observability
+  prometheus         Apache-2.0    https://github.com/pingcap/rust-prometheus
+  tracing            MIT           https://github.com/tokio-rs/tracing
+  tracing-subscriber MIT           https://github.com/tokio-rs/tracing
 
-5. RustCrypto Libraries (sha2, hex)
-   Copyright RustCrypto Developers
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/RustCrypto
-
-6. rcgen - Certificate Generation
-   Copyright (c) 2018-2024 est31 and contributors
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/est31/rcgen
-
-7. async-trait
-   Copyright (c) 2019-2024 David Tolnay
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/dtolnay/async-trait
-
-8. time - Date and time library
-   Copyright (c) 2019-2024 Time Contributors
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/time-rs/time
-
-9. pem - PEM encoding/decoding
-   Copyright (c) 2016-2024 Jonathan Creekmore
-   Licensed under Apache-2.0 OR MIT
-   https://github.com/jcreekmore/pem
+Serialization & utilities
+  serde              Apache-2.0 OR MIT   https://github.com/serde-rs/serde
+  serde_json         Apache-2.0 OR MIT   https://github.com/serde-rs/json
+  chrono             Apache-2.0 OR MIT   https://github.com/chronotope/chrono
+  regex              Apache-2.0 OR MIT   https://github.com/rust-lang/regex
+  sha2               Apache-2.0 OR MIT   https://github.com/RustCrypto/hashes
+  hex                Apache-2.0 OR MIT   https://github.com/Kixunil/hex-conservative
+  base64             Apache-2.0 OR MIT   https://github.com/marshallpierce/rust-base64
+  url                Apache-2.0 OR MIT   https://github.com/servo/rust-url
+  socket2            Apache-2.0 OR MIT   https://github.com/deprecatenet/rust-socket2
 
 --------------------------------------------------------------------------------
-MIT Licensed Components
+Rust crates — optional authentication features
 --------------------------------------------------------------------------------
 
-10. Tokio - Asynchronous runtime
-    Copyright (c) 2024 Tokio Contributors
-    Licensed under the MIT License
-    https://github.com/tokio-rs/tokio
+Included only when building with Cargo features (not in default build):
 
-11. tracing - Application-level tracing
-    Copyright (c) 2019-2024 Tokio Contributors
-    Licensed under the MIT License
-    https://github.com/tokio-rs/tracing
+  ldap3              Apache-2.0 OR MIT   feature: auth-ldap
+                     https://github.com/bluejekyll/ldap3
 
-12. bytes - Byte buffer utilities
-    Copyright (c) 2018-2024 Carl Lerche and contributors
-    Licensed under the MIT License
-    https://github.com/tokio-rs/bytes
+  sspi               Apache-2.0 OR MIT   features: auth-ntlm, auth-kerberos
+                     https://github.com/Devolutions/sspi-rs
+
+  kerberos_keytab    AGPL-3.0            feature: auth-kerberos
+                     https://crates.io/crates/kerberos_keytab
+                     WARNING: copyleft license — review before redistribution
+                     with auth-kerberos enabled. See docs/licensing.md.
+
+--------------------------------------------------------------------------------
+Native libraries (linked at build time)
+--------------------------------------------------------------------------------
+
+Used by Docker multi-stage build (Dockerfile) and native package builds:
+
+  librdkafka         BSD-2-Clause  https://github.com/confluentinc/librdkafka
+  OpenSSL            OpenSSL / Apache-style  https://www.openssl.org/
+  lz4, zlib, zstd    BSD / permissive  (Alpine / system packages)
+  cyrus-sasl         BSD-style     (optional SASL for Kafka)
+
+--------------------------------------------------------------------------------
+Docker Compose infrastructure images (optional, not bundled)
+--------------------------------------------------------------------------------
+
+When using docker-compose.yml, the following container images are pulled at
+runtime. They are separate from BSDM-Proxy binaries and governed by their
+own licenses:
+
+  confluentinc/cp-kafka:7.9.8        Apache Kafka (Apache-2.0)
+  confluentinc/cp-zookeeper:7.9.8    Apache ZooKeeper (Apache-2.0)
+  clickhouse/clickhouse-server:24.12 Apache-2.0
+  prom/prometheus:v3.12.0            Apache-2.0
+  grafana/grafana:12.3.8             AGPL-3.0 (core Grafana since v8.0)
+  grafana-clickhouse-datasource      Apache-2.0 (Grafana plugin)
+  grafana-piechart-panel             MIT (Grafana plugin)
+  redis:7.4-alpine                   BSD-3-Clause (redis-l2 / ha profiles)
+  kennethreitz/httpbin               BSD (test compose only)
+
+Grafana is licensed under AGPL-3.0. If you modify Grafana or offer it as a
+network service, AGPL obligations may apply. See docs/licensing.md.
+
+--------------------------------------------------------------------------------
+External data sources (admin-provided, not shipped)
+--------------------------------------------------------------------------------
+
+  Shallalist         URL categorization database — admin downloads separately;
+                     license terms defined by the list maintainer (if any).
+  URLhaus / PhishTank  HTTP APIs for threat intelligence — online services.
 
 ================================================================================
 APACHE LICENSE 2.0 NOTICE
@@ -101,16 +139,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ================================================================================
-PATENT GRANTS
-================================================================================
-
-Components licensed under Apache-2.0 include patent grants.
-Refer to each component's license for specific patent grant terms.
-
-================================================================================
 FULL LICENSE TEXTS
 ================================================================================
 
-For full license texts, see:
-- MIT License: ./LICENSE
+- MIT License (this project): ./LICENSE
 - Apache License 2.0: https://www.apache.org/licenses/LICENSE-2.0.txt
+- BSD-3-Clause: https://opensource.org/licenses/BSD-3-Clause
+- AGPL-3.0 (optional Grafana / auth-kerberos): https://www.gnu.org/licenses/agpl-3.0.html
+
+Detailed audit and compliance notes: docs/licensing.md

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 | [docs/acl.md](docs/acl.md) | Правила доступа, REST API |
 | [docs/categorization.md](docs/categorization.md) | Shallalist, URLhaus, PhishTank |
 | [docs/hierarchical-caching.md](docs/hierarchical-caching.md) | Иерархический кеш, ICP, HTCP |
+| [docs/licensing.md](docs/licensing.md) | Лицензии, third-party, AGPL-заметки |
+| [NOTICE](NOTICE) | Реестр third-party компонентов |
 | [docs/clickhouse-analytics.md](docs/clickhouse-analytics.md) | ClickHouse analytics, compose, SQL |
 | [docs/search-api.md](docs/search-api.md) | REST Search API (`/api/search`) |
 | [docs/adr/0002-clickhouse-analytics.md](docs/adr/0002-clickhouse-analytics.md) | ADR: ClickHouse как analytics store |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 | [packaging/README.md](../packaging/README.md) | Установка из release-пакета (systemd) |
 | [development.md](development.md) | Сборка, тесты, CI, релиз |
 | [structure.md](structure.md) | **Структура репозитория** |
+| [licensing.md](licensing.md) | **Лицензии и third-party компоненты** |
 | [CHANGELOG.md](../CHANGELOG.md) | История изменений |
 | [releases/v0.3.0.md](releases/v0.3.0.md) | **Release notes 0.3.0** |
 | [releases/v0.2.3-test.md](releases/v0.2.3-test.md) | Release notes 0.2.3-test (superseded) |

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,189 @@
+# Лицензирование и third-party компоненты
+
+Обзор лицензий переиспользуемого ПО в BSDM-Proxy v0.3.0.
+
+> См. также: [NOTICE](../NOTICE) · [LICENSE](../LICENSE)
+
+---
+
+## Лицензия проекта
+
+**BSDM-Proxy** распространяется под **MIT License** ([LICENSE](../LICENSE)).
+
+Workspace-крейты:
+
+| Крейт | Лицензия |
+|-------|----------|
+| `bsdm-proxy` (proxy) | MIT |
+| `cache-indexer` | MIT |
+| `bsdm-events` | MIT |
+| `bsdm-proxy-e2e` | MIT (только тесты, не в release) |
+
+---
+
+## Сводка по областям
+
+| Область | Статус | Примечание |
+|---------|--------|------------|
+| Дефолтная сборка (`auth-basic`) | ✅ Permissive | MIT / Apache-2.0 / BSD — без GPL/AGPL |
+| `auth-ldap`, `auth-ntlm` | ✅ Permissive | ldap3, sspi — Apache-2.0 OR MIT |
+| `auth-kerberos` | ⚠️ AGPL | `kerberos_keytab` — **AGPL-3.0** |
+| Docker Compose (инфра) | ⚠️ AGPL | Grafana core — **AGPL-3.0** |
+| Внешние БД (Shallalist) | ⚠️ Admin | Лицензия данных — на стороне администратора |
+
+---
+
+## Rust-зависимости
+
+### Дефолтная production-сборка
+
+Стандартная сборка proxy и cache-indexer:
+
+```bash
+cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer
+```
+
+Проверка лицензий runtime-графа (без dev/build deps):
+
+```bash
+cargo install cargo-license
+cargo license --avoid-dev-deps --avoid-build-deps
+```
+
+На момент v0.3.0: **~282** runtime crate, все с permissive-лицензиями (MIT, Apache-2.0, BSD-3-Clause, ISC и dual Apache/MIT).
+
+### Прямые зависимости proxy
+
+| Компонент | Лицензия | Назначение |
+|-----------|----------|------------|
+| hyper, tokio, bytes | MIT | HTTP server / async |
+| quick_cache | MIT | L1 cache |
+| rdkafka | MIT | Kafka producer |
+| rustls, ring | Apache-2.0 / ISC / MIT | TLS (MITM, upstream) |
+| redis | BSD-3-Clause | Redis L2 (опц.) |
+| brotli, zstd | BSD-3 / MIT | Сжатие тела кеша |
+| prometheus | Apache-2.0 | `/metrics` |
+| reqwest | Apache-2.0 OR MIT | HTTP client (categorization) |
+| serde, chrono, regex | Apache-2.0 OR MIT | Сериализация, время, ACL |
+
+Полный список прямых зависимостей — в [NOTICE](../NOTICE).
+
+### Опциональные auth-features
+
+| Feature | Crate | Лицензия | Риск |
+|---------|-------|----------|------|
+| `auth-ldap` | ldap3 | Apache-2.0 OR MIT | Нет |
+| `auth-ntlm` | sspi | Apache-2.0 OR MIT | Нет |
+| `auth-kerberos` | kerberos_keytab | **AGPL-3.0** | **Copyleft** |
+
+```bash
+# Показать copyleft при сборке с Kerberos
+cd proxy && cargo license --features auth-kerberos --json \
+  | jq '.[] | select(.license | test("GPL"))'
+```
+
+**Рекомендации для `auth-kerberos`:**
+
+- Не включать в enterprise/release binary без юридической оценки AGPL.
+- Для AD/Kerberos рассмотреть LDAP (`auth-ldap`) как permissive-альтернативу.
+- При необходимости Kerberos — оценить замену `kerberos_keytab` или dual-licensing.
+
+Дефолтный CI и release-пакет **не** включают `auth-kerberos`.
+
+### Нативные библиотеки
+
+При сборке Docker-образа ([Dockerfile](../Dockerfile)) статически линкуются:
+
+| Библиотека | Лицензия |
+|------------|----------|
+| librdkafka (через rdkafka-sys) | BSD-2-Clause |
+| OpenSSL | OpenSSL License |
+| lz4, zlib, zstd, cyrus-sasl | Permissive (Alpine packages) |
+
+---
+
+## Docker Compose (инфраструктура)
+
+Образы **не входят** в бинарники BSDM-Proxy — подтягиваются при `docker compose up`.
+
+| Образ | Лицензия | Compose-файл |
+|-------|----------|--------------|
+| `confluentinc/cp-kafka:7.9.8` | Apache-2.0 (community Kafka) | `docker-compose.yml` |
+| `confluentinc/cp-zookeeper:7.9.8` | Apache-2.0 | `docker-compose.yml` |
+| `clickhouse/clickhouse-server:24.12` | Apache-2.0 | `docker-compose.yml` |
+| `prom/prometheus:v3.12.0` | Apache-2.0 | `docker-compose.yml` |
+| **`grafana/grafana:12.3.8`** | **AGPL-3.0** | `docker-compose.yml` |
+| `grafana-clickhouse-datasource` | Apache-2.0 | Grafana plugin |
+| `grafana-piechart-panel` | MIT | Grafana plugin |
+| `redis:7.4-alpine` | BSD-3-Clause | `docker-compose.redis-l2.yml`, `.ha.yml` |
+| `kennethreitz/httpbin` | BSD | `docker-compose.test.yml` (только тесты) |
+
+### Grafana (AGPL-3.0)
+
+С Grafana 8.0 core перешёл с Apache-2.0 на **AGPL-3.0**.
+
+- **Внутреннее использование** без модификаций — обычно приемлемо.
+- **SaaS / модификации / перепродажа** — могут потребоваться обязательства AGPL или [Grafana Enterprise](https://grafana.com/licensing/).
+- Плагин ClickHouse datasource — отдельно под Apache-2.0.
+
+Альтернатива: развернуть только Prometheus + Search API без Grafana UI.
+
+---
+
+## Внешние данные и API
+
+Не являются Rust-зависимостями; администратор подключает самостоятельно.
+
+| Источник | Тип | Лицензия |
+|----------|-----|----------|
+| **Shallalist** | Локальная БД категорий | Определяется правообладателем списка; сервис discontinued с 2022 — проверяйте условия перед production |
+| **URLhaus** | HTTP API (abuse.ch) | Условия использования API |
+| **PhishTank** | HTTP API | Условия использования API |
+| MITM CA (`certs/`) | Генерируется локально | — |
+
+---
+
+## Соответствие и аудит
+
+### Регулярная проверка
+
+```bash
+# Полный граф runtime-зависимостей
+cargo license --avoid-dev-deps --avoid-build-deps
+
+# С optional auth
+cd proxy && cargo license --features auth-all
+
+# Security advisories (отдельно от лицензий)
+cargo install cargo-audit
+cargo audit
+```
+
+### Файлы проекта
+
+| Файл | Назначение |
+|------|------------|
+| [LICENSE](../LICENSE) | MIT — лицензия BSDM-Proxy |
+| [NOTICE](../NOTICE) | Краткий реестр third-party (прямые deps, Docker, native) |
+| `docs/licensing.md` | Этот документ — детали и рекомендации |
+
+### Исторические компоненты (удалены)
+
+Следующие компоненты **больше не используются** в v0.3.0:
+
+- Pingora (ранний HTTP stack)
+- OpenSearch Rust client (заменён на ClickHouse)
+- `docker-compose.clickhouse.yml` (слит в основной compose)
+
+---
+
+## Рекомендации для release / enterprise
+
+1. Собирать release **без** `auth-kerberos`, если не проведена AGPL-оценка.
+2. Включать [NOTICE](../NOTICE) в release tarball (`packaging/`).
+3. Для Docker-стека документировать AGPL Grafana для compliance-команды.
+4. Рассмотреть `cargo-deny` с license policy в CI (allow MIT/Apache/BSD; flag GPL/AGPL).
+
+---
+
+*Последний аудит: 2026-06 · v0.3.0 · `cargo license` + compose manifest*

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -81,4 +81,4 @@ bsdm-proxy/
 | `README.md_old`, `SDBM/` | — |
 | `.github/issue-bodies/ch-*.md` | Миграция завершена ([#125](https://github.com/onixus/bsdm-proxy/issues/125)) |
 
-См. [ADR 0002](adr/0002-clickhouse-analytics.md) · [clickhouse-analytics.md](clickhouse-analytics.md)
+См. [ADR 0002](adr/0002-clickhouse-analytics.md) · [clickhouse-analytics.md](clickhouse-analytics.md) · [licensing.md](licensing.md)

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bsdm-proxy-e2e"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 publish = false
 
 [lib]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bsdm-proxy"
 version = "0.3.0"
 edition = "2021"
+license = "MIT"
 
 # Binary targets
 [[bin]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Обновление лицензионной документации после аудита third-party компонентов.

### Изменения

- **`NOTICE`** — переписан: актуальные Rust deps (hyper, quick_cache, rustls, rdkafka…), native libs, Docker images; удалены устаревшие Pingora и OpenSearch
- **`docs/licensing.md`** — полный гайд: дефолтная сборка, optional auth-features, AGPL (Grafana, kerberos_keytab), команды `cargo license`
- `license = "MIT"` в `proxy/Cargo.toml` и `e2e/Cargo.toml`
- Ссылки в `docs/README.md`, `README.md`, `docs/structure.md`, `CHANGELOG.md`

### Ключевые замечания (документированы)

| Компонент | Лицензия |
|-----------|----------|
| Дефолтная сборка | Permissive (MIT/Apache/BSD) |
| `auth-kerberos` → kerberos_keytab | AGPL-3.0 |
| Grafana в docker-compose | AGPL-3.0 |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

