### PR TITLE
feat(categorization): offline hot path + release v0.3.2 (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-02
+
+Milestone **M2.5 perf P1**: hot-path optimizations and offline categorization.
+
 ### Added
 
 - **Fast cache serve path** — `PERF_FAST_CACHE_HIT` serves L1/L2 hits (HIT, REVALIDATED, NEGATIVE_HIT, L2_HIT) before ACL/categorization ([#100](https://github.com/onixus/bsdm-proxy/issues/100))
 - **Bounded Kafka queue** — `KafkaEventPipeline` with `KAFKA_QUEUE_CAPACITY` (default 8192), non-blocking `try_enqueue`, drop when full ([#106](https://github.com/onixus/bsdm-proxy/issues/106))
+- **Offline categorization** — `categorize_local()` on hot path (UT1/custom DB + sync cache); URLhaus/PhishTank in background `tokio` task ([#104](https://github.com/onixus/bsdm-proxy/issues/104))
 - Prometheus counter `bsdm_proxy_kafka_queue_dropped_total`
 
 ### Changed
 
-- **ACL regex precompilation** — regex patterns compiled on rule load/update; no `Mutex` on hot-path evaluation ([#109](https://github.com/onixus/bsdm-proxy/issues/109))
-- `docs/performance.md` — document `PERF_FAST_CACHE_HIT` and `KAFKA_QUEUE_CAPACITY`
+- **ACL regex precompilation** — regex patterns compiled on rule load/update; no `Mutex` on hot-path regex lookup ([#109](https://github.com/onixus/bsdm-proxy/issues/109))
+- Category cache uses `std::sync::RwLock` (no await on policy path)
+- `docs/performance.md`, `docs/categorization.md` — hot path / bench warnings
+
+Release package: `./scripts/build-package.sh` → `dist/bsdm-proxy-0.3.2-linux-<arch>.tar.gz`
 
 ## [0.3.1] - 2026-07-01
 
@@ -117,6 +125,7 @@ Beta — hierarchical caching Phase 3, optional MITM CA.
 
 [GitHub Releases](https://github.com/onixus/bsdm-proxy/releases/tag/v0.2.2b)
 
+[0.3.2]: https://github.com/onixus/bsdm-proxy/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/onixus/bsdm-proxy/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/onixus/bsdm-proxy/compare/v0.2.3-test...v0.3.0
 [0.2.3-test]: https://github.com/onixus/bsdm-proxy/releases/tag/v0.2.3-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-events"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "serde",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-proxy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "brotli",
@@ -393,7 +393,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cache-indexer"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bsdm-events",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 [![E2E Tests](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.3.1-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
 [![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org)
 
-> **Текущая версия:** `0.3.1` (M3 ClickHouse analytics) · **M2.5** P0 закрыт · **M3** retro-search — indexer, Grafana, Search API — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
+> **Текущая версия:** `0.3.2` (M2.5 perf P1) · **M2.5** P1 perf + offline categorization · **M3** retro-search — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
 
 ⚠️ **MITM-прокси для HTTPS.** Используйте только в корпоративной среде с согласия пользователей и в рамках законодательства.
 

--- a/bsdm-events/Cargo.toml
+++ b/bsdm-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-events"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 description = "Shared HTTP cache event schema for BSDM-Proxy Kafka pipeline"

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-indexer"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/charts/bsdm/Chart.yaml
+++ b/charts/bsdm/Chart.yaml
@@ -3,7 +3,7 @@ name: bsdm
 description: BSDM-Proxy forward proxy with optional Redis L2
 type: application
 version: 0.1.0
-appVersion: "0.3.1"
+appVersion: "0.3.2"
 keywords:
   - proxy
   - cache

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 2
 
 image:
   repository: ghcr.io/onixus/bsdm-proxy
-  tag: "0.3.1"
+  tag: "0.3.2"
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -26,8 +26,8 @@
 | ID | Issue | Блокер | Статус |
 |----|-------|--------|--------|
 | B7 | [#38](https://github.com/onixus/bsdm-proxy/issues/38) | Refactor ProxyService out of `main.rs` | ✅ |
-| B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path | ❌ |
-| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | ❌ |
+| B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path | ✅ |
+| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | 🔄 |
 | B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) | ✅ |
 | B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ✅ |
 | B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ✅ |

--- a/docs/categorization.md
+++ b/docs/categorization.md
@@ -6,11 +6,24 @@ BSDM proxy categorizes HTTP(S) traffic using a layered engine: local domain list
 
 ```
 Request URL → extract hostname
-    → Local category DB (UT1 Blacklists, optional)
-    → OTX threat intel (optional)
+    → In-memory category cache (sync)
+    → Local category DB (UT1 Blacklists, optional)     ← hot path (#104)
+    → URLhaus / PhishTank (optional, background task)  ← async enrich
+    → OTX threat intel (optional, future)
     → ML classifier (stub, optional)
     → Category + confidence + source
 ```
+
+### Hot path vs async enrichment (#104)
+
+На пути ответа клиенту вызывается только **`categorize_local()`**:
+
+- sync read in-memory cache (`std::sync::RwLock`)
+- lookup в UT1 / custom domain DB
+
+**URLhaus** и **PhishTank** не блокируют запрос: при отсутствии локальной категории запускается фоновый `tokio` task (`schedule_online_enrichment`), результат попадает в cache для следующих запросов.
+
+Первый запрос к неизвестному URL может пройти ACL до завершения online enrich (и до истечения policy cache TTL). Для threat-intel это ожидаемый компромисс async-модели.
 
 ## Local category database (UT1 Blacklists)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -41,6 +41,8 @@ cargo install oha   # или бинарь с https://github.com/hatoo/oha
 | `METRICS_SAMPLE_RATE` | `0` | `N` → histograms для 1 из N запросов (`0` = все) |
 | `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS body to client while buffering for L1 |
 
+> **Production ACL:** `PERF_FAST_CACHE_HIT=true` пропускает ACL и categorization на cache HIT. Используйте **только для bench/lab**, не в production с включённой политикой.
+
 ## HTTP Archive bench profiles (`BENCH_PROFILE`)
 
 Sites bench (70 sites × 20 warm repeats) is **warm-heavy**. Multi-worker accept (`WORKER_COUNT=4`) increases L1 lock contention on repeated HITs; a single worker often wins on warm goodput.

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,50 @@
+# Release v0.3.2
+
+Milestone **M2.5 perf P1** — hot-path optimizations and offline categorization.
+
+## Highlights
+
+- **Fast cache path** (`PERF_FAST_CACHE_HIT`) — serve cache hits before ACL/categorization ([#100](https://github.com/onixus/bsdm-proxy/issues/100))
+- **Bounded Kafka queue** — non-blocking event enqueue, drop + metric when full ([#106](https://github.com/onixus/bsdm-proxy/issues/106))
+- **Offline categorization** — UT1/custom DB on hot path; URLhaus/PhishTank async ([#104](https://github.com/onixus/bsdm-proxy/issues/104))
+- **ACL regex precompile** — no per-match regex `Mutex` ([#109](https://github.com/onixus/bsdm-proxy/issues/109))
+
+## Upgrade
+
+```bash
+git pull
+cargo build --release -p bsdm-proxy --bin proxy
+# or download release asset:
+# dist/bsdm-proxy-0.3.2-linux-x86_64.tar.gz
+```
+
+No breaking config changes. New optional env:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KAFKA_QUEUE_CAPACITY` | `8192` | In-memory Kafka event queue size |
+| `PERF_FAST_CACHE_HIT` | `false` | Bench: skip policy on cache HIT |
+
+## Bench profile
+
+```bash
+PERF_FAST_CACHE_HIT=true WORKER_COUNT=4 METRICS_SAMPLE_RATE=100 \
+  HTTP_PRESERVE_HEADER_CASE=false ./target/release/proxy
+```
+
+See [docs/performance.md](../performance.md). **Do not enable `PERF_FAST_CACHE_HIT` in production with ACL enabled.**
+
+## Categorization
+
+Online threat feeds (URLhaus, PhishTank) no longer block the request path. First request to an unknown URL may be allowed until async enrichment fills the category cache.
+
+See [docs/categorization.md](../categorization.md).
+
+## Release tag
+
+```bash
+git tag -a v0.3.2 -m "BSDM-Proxy v0.3.2"
+git push origin v0.3.2
+```
+
+Workflow [release.yml](../../.github/workflows/release.yml) publishes `bsdm-proxy-0.3.2-linux-*.tar.gz`.

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-proxy"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 

--- a/proxy/src/categorization.rs
+++ b/proxy/src/categorization.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 use url::Url;
 
@@ -180,7 +179,8 @@ impl Default for CategorizationConfig {
 /// Categorization engine
 pub struct CategorizationEngine {
     config: CategorizationConfig,
-    cache: Arc<RwLock<HashMap<String, CategoryCache>>>,
+    /// Sync lock: hot-path reads must not await (#104).
+    cache: Arc<std::sync::RwLock<HashMap<String, CategoryCache>>>,
     local_db: Option<HashMap<String, HashSet<Category>>>,
     custom_db: Option<HashMap<String, HashSet<Category>>>,
     http_client: Client,
@@ -192,7 +192,7 @@ impl CategorizationEngine {
 
         let mut engine = Self {
             config,
-            cache: Arc::new(RwLock::new(HashMap::new())),
+            cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
             local_db: None,
             custom_db: None,
             http_client: Client::builder()
@@ -224,8 +224,13 @@ impl CategorizationEngine {
         engine
     }
 
-    /// Categorize URL
-    pub async fn categorize(&self, url: &str) -> CategorizationResult {
+    /// Whether URLhaus / PhishTank lookups are configured.
+    pub fn online_enrichment_enabled(&self) -> bool {
+        self.config.urlhaus_enabled || self.config.phishtank_enabled
+    }
+
+    /// Hot path: in-memory cache + local UT1/custom DB only (no HTTP). #104
+    pub fn categorize_local(&self, url: &str) -> CategorizationResult {
         let parsed_url = match Url::parse(url) {
             Ok(u) => u,
             Err(e) => {
@@ -236,17 +241,14 @@ impl CategorizationEngine {
 
         let domain = parsed_url.host_str().unwrap_or("").to_string();
 
-        // Check cache first
-        if let Some(cached) = self.get_cached(&domain).await {
+        if let Some(cached) = self.get_cached(&domain) {
             debug!("Category cache hit for: {}", domain);
             return self.create_result(url, &domain, cached.categories, "cache", true);
         }
 
-        // Try local databases first (faster)
         let mut categories = HashSet::new();
         let mut source = "unknown";
 
-        // Check local category DB (UT1)
         if self.config.ut1_enabled {
             if let Some(cats) = self.check_local_db(&domain) {
                 categories.extend(cats);
@@ -254,7 +256,6 @@ impl CategorizationEngine {
             }
         }
 
-        // Check custom database
         if self.config.custom_db_enabled {
             if let Some(cats) = self.check_custom_db(&domain) {
                 categories.extend(cats);
@@ -266,35 +267,74 @@ impl CategorizationEngine {
             }
         }
 
-        // Check online services if no local match
-        if categories.is_empty() {
-            // Check URLhaus for malware
-            if self.config.urlhaus_enabled {
-                if let Some(cats) = self.check_urlhaus(url).await {
-                    categories.extend(cats);
-                    source = "urlhaus";
-                }
-            }
-
-            // Check PhishTank for phishing
-            if self.config.phishtank_enabled {
-                if let Some(cats) = self.check_phishtank(url).await {
-                    categories.extend(cats);
-                    source = if source == "unknown" {
-                        "phishtank"
-                    } else {
-                        "multiple"
-                    };
-                }
-            }
-        }
-
-        // Cache result
         if !categories.is_empty() {
-            self.cache_categories(&domain, categories.clone()).await;
+            self.cache_categories(&domain, categories.clone());
         }
 
         self.create_result(url, &domain, categories, source, false)
+    }
+
+    /// Spawn background URLhaus/PhishTank lookup when local DB had no match (#104).
+    pub fn schedule_online_enrichment(self: &Arc<Self>, url: &str) {
+        if !self.online_enrichment_enabled() {
+            return;
+        }
+        let url = url.to_string();
+        let engine = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(e) = engine.enrich_online(&url).await {
+                debug!("Online categorization enrichment failed for {}: {}", url, e);
+            }
+        });
+    }
+
+    /// Categorize URL (compat wrapper — local only; online enrichment is async).
+    pub async fn categorize(&self, url: &str) -> CategorizationResult {
+        self.categorize_local(url)
+    }
+
+    async fn enrich_online(&self, url: &str) -> Result<(), String> {
+        let parsed_url = Url::parse(url).map_err(|e| e.to_string())?;
+        let domain = parsed_url.host_str().unwrap_or("").to_string();
+
+        if self
+            .get_cached(&domain)
+            .is_some_and(|c| !c.categories.is_empty())
+        {
+            return Ok(());
+        }
+
+        let mut categories = HashSet::new();
+        let mut source = "unknown";
+
+        if self.config.urlhaus_enabled {
+            if let Some(cats) = self.check_urlhaus(url).await {
+                categories.extend(cats);
+                source = "urlhaus";
+            }
+        }
+
+        if self.config.phishtank_enabled {
+            if let Some(cats) = self.check_phishtank(url).await {
+                categories.extend(cats);
+                source = if source == "unknown" {
+                    "phishtank"
+                } else {
+                    "multiple"
+                };
+            }
+        }
+
+        if categories.is_empty() {
+            return Ok(());
+        }
+
+        self.cache_categories(&domain, categories);
+        debug!(
+            "Online categorization enriched {} (source={})",
+            domain, source
+        );
+        Ok(())
     }
 
     fn check_local_db(&self, domain: &str) -> Option<HashSet<Category>> {
@@ -432,23 +472,24 @@ impl CategorizationEngine {
         Ok(count)
     }
 
-    /// Get cached categories
-    async fn get_cached(&self, domain: &str) -> Option<CategoryCache> {
-        let cache = self.cache.read().await;
+    /// Get cached categories (sync hot path).
+    fn get_cached(&self, domain: &str) -> Option<CategoryCache> {
+        let cache = self.cache.read().ok()?;
         cache.get(domain).filter(|c| !c.is_expired()).cloned()
     }
 
-    /// Cache categories
-    async fn cache_categories(&self, domain: &str, categories: HashSet<Category>) {
-        let mut cache = self.cache.write().await;
-        cache.insert(
-            domain.to_string(),
-            CategoryCache {
-                categories,
-                cached_at: Instant::now(),
-                ttl: self.config.cache_ttl,
-            },
-        );
+    /// Cache categories (sync).
+    fn cache_categories(&self, domain: &str, categories: HashSet<Category>) {
+        if let Ok(mut cache) = self.cache.write() {
+            cache.insert(
+                domain.to_string(),
+                CategoryCache {
+                    categories,
+                    cached_at: Instant::now(),
+                    ttl: self.config.cache_ttl,
+                },
+            );
+        }
     }
 
     /// Create result
@@ -472,10 +513,11 @@ impl CategorizationEngine {
         }
     }
 
-    /// Clean expired cache
-    pub async fn cleanup_cache(&self) {
-        let mut cache = self.cache.write().await;
-        cache.retain(|_, entry| !entry.is_expired());
+    /// Clean expired cache entries.
+    pub fn cleanup_cache(&self) {
+        if let Ok(mut cache) = self.cache.write() {
+            cache.retain(|_, entry| !entry.is_expired());
+        }
     }
 }
 
@@ -520,29 +562,48 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_categorization_disabled() {
+    #[test]
+    fn test_categorization_disabled() {
         let config = CategorizationConfig {
             enabled: false,
             ..Default::default()
         };
 
         let engine = CategorizationEngine::new(config);
-        let result = engine.categorize("https://example.com").await;
+        let result = engine.categorize_local("https://example.com");
 
         assert!(result.categories.is_empty());
     }
 
-    #[tokio::test]
-    async fn test_cache() {
+    #[test]
+    fn test_categorize_local_ut1() {
+        let dir = tempfile::tempdir().unwrap();
+        let cat_dir = dir.path().join("blacklists").join("malware");
+        std::fs::create_dir_all(&cat_dir).unwrap();
+        std::fs::write(cat_dir.join("domains"), "evil.example\n").unwrap();
+
+        let config = CategorizationConfig {
+            ut1_enabled: true,
+            ut1_path: Some(dir.path().to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+
+        let engine = CategorizationEngine::new(config);
+        let result = engine.categorize_local("https://www.evil.example/path");
+        assert!(result.categories.contains(&Category::Malware));
+        assert_eq!(result.source, "ut1");
+    }
+
+    #[test]
+    fn test_cache() {
         let config = CategorizationConfig::default();
         let engine = CategorizationEngine::new(config);
 
         let mut cats = HashSet::new();
         cats.insert(Category::News);
-        engine.cache_categories("example.com", cats.clone()).await;
+        engine.cache_categories("example.com", cats.clone());
 
-        let cached = engine.get_cached("example.com").await;
+        let cached = engine.get_cached("example.com");
         assert!(cached.is_some());
         assert_eq!(cached.unwrap().categories, cats);
     }

--- a/proxy/src/pipeline.rs
+++ b/proxy/src/pipeline.rs
@@ -89,7 +89,7 @@ impl KafkaEventPipeline {
         Some(Arc::new(Self { sender, producer }))
     }
 
-    /// Enqueue without blocking the request hot path. Drops when full (`KAFKA_QUEUE_DROP_POLICY=drop_new`).
+    /// Enqueue without blocking the request hot path. Drops when queue is full (drop-new).
     pub fn try_enqueue(&self, event: CacheEvent, metrics: &Metrics) {
         match self.sender.try_send(event) {
             Ok(()) => {}

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -421,11 +421,14 @@ impl ProxyService {
         }
     }
 
-    async fn categorize_url(&self, url: &str) -> (Vec<String>, Vec<String>) {
+    fn categorize_url(&self, url: &str) -> (Vec<String>, Vec<String>) {
         let Some(engine) = &self.categorization else {
             return (Vec::new(), Vec::new());
         };
-        let result = engine.categorize(url).await;
+        let result = engine.categorize_local(url);
+        if result.categories.is_empty() && engine.online_enrichment_enabled() {
+            engine.schedule_online_enrichment(url);
+        }
         let categories: Vec<String> = result
             .categories
             .iter()
@@ -507,7 +510,7 @@ impl ProxyService {
             }
         }
 
-        let (category_names, threat_sources) = self.categorize_url(url).await;
+        let (category_names, threat_sources) = self.categorize_url(url);
         let blocking = self
             .check_acl(url, domain, &category_names, username, groups, client_ip)
             .await;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes M2.5 perf P1 item **#104** and prepares **v0.3.2** release (includes perf work from #146 already on `main`).

### #104 — Offline categorization
- **`categorize_local()`** — sync hot path: in-memory cache + UT1/custom DB only (no HTTP await)
- **`schedule_online_enrichment()`** — URLhaus/PhishTank in background `tokio` task when local DB has no match
- Category cache migrated to `std::sync::RwLock`

### Release v0.3.2
- Version bump: `proxy`, `cache-indexer`, `bsdm-events`, Helm chart
- `CHANGELOG.md` [0.3.2], `docs/releases/v0.3.2.md`
- `docs/BLOCKERS.md`: B8 ✅, B9 🔄
- `docs/performance.md`: production ACL warning for `PERF_FAST_CACHE_HIT`

## Связанные issue

- Closes #104
- Closes #39 (B8)

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

## Post-merge

Tag `v0.3.2` to trigger release workflow.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

