### PR TITLE
feat(proxy): x-cache-status MISS-STREAMING on upstream response (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Milestone **M2.5 perf P1**: hot-path optimizations and offline categorization.
 - **Fast cache serve path** — `PERF_FAST_CACHE_HIT` serves L1/L2 hits (HIT, REVALIDATED, NEGATIVE_HIT, L2_HIT) before ACL/categorization ([#100](https://github.com/onixus/bsdm-proxy/issues/100))
 - **Bounded Kafka queue** — `KafkaEventPipeline` with `KAFKA_QUEUE_CAPACITY` (default 8192), non-blocking `try_enqueue`, drop when full ([#106](https://github.com/onixus/bsdm-proxy/issues/106))
 - **Offline categorization** — `categorize_local()` on hot path (UT1/custom DB + sync cache); URLhaus/PhishTank in background `tokio` task ([#104](https://github.com/onixus/bsdm-proxy/issues/104))
+- **`x-cache-status` on MISS** — `MISS-STREAMING` / `MISS` on response headers before cache insert completes ([#111](https://github.com/onixus/bsdm-proxy/issues/111))
 - Prometheus counter `bsdm_proxy_kafka_queue_dropped_total`
 
 ### Changed

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -38,6 +38,8 @@ See [docs/performance.md](../performance.md). **Do not enable `PERF_FAST_CACHE_H
 
 Online threat feeds (URLhaus, PhishTank) no longer block the request path. First request to an unknown URL may be allowed until async enrichment fills the category cache.
 
+Cache MISS responses include `x-cache-status: MISS-STREAMING` (default streaming path) or `MISS` before the object is stored in L1.
+
 See [docs/categorization.md](../categorization.md).
 
 ## Release tag

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -26,7 +26,11 @@ async fn e2e_cache_hit_on_repeat_request() {
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
 
-    assert_ne!(first.as_deref(), Some("HIT"));
+    assert!(
+        matches!(first.as_deref(), Some("MISS") | Some("MISS-STREAMING")),
+        "expected MISS on first request, got {:?}",
+        first
+    );
 
     let second = client.get(&url).send().await.expect("second GET");
 

--- a/proxy/src/cache_freshness.rs
+++ b/proxy/src/cache_freshness.rs
@@ -40,6 +40,30 @@ impl CacheStoreDecision {
     }
 }
 
+/// `x-cache-status` for upstream MISS before cache insert completes (#111).
+pub fn miss_x_cache_status_header(streaming: bool, precheck: &CacheStoreDecision) -> &'static str {
+    if !precheck.store {
+        return "BYPASS";
+    }
+    if precheck.is_negative {
+        return if streaming {
+            "NEGATIVE-MISS-STREAMING"
+        } else {
+            "NEGATIVE-MISS"
+        };
+    }
+    if streaming {
+        "MISS-STREAMING"
+    } else {
+        "MISS"
+    }
+}
+
+/// Prometheus / internal label (underscores).
+pub fn cache_status_metric_label(header_label: &str) -> String {
+    header_label.replace('-', "_")
+}
+
 pub fn parse_cache_control(value: &str) -> CacheControlDirectives {
     let mut directives = CacheControlDirectives::default();
     for part in value.split(',') {
@@ -284,5 +308,22 @@ mod tests {
         let h = headers(&[("Cache-Control", "private, max-age=3600")]);
         let decision = evaluate_store("GET", 200, &h, 100, &default_config());
         assert!(!decision.store);
+    }
+
+    #[test]
+    fn miss_x_cache_status_header_streaming() {
+        let store = CacheStoreDecision {
+            store: true,
+            ttl: Duration::from_secs(60),
+            is_negative: false,
+            must_revalidate: false,
+            etag: None,
+            last_modified: None,
+        };
+        assert_eq!(miss_x_cache_status_header(true, &store), "MISS-STREAMING");
+        assert_eq!(
+            cache_status_metric_label("MISS-STREAMING"),
+            "MISS_STREAMING"
+        );
     }
 }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -22,7 +22,10 @@ use crate::acl::{AclAction, AclDecision, AclEngine};
 use crate::auth::{AuthManager, ProxyAuthOutcome, UserInfo};
 use crate::cache::{CacheConfig, CachedResponse, CACHEABLE_METHODS};
 use crate::cache_digest::DigestRegistry;
-use crate::cache_freshness::{evaluate_store, evaluate_store_precheck, refresh_ttl_from_headers};
+use crate::cache_freshness::{
+    cache_status_metric_label, evaluate_store, evaluate_store_precheck, miss_x_cache_status_header,
+    refresh_ttl_from_headers,
+};
 use crate::cache_key::http_cache_key;
 use crate::categorization::CategorizationEngine;
 use crate::hierarchy::{HierarchyManager, HierarchyResult};
@@ -896,6 +899,12 @@ impl ProxyService {
         }
     }
 
+    fn attach_x_cache_status(resp: &mut Response<Body>, label: &str) {
+        if let Ok(val) = HeaderValue::from_str(label) {
+            resp.headers_mut().insert("x-cache-status", val);
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn complete_cache_miss(
         &self,
@@ -1323,11 +1332,10 @@ impl ProxyService {
 
                 if self.perf.streaming_miss_enabled {
                     let upstream_body = response.into_body();
-                    let x_cache = if store_precheck.store {
-                        "MISS"
-                    } else {
-                        "BYPASS"
-                    };
+                    let x_cache = miss_x_cache_status_header(true, &store_precheck);
+                    if let Some(g) = guard.as_mut() {
+                        g.set_cache_status(&cache_status_metric_label(x_cache));
+                    }
 
                     let handle = self.miss_completion_handle();
                     let cache_key_cb = cache_key.clone();
@@ -1389,9 +1397,7 @@ impl ProxyService {
                     let mut resp = Response::new(tee.boxed());
                     *resp.status_mut() = status;
                     Self::apply_response_headers(&headers_map, &mut resp);
-                    if let Ok(val) = HeaderValue::from_str(x_cache) {
-                        resp.headers_mut().insert("x-cache-status", val);
-                    }
+                    Self::attach_x_cache_status(&mut resp, x_cache);
                     return resp;
                 }
 
@@ -1424,7 +1430,7 @@ impl ProxyService {
                     body_bytes.len(),
                     &self.cache_config,
                 );
-                let cache_status = self.complete_cache_miss(
+                let _cache_status = self.complete_cache_miss(
                     cache_key,
                     &url,
                     method,
@@ -1449,9 +1455,8 @@ impl ProxyService {
                 let mut resp = Response::new(full(body_bytes));
                 *resp.status_mut() = status;
                 Self::apply_response_headers(&headers_map, &mut resp);
-                if let Ok(val) = HeaderValue::from_str(cache_status) {
-                    resp.headers_mut().insert("x-cache-status", val);
-                }
+                let header_label = miss_x_cache_status_header(false, &store_decision);
+                Self::attach_x_cache_status(&mut resp, header_label);
                 resp
             }
             Err(e) => {

--- a/scripts/httparchive-page-load.py
+++ b/scripts/httparchive-page-load.py
@@ -21,6 +21,8 @@ def cache_label(headers) -> str:
     """Normalize cache status from BSDM (x-cache-status) or Squid (Cache-Status / X-Cache)."""
     xcs = headers.get("x-cache-status")
     if xcs:
+        if xcs.endswith("-STREAMING"):
+            return xcs.removesuffix("-STREAMING")
         return xcs
     cache_status = headers.get("Cache-Status") or headers.get("cache-status")
     if cache_status:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes M2.5 P1 item **#111**: emit `x-cache-status` on upstream MISS **before** L1 insert completes.

- **`MISS-STREAMING`** — default path (`STREAMING_MISS_ENABLED=true`): header set with upstream response headers, body streams via `TeeMissBody`
- **`MISS`** / **`NEGATIVE-MISS`** — buffered path (`STREAMING_MISS_ENABLED=false`)
- Metrics guard gets early `MISS_STREAMING` label (underscore form)
- e2e: first request must be `MISS` or `MISS-STREAMING`
- HTTP Archive harness strips `-STREAMING` suffix for aggregation

Completes **v0.3.2** release scope (with #146/#147 already on `main`).

## Связанные issue

- Closes #111

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

## Post-merge

```bash
git tag -a v0.3.2 -m "BSDM-Proxy v0.3.2"
git push origin v0.3.2
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

