### PR TITLE
perf(acl): AclEngineHandle arc-swap, lock-free hot path (B9 / #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ACL lock-free snapshot** — `AclEngineHandle` with `arc-swap`; hot path `check_access` without `tokio::RwLock` ([#40](https://github.com/onixus/bsdm-proxy/issues/40) / B9)
+
 ## [0.3.2] - 2026-07-02
 
 Milestone **M2.5 perf P1**: hot-path optimizations and offline categorization.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
 name = "bsdm-proxy"
 version = "0.3.2"
 dependencies = [
+ "arc-swap",
  "base64",
  "brotli",
  "bsdm-events",

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -27,7 +27,7 @@
 |----|-------|--------|--------|
 | B7 | [#38](https://github.com/onixus/bsdm-proxy/issues/38) | Refactor ProxyService out of `main.rs` | ✅ |
 | B8 | [#39](https://github.com/onixus/bsdm-proxy/issues/39) | Move online categorization off hot path | ✅ |
-| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | 🔄 |
+| B9 | [#40](https://github.com/onixus/bsdm-proxy/issues/40) | Replace ACL global Mutex | ✅ |
 | B10 | [#41](https://github.com/onixus/bsdm-proxy/issues/41) | Kafka reliable delivery (topic env, acks) | ✅ |
 | B11 | [#42](https://github.com/onixus/bsdm-proxy/issues/42) | Indexer: add `categories` to CacheEvent | ✅ |
 | B12 | [#43](https://github.com/onixus/bsdm-proxy/issues/43) | Shared `bsdm-events` crate | ✅ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ TCP accept
   → authenticate_proxy()          # Proxy-Authorization
   → check_policy()
        → categorization.categorize()   # UT1 Blacklists / OTX / custom
-       → acl_engine.check_access()     # Mutex lock
+       → acl_engine.check_access()     # ArcSwap snapshot (lock-free read)
   → L1 cache lookup (GET/HEAD)
   → [if HIERARCHY_ENABLED] resolve_source()
        → ICP query siblings (parallel UDP)
@@ -110,7 +110,7 @@ TCP accept
 
 - Вся логика в **binary crate** (`main.rs` ~1300 строк) — `ProxyService` не в `lib.rs` (B7)
 - Categorization с online API на **критическом пути** каждого запроса
-- ACL под глобальным `Mutex` — serializes concurrent ACL checks
+- ACL uses `AclEngineHandle` (`arc-swap`) — no `RwLock` on hot-path checks
 - Hierarchy metrics (`bsdm_proxy_hierarchy_*`) экспортируются в Prometheus при `HIERARCHY_ENABLED=true`
 - Нет `docker-compose.hierarchy.yml` для multi-instance E2E
 
@@ -206,7 +206,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 |----|--------|-------|-----------|
 | **B7** | Монолит `main.rs` | `main.rs` | M1–M2 |
 | **B8** | Categorization на hot path (external HTTP) | `categorization.rs`, `main.rs` | M2 |
-| **B9** | ACL под `Mutex` | `policy_config.rs`, `main.rs` | M2 |
+| **B9** | ACL lock-free snapshot | `acl.rs` (`AclEngineHandle`) | M2 |
 | **B10** | Kafka `acks=0`, topic hardcoded | `main.rs:361-365` | M3 |
 | **B11** | Schema drift: `categories` в indexer | ✅ Done | `cache-indexer/src/main.rs` | M3 |
 | **B12** | Нет shared event crate | `proxy`, `cache-indexer` | M3 |

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -46,6 +46,7 @@ hex = "0.4"
 
 # ACL and Categorization
 regex = "1.12"
+arc-swap = "1.7"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 reqwest = { version = "0.13", features = ["json", "form"] }
 sspi = { version = "0.21.1", optional = true, features = ["network_client"] }

--- a/proxy/src/acl.rs
+++ b/proxy/src/acl.rs
@@ -8,11 +8,13 @@
 //! - Time-based access control
 //! - User/group-based rules
 
+use arc_swap::ArcSwap;
 use chrono::Timelike;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 /// Minutes since midnight for time-window matching (0–1439).
@@ -168,6 +170,72 @@ impl AclDecision {
     }
 }
 
+/// Lock-free snapshot handle for hot-path ACL checks (#40 / B9).
+pub struct AclEngineHandle {
+    snapshot: Arc<ArcSwap<AclEngine>>,
+}
+
+impl AclEngineHandle {
+    pub fn new(engine: AclEngine) -> Self {
+        Self {
+            snapshot: Arc::new(ArcSwap::from_pointee(engine)),
+        }
+    }
+
+    pub fn shared(snapshot: Arc<ArcSwap<AclEngine>>) -> Self {
+        Self { snapshot }
+    }
+
+    pub fn load(&self) -> arc_swap::Guard<Arc<AclEngine>> {
+        self.snapshot.load()
+    }
+
+    /// Hot path: atomic snapshot read, no `RwLock` (#40).
+    pub fn check_access(
+        &self,
+        url: &str,
+        domain: &str,
+        categories: &[&str],
+        user: Option<&str>,
+        groups: &[&str],
+        client_ip: Option<IpAddr>,
+    ) -> AclDecision {
+        self.snapshot
+            .load()
+            .check_access(url, domain, categories, user, groups, client_ip)
+    }
+
+    pub fn replace(&self, engine: AclEngine) {
+        self.snapshot.store(Arc::new(engine));
+    }
+
+    fn fork_from(engine: &AclEngine) -> AclEngine {
+        let mut next = AclEngine::new(engine.default_action());
+        next.load_rules(engine.rules().to_vec());
+        next
+    }
+
+    /// Copy-on-write update for ACL API / reload paths.
+    pub fn mutate<F>(&self, f: F)
+    where
+        F: FnOnce(&mut AclEngine),
+    {
+        let current = self.snapshot.load_full();
+        let next = match Arc::try_unwrap(current) {
+            Ok(mut engine) => {
+                f(&mut engine);
+                engine
+            }
+            Err(arc) => {
+                let mut engine = Self::fork_from(&arc);
+                f(&mut engine);
+                engine
+            }
+        };
+        self.snapshot.store(Arc::new(next));
+    }
+}
+
 /// ACL engine
 pub struct AclEngine {
     rules: Vec<AclRule>,
@@ -244,7 +312,7 @@ impl AclEngine {
         self.rules.iter().any(|r| r.id == id)
     }
 
-    /// Check if request is allowed (read-mostly; safe under `RwLock` read guard).
+    /// Check if request is allowed (immutable snapshot; no lock on hot path).
     pub fn check_access(
         &self,
         url: &str,
@@ -658,6 +726,37 @@ mod tests {
                     None,
                     &[],
                     None
+                )
+                .action,
+            AclAction::Deny
+        );
+    }
+
+    #[test]
+    fn handle_arcswap_hot_path_without_rwlock() {
+        let handle = AclEngineHandle::new(AclEngine::new(AclAction::Allow));
+        handle.mutate(|engine| {
+            engine.add_rule(AclRule {
+                id: "block-bad".to_string(),
+                name: "block".to_string(),
+                enabled: true,
+                priority: 100,
+                action: AclAction::Deny,
+                rule_type: AclRuleType::Domain("blocked.test".to_string()),
+                redirect_url: None,
+                comment: None,
+            });
+        });
+
+        assert_eq!(
+            handle
+                .check_access(
+                    "http://blocked.test/path",
+                    "blocked.test",
+                    &[],
+                    None,
+                    &[],
+                    None,
                 )
                 .action,
             AclAction::Deny

--- a/proxy/src/acl_api.rs
+++ b/proxy/src/acl_api.rs
@@ -7,10 +7,9 @@ use hyper::header::AUTHORIZATION;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use serde::Serialize;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-use crate::acl::{AclAction, AclEngine, AclRule};
+use crate::acl::{AclAction, AclEngineHandle, AclRule};
 use crate::acl_config::{load_acl_engine_from_file, parse_acl_action};
 use crate::http_types::{full, Body};
 use crate::policy_cache::PolicyDecisionCache;
@@ -40,14 +39,14 @@ impl AclApiConfig {
 
 #[derive(Clone)]
 pub struct AclApiState {
-    engine: Arc<RwLock<AclEngine>>,
+    engine: Arc<AclEngineHandle>,
     config: AclApiConfig,
     policy_cache: Option<Arc<PolicyDecisionCache>>,
 }
 
 impl AclApiState {
     pub fn new(
-        engine: Arc<RwLock<AclEngine>>,
+        engine: Arc<AclEngineHandle>,
         config: AclApiConfig,
         policy_cache: Option<Arc<PolicyDecisionCache>>,
     ) -> Self {
@@ -102,7 +101,7 @@ impl AclApiState {
     }
 
     async fn list_rules(&self) -> Response<Body> {
-        let engine = self.engine.read().await;
+        let engine = self.engine.load();
         let payload = ListRulesResponse {
             count: engine.rule_count(),
             default_action: engine.default_action(),
@@ -142,8 +141,7 @@ impl AclApiState {
             );
         }
 
-        let mut engine = self.engine.write().await;
-        if engine.has_rule(&rule.id) {
+        if self.engine.load().has_rule(&rule.id) {
             return json_response(
                 StatusCode::CONFLICT,
                 &format!(
@@ -154,7 +152,7 @@ impl AclApiState {
         }
 
         info!("ACL API: adding rule {} ({})", rule.id, rule.name);
-        engine.add_rule(rule.clone());
+        self.engine.mutate(|engine| engine.add_rule(rule.clone()));
         match serde_json::to_string(&rule) {
             Ok(body) => json_response(StatusCode::CREATED, &body),
             Err(_) => json_response(StatusCode::CREATED, r#"{"status":"created"}"#),
@@ -172,8 +170,7 @@ impl AclApiState {
         match load_acl_engine_from_file(path, self.config.default_action) {
             Ok(loaded) => {
                 let count = loaded.rule_count();
-                let mut engine = self.engine.write().await;
-                *engine = loaded;
+                self.engine.replace(loaded);
                 if let Some(cache) = &self.policy_cache {
                     cache.invalidate();
                 }
@@ -220,13 +217,13 @@ fn escape_json(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acl::AclEngine;
+    use crate::acl::{AclEngine, AclEngineHandle};
     use http_body_util::BodyExt;
     use hyper::body::Bytes;
     use hyper::{Method, StatusCode};
 
     fn test_state() -> AclApiState {
-        let engine = Arc::new(RwLock::new(AclEngine::new(AclAction::Allow)));
+        let engine = Arc::new(AclEngineHandle::new(AclEngine::new(AclAction::Allow)));
         AclApiState::new(
             engine,
             AclApiConfig {
@@ -239,7 +236,7 @@ mod tests {
     }
 
     fn test_state_with_token() -> AclApiState {
-        let engine = Arc::new(RwLock::new(AclEngine::new(AclAction::Allow)));
+        let engine = Arc::new(AclEngineHandle::new(AclEngine::new(AclAction::Allow)));
         AclApiState::new(
             engine,
             AclApiConfig {

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -36,7 +36,7 @@ pub mod tls;
 pub mod upstream;
 
 // Re-export commonly used types
-pub use acl::{AclAction, AclDecision, AclEngine, AclRule};
+pub use acl::{AclAction, AclDecision, AclEngine, AclEngineHandle, AclRule};
 pub use acl_api::{AclApiConfig, AclApiState};
 pub use acl_config::{load_acl_engine_from_file, parse_acl_action};
 #[cfg(feature = "auth-kerberos")]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -310,8 +310,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         _ = interval.tick() => {
                             match reload_acl_engine(&rules_path, default_action) {
                                 Ok(engine) => {
-                                    let mut guard = acl_engine.write().await;
-                                    *guard = engine;
+                                    acl_engine.replace(engine);
                                     policy_cache.invalidate();
                                     info!("ACL rules reloaded from {}", rules_path);
                                 }

--- a/proxy/src/policy_config.rs
+++ b/proxy/src/policy_config.rs
@@ -1,17 +1,16 @@
 //! Load ACL and categorization configuration from environment variables.
 
-use bsdm_proxy::acl::{AclAction, AclEngine};
+use bsdm_proxy::acl::{AclAction, AclEngine, AclEngineHandle};
 use bsdm_proxy::acl_config::{load_acl_engine_from_file, parse_acl_action};
 use bsdm_proxy::categorization::{CategorizationConfig, CategorizationEngine};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
 use tracing::{info, warn};
 
 #[derive(Clone)]
 pub struct PolicyConfig {
     pub acl_enabled: bool,
-    pub acl_engine: Option<Arc<RwLock<AclEngine>>>,
+    pub acl_engine: Option<Arc<AclEngineHandle>>,
     pub acl_rules_path: Option<String>,
     pub acl_auto_reload: bool,
     pub acl_reload_interval: Duration,
@@ -94,7 +93,7 @@ pub fn load_policy_config() -> PolicyConfig {
             info!("ACL enabled without ACL_RULES_PATH, using default action only");
             AclEngine::new(default_action)
         };
-        Some(Arc::new(RwLock::new(engine)))
+        Some(Arc::new(AclEngineHandle::new(engine)))
     } else {
         None
     };

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -15,10 +15,9 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
-use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
-use crate::acl::{AclAction, AclDecision, AclEngine};
+use crate::acl::{AclAction, AclDecision, AclEngineHandle};
 use crate::auth::{AuthManager, ProxyAuthOutcome, UserInfo};
 use crate::cache::{CacheConfig, CachedResponse, CACHEABLE_METHODS};
 use crate::cache_digest::DigestRegistry;
@@ -44,7 +43,7 @@ use crate::tls::CertCache;
 use crate::upstream::{build_upstream_https_connector, UpstreamTlsConfig};
 
 pub struct ProxyPolicy {
-    pub acl_engine: Option<Arc<RwLock<AclEngine>>>,
+    pub acl_engine: Option<Arc<AclEngineHandle>>,
     pub categorization: Option<Arc<CategorizationEngine>>,
 }
 
@@ -213,7 +212,7 @@ pub struct ProxyService {
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) mitm_enabled: bool,
     auth: Option<Arc<AuthManager>>,
-    acl_engine: Option<Arc<RwLock<AclEngine>>>,
+    acl_engine: Option<Arc<AclEngineHandle>>,
     categorization: Option<Arc<CategorizationEngine>>,
     hierarchy: Option<Arc<HierarchyManager>>,
     digest_registry: Option<Arc<DigestRegistry>>,
@@ -461,17 +460,14 @@ impl ProxyService {
 
         let eval_start = Instant::now();
         let category_refs: Vec<&str> = category_names.iter().map(String::as_str).collect();
-        let decision = {
-            let engine = acl_engine.read().await;
-            engine.check_access(
-                url,
-                domain,
-                &category_refs,
-                username,
-                groups,
-                Self::parse_client_ip(client_ip),
-            )
-        };
+        let decision = acl_engine.check_access(
+            url,
+            domain,
+            &category_refs,
+            username,
+            groups,
+            Self::parse_client_ip(client_ip),
+        );
 
         self.metrics
             .acl_eval_duration_seconds


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fully closes **B9 / #40**: remove `tokio::sync::RwLock` from ACL hot path.

- New **`AclEngineHandle`** — `arc-swap` atomic snapshot (`Arc<ArcSwap<AclEngine>>`)
- **`check_access()`** on hot path: single atomic load, no await, no RwLock
- **Reload / ACL API**: `replace()` (file reload) or `mutate()` (copy-on-write for `add_rule`)
- Regex precompile (#109) unchanged inside immutable `AclEngine` snapshots

## Связанные issue

- Closes #40
- Closes B9

## Testing

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --all-targets
```

New unit test: `handle_arcswap_hot_path_without_rwlock`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05e91835-855a-4f94-903b-27faf6434786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

