### PR TITLE
[M3] k8s ClickHouse Operator analytics plane (#135)

### DIFF
--- a/charts/bsdm/Chart.yaml
+++ b/charts/bsdm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bsdm
 description: BSDM-Proxy forward proxy with optional Redis L2
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.3.2"
 keywords:
   - proxy

--- a/charts/bsdm/README.md
+++ b/charts/bsdm/README.md
@@ -1,10 +1,14 @@
 # Helm chart skeleton for BSDM-Proxy on Kubernetes.
 #
-# Install:
+# Install (data plane):
 #   helm install bsdm ./charts/bsdm -n bsdm-proxy --create-namespace
 #
 # Production profile:
 #   helm install bsdm ./charts/bsdm -f values-prod.yaml -n bsdm-proxy --create-namespace
+#
+# Analytics plane (cache-indexer → ClickHouse):
+#   helm upgrade --install bsdm-indexer ./charts/bsdm \
+#     -f values-analytics.yaml -n bsdm-analytics --create-namespace
 #
 # Full architecture: docs/k8s-architecture.md
 
@@ -14,6 +18,8 @@
 - Helm 3
 - (prod) Redis L2 — deploy separately or enable future redis subchart
 - (prod) Kafka in `bsdm-analytics` namespace
+- (prod) ClickHouse — Altinity Operator CHI (`examples/clickhouse-installation.yaml`)
+  or managed / ClickHouse Cloud. **OpenSearch is not required.**
 - MITM CA Secret (if `mitm.enabled`):
 
 ```bash
@@ -33,24 +39,36 @@ Set `mitm.existingSecret: bsdm-mitm-ca` in values.
 | `proxy.cacheCapacity` | 10000 | 25000 per pod |
 | `proxy.redisL2Enabled` | false | true |
 | `spill.sizeLimit` | 20Gi | 30Gi |
+| `indexer.enabled` | false | see `values-analytics.yaml` |
 
 ## Templates
 
 | File | Resource |
 |------|----------|
-| `deployment.yaml` | proxy Deployment |
+| `deployment.yaml` | proxy Deployment (`replicaCount > 0`) |
 | `service.yaml` | ClusterIP :1488, :9090 |
-| `configmap-env.yaml` | non-secret env |
+| `configmap-env.yaml` | proxy non-secret env |
+| `indexer-*.yaml` | cache-indexer when `indexer.enabled` |
 | `hpa.yaml` | optional HPA |
 | `pdb.yaml` | PodDisruptionBudget |
 | `networkpolicy.yaml` | optional NetworkPolicy |
 | `servicemonitor.yaml` | Prometheus Operator |
 
+## Examples
+
+| Path | Description |
+|------|-------------|
+| `examples/clickhouse-installation.yaml` | Altinity `ClickHouseInstallation` CR |
+| `values-analytics.yaml` | Indexer-only release (`replicaCount: 0`) |
+
+Build indexer image: `docker build --target cache-indexer -t ghcr.io/onixus/bsdm-cache-indexer:0.3.2 .`
+
 ## Not included (deploy separately)
 
 - Redis / Sentinel
-- Kafka, ClickHouse, cache-indexer
+- Kafka (Strimzi / Bitnami)
+- ClickHouse Operator itself (install Altinity chart once per cluster)
 - Ingress / Gateway API
 - cert-manager Issuer
 
-See `docker-compose.ha.yml` for local HA demo without k8s.
+See `docker-compose.yml` for local full stack without k8s.

--- a/charts/bsdm/examples/clickhouse-installation.yaml
+++ b/charts/bsdm/examples/clickhouse-installation.yaml
@@ -1,0 +1,71 @@
+# Example ClickHouseInstallation for Altinity ClickHouse Operator.
+# Deploy into namespace bsdm-analytics AFTER installing the operator:
+#
+#   helm repo add altinity https://docs.altinity.com/clickhouse-operator/
+#   helm install clickhouse-operator altinity/altinity-clickhouse-operator \
+#     -n clickhouse-operator --create-namespace
+#
+#   kubectl apply -f charts/bsdm/examples/clickhouse-installation.yaml
+#
+# Schema init (once cluster is Ready):
+#   kubectl -n bsdm-analytics exec -it chi-bsdm-bsdm-0-0-0 -- \
+#     clickhouse-client --multiquery < scripts/clickhouse/http_cache.sql
+#
+# HTTP endpoint for cache-indexer:
+#   http://clickhouse-bsdm.bsdm-analytics.svc.cluster.local:8123
+#
+# Native TCP (Grafana plugin):
+#   clickhouse-bsdm.bsdm-analytics.svc.cluster.local:9000
+#
+# See docs/k8s-architecture.md § Analytics plane.
+
+apiVersion: "clickhouse.altinity.com/v1"
+kind: ClickHouseInstallation
+metadata:
+  name: bsdm
+  namespace: bsdm-analytics
+  labels:
+    app.kubernetes.io/part-of: bsdm
+    app.kubernetes.io/component: clickhouse
+spec:
+  configuration:
+    clusters:
+      - name: bsdm
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+        templates:
+          podTemplate: bsdm-pod
+          volumeClaimTemplate: bsdm-data
+    databases:
+      - name: bsdm
+    settings:
+      # JSONEachRow inserts from cache-indexer
+      max_memory_usage: "10000000000"
+      max_concurrent_queries: 100
+  templates:
+    podTemplates:
+      - name: bsdm-pod
+        spec:
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:24.12
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: 8Gi
+                limits:
+                  cpu: "8"
+                  memory: 32Gi
+    volumeClaimTemplates:
+      - name: bsdm-data
+        reclaimPolicy: Retain
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              # Former OpenSearch StatefulSet guidance was ~64Gi; CH MergeTree
+              # for http_cache (TTL 42d) typically needs less for the same
+              # event volume — start at 100Gi and grow with retention.
+              storage: 100Gi

--- a/charts/bsdm/templates/_helpers.tpl
+++ b/charts/bsdm/templates/_helpers.tpl
@@ -46,3 +46,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "bsdm.indexerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "bsdm.name" . }}-indexer
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: cache-indexer
+{{- end }}

--- a/charts/bsdm/templates/configmap-env.yaml
+++ b/charts/bsdm/templates/configmap-env.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.replicaCount) 0 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,3 +34,4 @@ data:
   {{- if .Values.proxy.kafkaBrokers }}
   KAFKA_BROKERS: {{ .Values.proxy.kafkaBrokers | quote }}
   {{- end }}
+{{- end }}

--- a/charts/bsdm/templates/deployment.yaml
+++ b/charts/bsdm/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.replicaCount) 0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -123,3 +124,4 @@ spec:
           configMap:
             name: {{ .Values.acl.existingConfigMap }}
         {{- end }}
+{{- end }}

--- a/charts/bsdm/templates/hpa.yaml
+++ b/charts/bsdm/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and (gt (int .Values.replicaCount) 0) .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/bsdm/templates/indexer-configmap.yaml
+++ b/charts/bsdm/templates/indexer-configmap.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.indexer .Values.indexer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "bsdm.fullname" . }}-indexer-env
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache-indexer
+data:
+  METRICS_PORT: {{ .Values.indexer.service.port | quote }}
+  KAFKA_BROKERS: {{ .Values.indexer.kafka.brokers | quote }}
+  KAFKA_TOPIC: {{ .Values.indexer.kafka.topic | quote }}
+  KAFKA_GROUP_ID: {{ .Values.indexer.kafka.groupId | quote }}
+  CLICKHOUSE_URL: {{ .Values.indexer.clickhouse.url | quote }}
+  CLICKHOUSE_DATABASE: {{ .Values.indexer.clickhouse.database | quote }}
+  CLICKHOUSE_TABLE: {{ .Values.indexer.clickhouse.table | quote }}
+  SEARCH_API_ENABLED: {{ .Values.indexer.searchApi.enabled | quote }}
+  SEARCH_API_MAX_LIMIT: {{ .Values.indexer.searchApi.maxLimit | quote }}
+  SEARCH_API_DEFAULT_DAYS: {{ .Values.indexer.searchApi.defaultDays | quote }}
+  RUST_LOG: {{ .Values.indexer.rustLog | quote }}
+  {{- if .Values.indexer.clickhouse.user }}
+  CLICKHOUSE_USER: {{ .Values.indexer.clickhouse.user | quote }}
+  {{- end }}
+  {{- if and .Values.indexer.searchApi.token (ne .Values.indexer.searchApi.token "") }}
+  SEARCH_API_TOKEN: {{ .Values.indexer.searchApi.token | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/bsdm/templates/indexer-deployment.yaml
+++ b/charts/bsdm/templates/indexer-deployment.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.indexer .Values.indexer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bsdm.fullname" . }}-indexer
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache-indexer
+spec:
+  replicas: {{ .Values.indexer.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "bsdm.indexerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/indexer-configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "bsdm.indexerSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "bsdm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: cache-indexer
+          image: "{{ .Values.indexer.image.repository }}:{{ .Values.indexer.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.indexer.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: admin
+              containerPort: {{ .Values.indexer.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "bsdm.fullname" . }}-indexer-env
+          {{- if .Values.indexer.clickhouse.existingSecret }}
+          env:
+            - name: CLICKHOUSE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.indexer.clickhouse.existingSecret }}
+                  key: username
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.indexer.clickhouse.existingSecret }}
+                  key: password
+          {{- else if .Values.indexer.clickhouse.password }}
+          env:
+            - name: CLICKHOUSE_PASSWORD
+              value: {{ .Values.indexer.clickhouse.password | quote }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: admin
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.indexer.resources | nindent 12 }}
+{{- end }}

--- a/charts/bsdm/templates/indexer-service.yaml
+++ b/charts/bsdm/templates/indexer-service.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.indexer .Values.indexer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bsdm.fullname" . }}-indexer
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cache-indexer
+spec:
+  type: ClusterIP
+  ports:
+    - name: admin
+      port: {{ .Values.indexer.service.port }}
+      targetPort: admin
+      protocol: TCP
+  selector:
+    {{- include "bsdm.indexerSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/bsdm/templates/networkpolicy.yaml
+++ b/charts/bsdm/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicy.enabled }}
+{{- if and (gt (int .Values.replicaCount) 0) .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/bsdm/templates/pdb.yaml
+++ b/charts/bsdm/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pdb.enabled }}
+{{- if and (gt (int .Values.replicaCount) 0) .Values.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/bsdm/templates/service.yaml
+++ b/charts/bsdm/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.replicaCount) 0 }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "bsdm.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/bsdm/templates/servicemonitor.yaml
+++ b/charts/bsdm/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled }}
+{{- if and (gt (int .Values.replicaCount) 0) .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/bsdm/values-analytics.yaml
+++ b/charts/bsdm/values-analytics.yaml
@@ -1,0 +1,62 @@
+# Optional analytics-plane overlay for cache-indexer → external ClickHouse.
+# Proxy data-plane values remain in values.yaml / values-prod.yaml.
+#
+# Prerequisites:
+#   - Kafka bootstrap reachable (e.g. kafka-bootstrap.bsdm-analytics.svc:9092)
+#   - ClickHouse HTTP :8123 (Operator CHI or managed CH / ClickHouse Cloud)
+#   - Schema applied: scripts/clickhouse/http_cache.sql
+#
+# Install indexer into analytics namespace:
+#   helm upgrade --install bsdm-indexer ./charts/bsdm \
+#     -f charts/bsdm/values-analytics.yaml \
+#     -n bsdm-analytics --create-namespace
+#
+# Or enable indexer alongside proxy in one release (same cluster DNS):
+#   indexer.enabled=true + clickhouse.url pointing at CHI service.
+#
+# Full guide: docs/k8s-architecture.md
+
+# Disable proxy Deployment when installing indexer-only release into analytics ns
+fullnameOverride: bsdm
+replicaCount: 0
+
+indexer:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ghcr.io/onixus/bsdm-cache-indexer
+    tag: "0.3.2"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "250m"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  service:
+    port: 8080
+  kafka:
+    brokers: "kafka-bootstrap.bsdm-analytics.svc:9092"
+    topic: cache-events
+    groupId: cache-indexer-group
+  clickhouse:
+    # Altinity CHI default Service name pattern: clickhouse-<chi-name>
+    url: "http://clickhouse-bsdm.bsdm-analytics.svc.cluster.local:8123"
+    database: bsdm
+    table: http_cache
+    # Prefer existing Secret with keys username / password when set
+    existingSecret: ""
+    user: ""
+    password: ""
+  searchApi:
+    enabled: true
+    token: ""
+    maxLimit: 10000
+    defaultDays: 30
+  rustLog: "info,cache_indexer=info"
+
+# Proxy Kafka still pointed from values-prod when co-located; unused if replicaCount=0
+proxy:
+  kafkaBrokers: "kafka-bootstrap.bsdm-analytics.svc:9092"
+  kafkaTopic: cache-events

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -127,6 +127,42 @@ serviceMonitor:
   interval: 30s
   labels: {}
 
+# Optional cache-indexer (Kafka → ClickHouse). Prefer a separate release in
+# bsdm-analytics with values-analytics.yaml, or enable alongside proxy.
+indexer:
+  enabled: false
+  replicaCount: 2
+  image:
+    repository: ghcr.io/onixus/bsdm-cache-indexer
+    tag: "0.3.2"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "250m"
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  service:
+    port: 8080
+  kafka:
+    brokers: "kafka-bootstrap.bsdm-analytics.svc:9092"
+    topic: cache-events
+    groupId: cache-indexer-group
+  clickhouse:
+    url: "http://clickhouse-bsdm.bsdm-analytics.svc.cluster.local:8123"
+    database: bsdm
+    table: http_cache
+    existingSecret: ""
+    user: ""
+    password: ""
+  searchApi:
+    enabled: true
+    token: ""
+    maxLimit: 10000
+    defaultDays: 30
+  rustLog: "info,cache_indexer=info"
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -82,9 +82,16 @@ LIMIT 50;
 | 2 | Grafana + Search API ([#129](https://github.com/onixus/bsdm-proxy/issues/129), [#130](https://github.com/onixus/bsdm-proxy/issues/130)) |
 | 3 | Default compose ([#132](https://github.com/onixus/bsdm-proxy/issues/132)) |
 | 4 | Remove OpenSearch code ([#134](https://github.com/onixus/bsdm-proxy/issues/134)) |
+| 5 | k8s ClickHouse Operator + Helm indexer ([#135](https://github.com/onixus/bsdm-proxy/issues/135)) |
 
 Epic: [#125](https://github.com/onixus/bsdm-proxy/issues/125).
 
 ## k8s
 
-См. [k8s-architecture.md](k8s-architecture.md) — ClickHouse Operator / Altinity chart в analytics namespace.
+Analytics plane: Kafka → cache-indexer → **ClickHouse** (no OpenSearch).
+
+1. Install [Altinity ClickHouse Operator](https://github.com/Altinity/clickhouse-operator).
+2. Apply CHI example: [`charts/bsdm/examples/clickhouse-installation.yaml`](../charts/bsdm/examples/clickhouse-installation.yaml).
+3. Deploy indexer: `helm upgrade --install bsdm-indexer ./charts/bsdm -f charts/bsdm/values-analytics.yaml -n bsdm-analytics`.
+
+Details: [k8s-architecture.md](k8s-architecture.md) § Analytics plane · issue [#135](https://github.com/onixus/bsdm-proxy/issues/135).

--- a/docs/k8s-architecture.md
+++ b/docs/k8s-architecture.md
@@ -164,14 +164,110 @@ sessionAffinity: None
 
 ## Analytics plane (`bsdm-analytics` namespace)
 
+```mermaid
+flowchart LR
+  P[proxy pods] -->|async CacheEvent| K[Kafka cache-events]
+  K --> I[cache-indexer]
+  I -->|JSONEachRow HTTP :8123| CH[(ClickHouse CHI)]
+  G[Grafana] -->|native :9000| CH
+  SOC[Search API /api/search] --> I
+  I -.-> CH
+```
+
 | Компонент | Назначение |
 |-----------|------------|
 | Kafka topic `cache-events` | 12 partitions, RF=3, retention 7d |
-| cache-indexer | Consumer group, HPA по lag |
-| ClickHouse | Table `bsdm.http_cache`, TTL 42d |
-| Prometheus + Grafana | Scrape `/metrics` всех proxy pods |
+| cache-indexer | Consumer group → ClickHouse; HPA по lag |
+| **ClickHouse** (Operator / managed) | Table `bsdm.http_cache`, TTL 42d |
+| Prometheus + Grafana | Proxy metrics + CH SQL dashboards |
 
-Proxy **не должен** блокироваться на Kafka (см. [#106](https://github.com/onixus/bsdm-proxy/issues/106)).
+**OpenSearch не требуется** — analytics path только ClickHouse ([ADR 0002](adr/0002-clickhouse-analytics.md), epic [#125](https://github.com/onixus/bsdm-proxy/issues/125)).
+
+Proxy **не должен** блокироваться на Kafka (bounded queue, drop-new).
+
+### ClickHouse Operator (Altinity)
+
+Рекомендуемый on-prem путь — [Altinity ClickHouse Operator](https://github.com/Altinity/clickhouse-operator):
+
+```bash
+helm repo add altinity https://docs.altinity.com/clickhouse-operator/
+helm install clickhouse-operator altinity/altinity-clickhouse-operator \
+  -n clickhouse-operator --create-namespace
+
+kubectl create namespace bsdm-analytics
+kubectl apply -f charts/bsdm/examples/clickhouse-installation.yaml
+```
+
+Пример CR: [`charts/bsdm/examples/clickhouse-installation.yaml`](../charts/bsdm/examples/clickhouse-installation.yaml) — 1 shard / 1 replica, PVC **100Gi** (Retain).
+
+Альтернативы: ClickHouse Cloud, managed DB, или plain StatefulSet (lab only).
+
+#### Endpoints
+
+| Protocol | Service (CHI `bsdm`) | Client |
+|----------|----------------------|--------|
+| HTTP `:8123` | `clickhouse-bsdm.bsdm-analytics.svc` | cache-indexer |
+| Native `:9000` | same | Grafana `grafana-clickhouse-datasource` |
+
+Init schema once:
+
+```bash
+kubectl -n bsdm-analytics exec -i chi-bsdm-bsdm-0-0-0 -- \
+  clickhouse-client --multiquery < scripts/clickhouse/http_cache.sql
+```
+
+Session columns on existing volumes: `scripts/clickhouse/migrations/001_session_correlation.sql`.
+
+### Helm: cache-indexer → external CH
+
+```bash
+# Indexer-only release in analytics namespace
+helm upgrade --install bsdm-indexer ./charts/bsdm \
+  -f charts/bsdm/values-analytics.yaml \
+  -n bsdm-analytics --create-namespace
+```
+
+| Value | Purpose |
+|-------|---------|
+| `indexer.enabled` | Deploy cache-indexer Deployment + Service `:8080` |
+| `indexer.clickhouse.url` | HTTP URL of CHI / managed CH |
+| `indexer.clickhouse.existingSecret` | Optional Secret keys `username` / `password` |
+| `replicaCount: 0` | Skip proxy templates when installing indexer-only |
+
+Proxy Kafka brokers (data plane): `proxy.kafkaBrokers` in `values-prod.yaml` → `kafka-bootstrap.bsdm-analytics.svc:9092`.
+
+### Sizing storage (vs OpenSearch)
+
+| | OpenSearch (legacy) | ClickHouse `http_cache` |
+|--|---------------------|-------------------------|
+| Guidance | ~64Gi StatefulSet | start **100Gi** PVC, grow with retention |
+| Retention | ISM ~42d | MergeTree **TTL 42 DAY** |
+| Compression | Lucene | columnar + TTL delete |
+
+Для SOC-объёмов (корпоративный medium) 100Gi обычно достаточно на 42 дня компактных `CacheEvent`; увеличивайте PVC / shards при sample rate 1 или длинном retention.
+
+### Backup / DR
+
+| Метод | Когда |
+|-------|--------|
+| `FREEZE PARTITION` + volume snapshot | on-prem CHI / StatefulSet |
+| ClickHouse Cloud / managed backups | cloud |
+| S3 `BACKUP` / `RESTORE` (CH 22+) | cross-region DR |
+| Kafka retention 7d | replay-окно при потере fresh inserts |
+
+Не полагайтесь на OpenSearch snapshots — их больше нет в product path.
+
+### GitOps layout
+
+```
+gitops/
+├── bsdm-proxy/              # Helm charts/bsdm + values-prod.yaml
+├── bsdm-analytics/
+│   ├── kafka/               # Strimzi / Bitnami
+│   ├── clickhouse/          # Operator + CHI (examples/clickhouse-installation.yaml)
+│   └── indexer/             # Helm -f values-analytics.yaml
+└── secrets/                 # External Secrets → mitm-ca, CH user, SEARCH_API_TOKEN
+```
 
 ---
 
@@ -220,18 +316,15 @@ bsdm-proxy + Redis + Kafka + ClickHouse + indexer + Grafana
 
 ## GitOps layout
 
-```
-gitops/
-├── bsdm-proxy/          # Helm release, values-prod.yaml
-├── bsdm-analytics/      # Kafka, OS, indexer
-└── secrets/             # External Secrets → mitm-ca, ldap-bind
-```
+См. [Analytics plane](#analytics-plane-bsdm-analytics-namespace) — Kafka + ClickHouse Operator + indexer; OpenSearch не входит в layout.
 
 | Артефакт | Источник |
 |----------|----------|
 | Env defaults | Helm `values.yaml` → ConfigMap |
 | ACL rules | ConfigMap + `ACL_AUTO_RELOAD=true` |
 | MITM CA | cert-manager Certificate → Secret |
+| ClickHouse | Operator `ClickHouseInstallation` |
+| Indexer | Helm `-f values-analytics.yaml` |
 
 ---
 
@@ -268,7 +361,8 @@ helm install bsdm ./charts/bsdm \
 | [#96](https://github.com/onixus/bsdm-proxy/issues/96) Policy cache | Lower CPU → fewer replicas |
 | [#97](https://github.com/onixus/bsdm-proxy/issues/97) WORKER_COUNT profiles | `values-prod.yaml`: `workerCount: 1` |
 | [#107](https://github.com/onixus/bsdm-proxy/issues/107) HA guide | This document |
+| [#135](https://github.com/onixus/bsdm-proxy/issues/135) CH Operator analytics | CHI example + `values-analytics.yaml` |
 
 ---
 
-*Последнее обновление: 2026-06 · BSDM v0.3.1*
+*Последнее обновление: 2026-07 · BSDM v0.3.2 · M3 CH Operator (#135)*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -122,8 +122,8 @@ proxy → Kafka → cache-indexer → ClickHouse
 
 ### Текущий gap
 
-- CSV/JSON export polish for SOC playbooks (Search API already supports `format=csv`)
 - Session correlation across multi-node proxies (today: per-node soft sessions)
+- k8s production soak of CHI example (#135 docs/Helm shipped)
 
 ### Задачи
 
@@ -136,7 +136,8 @@ proxy → Kafka → cache-indexer → ClickHouse
 - [x] **Default compose on ClickHouse** — `docker compose up` ([#132](https://github.com/onixus/bsdm-proxy/issues/132))
 - [x] **Remove OpenSearch backend** — ClickHouse-only cache-indexer ([#134](https://github.com/onixus/bsdm-proxy/issues/134))
 - [x] **Session correlation** — `session_id`, redirect chains (`parent_event_id` / `redirect_url`)
-- [ ] **Экспорт** — CSV/JSON для SOC
+- [x] **Экспорт** — CSV/JSON для SOC (`/api/search?format=csv|json`)
+- [x] **k8s ClickHouse Operator plane** — CHI example + Helm indexer ([#135](https://github.com/onixus/bsdm-proxy/issues/135))
 
 **Критерий завершения M3:** аналитик находит «кто ходил на domain X за 30 дней» через Dashboards **или** Grafana/CH SQL; CH indexer в production path.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes Phase 5 of the OpenSearch → ClickHouse migration ([#135](https://github.com/onixus/bsdm-proxy/issues/135) / epic [#125](https://github.com/onixus/bsdm-proxy/issues/125)): k8s analytics plane for ClickHouse Operator + Helm indexer.

### Changes

- **`charts/bsdm/examples/clickhouse-installation.yaml`** — Altinity `ClickHouseInstallation` (1 shard, 100Gi PVC, CH 24.12)
- **Helm `indexer.*`** — optional Deployment / Service / ConfigMap for cache-indexer
- **`values-analytics.yaml`** — indexer-only release (`replicaCount: 0`, `fullnameOverride: bsdm`)
- **`docs/k8s-architecture.md`** — Kafka → indexer → CH diagram, Operator install, sizing vs OpenSearch, backup/DR; OpenSearch removed from GitOps path
- Roadmap: mark #135 + SOC CSV/JSON export complete; chart version **0.1.1**

### Deploy sketch

```bash
helm install clickhouse-operator altinity/altinity-clickhouse-operator -n clickhouse-operator --create-namespace
kubectl apply -f charts/bsdm/examples/clickhouse-installation.yaml
helm upgrade --install bsdm-indexer ./charts/bsdm -f charts/bsdm/values-analytics.yaml -n bsdm-analytics --create-namespace
```

### Testing

```bash
helm template bsdm-indexer ./charts/bsdm -f charts/bsdm/values-analytics.yaml -n bsdm-analytics
helm template bsdm ./charts/bsdm -f charts/bsdm/values-prod.yaml -n bsdm-proxy
```

## Связанные issue

- [x] `Closes #135`
- Milestone: M3

## Checklist

- [x] Документация обновлена
- [x] OpenSearch не required в k8s path
- [x] Helm values example for external / Operator CH

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

