### PR TITLE
[M4] Categorization Prometheus metrics and threat panels (#105)

### DIFF
--- a/docs/categorization.md
+++ b/docs/categorization.md
@@ -106,7 +106,23 @@ Stub only (`ML_ENABLED`); not used in production paths yet.
 
 ## Policy integration
 
-Categories feed URL filtering and policy rules. Events include `category`, `category_source` (`ut1`, `otx`, `ml`, `none`), and `category_confidence` in Kafka / ClickHouse.
+Categories feed URL filtering and policy rules. Events include `categories`, `threat_sources` (`ut1`, `urlhaus`, `phishtank`, …), and `acl_action` in Kafka / ClickHouse.
+
+## Prometheus metrics (M4)
+
+Exported on the proxy metrics port (`/metrics`):
+
+| Metric | Labels | Description |
+|--------|--------|-------------|
+| `bsdm_proxy_categorization_lookups_total` | `source`, `result` | Hot-path lookups (`source`: ut1/custom/cache/unknown; `result`: hit/miss) |
+| `bsdm_proxy_categorization_cache_hits_total` | — | In-memory category cache hits |
+| `bsdm_proxy_categorization_cache_misses_total` | — | Cache miss → local DB scan |
+| `bsdm_proxy_categorization_duration_seconds` | — | Histogram of `categorize_local` latency |
+| `bsdm_proxy_categorization_category_total` | `category` | Categories returned |
+| `bsdm_proxy_categorization_blocked_total` | `category`, `action` | ACL deny/redirect with those categories |
+| `bsdm_proxy_categorization_online_enrich_scheduled_total` | — | Background URLhaus/PhishTank tasks |
+
+Grafana: panels on **BSDM Proxy Dashboard** + SQL threat panels on **BSDM HTTP Traffic (ClickHouse)**.
 
 ## Configuration reference
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,12 +149,12 @@ Rule-based обнаружение угроз (без ML). Запросы и ал
 
 ### Задачи
 
-- [ ] **Обогащение событий** — reputation, URLhaus/PhishTank metadata ([#102](https://github.com/onixus/bsdm-proxy/issues/102))
-- [ ] **Rule-based alerts** — burst domain, off-hours, blocked burst
+- [x] **Обогащение событий** — `acl_action`, `threat_sources` in CH / Search API ([#102](https://github.com/onixus/bsdm-proxy/issues/102))
+- [ ] **Rule-based alerts** — burst domain, off-hours, blocked burst (starter SQL: `scripts/clickhouse/m4_threat_queries.sql`)
 - [ ] **C&C heuristics** — beacon pattern, high-entropy domains
 - [ ] **Alerting** — CH/Grafana alerting или webhook worker
-- [ ] **Threat dashboard** — Grafana + CH
-- [ ] **Categorization metrics** ([#105](https://github.com/onixus/bsdm-proxy/issues/105))
+- [ ] **Threat dashboard** — Grafana + CH (panels: top blocked categories, burst domains)
+- [x] **Categorization metrics** ([#105](https://github.com/onixus/bsdm-proxy/issues/105))
 - [ ] **PhishTank API key** (`PHISHTANK_API_KEY`)
 
 **Критерий завершения M4:** автоматический алерт на beacon-паттерн; threat dashboard с top blocked categories.

--- a/grafana/dashboards/bsdm-http-traffic-ch.json
+++ b/grafana/dashboards/bsdm-http-traffic-ch.json
@@ -281,11 +281,71 @@
       ],
       "title": "Blocked / threat events",
       "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 42 },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT arrayJoin(categories) AS category, count() AS events\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND acl_action IN ('deny', 'redirect')\nGROUP BY category\nORDER BY events DESC\nLIMIT 20",
+          "refId": "A"
+        }
+      ],
+      "title": "Top blocked categories",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 42 },
+      "id": 10,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT client_ip, domain, count() AS requests, min(ts) AS first_ts, max(ts) AS last_ts\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\nGROUP BY client_ip, domain\nHAVING requests >= 50\nORDER BY requests DESC\nLIMIT 50",
+          "refId": "A"
+        }
+      ],
+      "title": "Burst domains (≥50 req in range)",
+      "type": "table"
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["bsdm", "http-cache", "clickhouse"],
+  "tags": ["bsdm", "http-cache", "clickhouse", "m4"],
   "templating": {
     "list": [
       {

--- a/grafana/dashboards/bsdm-proxy.json
+++ b/grafana/dashboards/bsdm-proxy.json
@@ -640,11 +640,82 @@
       ],
       "title": "Upstream Connections",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 20,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(bsdm_proxy_categorization_lookups_total[1m])) by (source, result)",
+          "legendFormat": "{{source}} {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Categorization lookups",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 21,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(bsdm_proxy_categorization_blocked_total[5m])) by (category, action)",
+          "legendFormat": "{{action}} {{category}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(bsdm_proxy_categorization_online_enrich_scheduled_total[5m])",
+          "legendFormat": "online enrich scheduled",
+          "refId": "B"
+        }
+      ],
+      "title": "Categorization blocked / enrich",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 39,
-  "tags": ["bsdm-proxy", "proxy", "cache"],
+  "tags": ["bsdm-proxy", "proxy", "cache", "categorization"],
   "templating": {
     "list": []
   },

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -71,6 +71,19 @@ pub struct Metrics {
     pub hierarchy_icp_queries_total: CounterVec,
     pub hierarchy_digest_skipped_total: Counter,
     pub hierarchy_lookup_duration_seconds: Histogram,
+
+    // Categorization metrics (M4 / #105)
+    /// Lookups on the hot path: `source` = ut1|custom|cache|unknown|none, `result` = hit|miss.
+    pub categorization_lookups_total: CounterVec,
+    pub categorization_cache_hits_total: Counter,
+    pub categorization_cache_misses_total: Counter,
+    pub categorization_duration_seconds: Histogram,
+    /// Category labels observed on a lookup (local DB / cache hit).
+    pub categorization_category_total: CounterVec,
+    /// Policy deny/redirect while URL had these categories.
+    pub categorization_blocked_total: CounterVec,
+    /// Background URLhaus/PhishTank enrich tasks scheduled.
+    pub categorization_online_enrich_scheduled_total: Counter,
 }
 
 impl Metrics {
@@ -332,6 +345,64 @@ impl Metrics {
         )?;
         registry.register(Box::new(hierarchy_lookup_duration_seconds.clone()))?;
 
+        let categorization_lookups_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_categorization_lookups_total",
+                "URL categorization lookups on the hot path",
+            ),
+            &["source", "result"],
+        )?;
+        registry.register(Box::new(categorization_lookups_total.clone()))?;
+
+        let categorization_cache_hits_total = Counter::new(
+            "bsdm_proxy_categorization_cache_hits_total",
+            "In-memory categorization cache hits",
+        )?;
+        registry.register(Box::new(categorization_cache_hits_total.clone()))?;
+
+        let categorization_cache_misses_total = Counter::new(
+            "bsdm_proxy_categorization_cache_misses_total",
+            "In-memory categorization cache misses",
+        )?;
+        registry.register(Box::new(categorization_cache_misses_total.clone()))?;
+
+        let categorization_duration_seconds = Histogram::with_opts(
+            HistogramOpts::new(
+                "bsdm_proxy_categorization_duration_seconds",
+                "Hot-path categorize_local duration in seconds",
+            )
+            .buckets(vec![
+                0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05,
+            ]),
+        )?;
+        registry.register(Box::new(categorization_duration_seconds.clone()))?;
+
+        let categorization_category_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_categorization_category_total",
+                "Categories returned by categorization lookups",
+            ),
+            &["category"],
+        )?;
+        registry.register(Box::new(categorization_category_total.clone()))?;
+
+        let categorization_blocked_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_categorization_blocked_total",
+                "ACL deny/redirect decisions with categorized URLs",
+            ),
+            &["category", "action"],
+        )?;
+        registry.register(Box::new(categorization_blocked_total.clone()))?;
+
+        let categorization_online_enrich_scheduled_total = Counter::new(
+            "bsdm_proxy_categorization_online_enrich_scheduled_total",
+            "Background URLhaus/PhishTank enrichment tasks scheduled",
+        )?;
+        registry.register(Box::new(
+            categorization_online_enrich_scheduled_total.clone(),
+        ))?;
+
         Ok(Metrics {
             registry,
             requests_total,
@@ -369,7 +440,56 @@ impl Metrics {
             hierarchy_icp_queries_total,
             hierarchy_digest_skipped_total,
             hierarchy_lookup_duration_seconds,
+            categorization_lookups_total,
+            categorization_cache_hits_total,
+            categorization_cache_misses_total,
+            categorization_duration_seconds,
+            categorization_category_total,
+            categorization_blocked_total,
+            categorization_online_enrich_scheduled_total,
         })
+    }
+
+    pub fn record_categorization_lookup(
+        &self,
+        source: &str,
+        from_cache: bool,
+        categories: &[String],
+        duration_secs: f64,
+    ) {
+        let result = if categories.is_empty() { "miss" } else { "hit" };
+        self.categorization_lookups_total
+            .with_label_values(&[source, result])
+            .inc();
+        if from_cache {
+            self.categorization_cache_hits_total.inc();
+        } else {
+            self.categorization_cache_misses_total.inc();
+        }
+        self.categorization_duration_seconds.observe(duration_secs);
+        for cat in categories {
+            self.categorization_category_total
+                .with_label_values(&[cat])
+                .inc();
+        }
+    }
+
+    pub fn record_categorization_blocked(&self, categories: &[String], action: &str) {
+        if categories.is_empty() {
+            self.categorization_blocked_total
+                .with_label_values(&["none", action])
+                .inc();
+            return;
+        }
+        for cat in categories {
+            self.categorization_blocked_total
+                .with_label_values(&[cat, action])
+                .inc();
+        }
+    }
+
+    pub fn record_categorization_online_enrich_scheduled(&self) {
+        self.categorization_online_enrich_scheduled_total.inc();
     }
 
     pub fn record_hierarchy_resolution(&self, result: &str) {
@@ -508,5 +628,21 @@ mod tests {
         assert!(out.contains("bsdm_proxy_hierarchy_icp_queries_total"));
         assert!(out.contains("bsdm_proxy_hierarchy_peer_requests_total"));
         assert!(out.contains("parent_hit"));
+    }
+
+    #[test]
+    fn categorization_metrics_exported() {
+        let m = Metrics::new().unwrap();
+        m.record_categorization_lookup("ut1", false, &["malware".to_string()], 0.0002);
+        m.record_categorization_lookup("cache", true, &["news".to_string()], 0.00005);
+        m.record_categorization_blocked(&["malware".to_string()], "deny");
+        m.record_categorization_online_enrich_scheduled();
+        let out = String::from_utf8(m.export().unwrap()).unwrap();
+        assert!(out.contains("bsdm_proxy_categorization_lookups_total"));
+        assert!(out.contains("bsdm_proxy_categorization_cache_hits_total"));
+        assert!(out.contains("bsdm_proxy_categorization_duration_seconds"));
+        assert!(out.contains("bsdm_proxy_categorization_blocked_total"));
+        assert!(out.contains("bsdm_proxy_categorization_online_enrich_scheduled_total"));
+        assert!(out.contains(r#"category="malware""#));
     }
 }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -493,9 +493,11 @@ impl ProxyService {
         let Some(engine) = &self.categorization else {
             return (Vec::new(), Vec::new());
         };
+        let start = Instant::now();
         let result = engine.categorize_local(url);
         if result.categories.is_empty() && engine.online_enrichment_enabled() {
             engine.schedule_online_enrichment(url);
+            self.metrics.record_categorization_online_enrich_scheduled();
         }
         let categories: Vec<String> = result
             .categories
@@ -504,10 +506,16 @@ impl ProxyService {
             .filter(|name| !name.is_empty())
             .collect();
         let threat_sources = if result.source != "unknown" && !categories.is_empty() {
-            vec![result.source]
+            vec![result.source.clone()]
         } else {
             Vec::new()
         };
+        self.metrics.record_categorization_lookup(
+            &result.source,
+            result.cached,
+            &categories,
+            start.elapsed().as_secs_f64(),
+        );
         (categories, threat_sources)
     }
 
@@ -554,6 +562,8 @@ impl ProxyService {
             None
         } else {
             info!("ACL {} for {}: {}", decision.action, url, decision.reason);
+            self.metrics
+                .record_categorization_blocked(category_names, &action_label);
             Some(decision)
         }
     }

--- a/scripts/clickhouse/m4_threat_queries.sql
+++ b/scripts/clickhouse/m4_threat_queries.sql
@@ -1,0 +1,44 @@
+-- M4 threat / SOC example queries for bsdm.http_cache
+-- Run ad-hoc or wire into Grafana alerts / materialized views later.
+
+-- Top blocked categories (7d)
+-- SELECT arrayJoin(categories) AS category, count() AS events
+-- FROM bsdm.http_cache
+-- WHERE ts >= now() - INTERVAL 7 DAY
+--   AND acl_action IN ('deny', 'redirect')
+-- GROUP BY category
+-- ORDER BY events DESC
+-- LIMIT 20;
+
+-- Burst domains: same domain > N requests / 5 minutes from one client
+-- SELECT
+--   client_ip,
+--   domain,
+--   count() AS requests,
+--   min(ts) AS first_ts,
+--   max(ts) AS last_ts
+-- FROM bsdm.http_cache
+-- WHERE ts >= now() - INTERVAL 1 HOUR
+-- GROUP BY client_ip, domain
+-- HAVING requests >= 50
+-- ORDER BY requests DESC
+-- LIMIT 100;
+
+-- Off-hours traffic (UTC): 22:00–06:00 with threat sources
+-- SELECT ts, username, client_ip, domain, url, threat_sources, categories
+-- FROM bsdm.http_cache
+-- WHERE ts >= now() - INTERVAL 7 DAY
+--   AND (toHour(ts) >= 22 OR toHour(ts) < 6)
+--   AND length(threat_sources) > 0
+-- ORDER BY ts DESC
+-- LIMIT 200;
+
+-- High-entropy / short-lived domains (simple heuristic: long labels, many digits)
+-- SELECT domain, count() AS requests, uniqExact(client_ip) AS clients
+-- FROM bsdm.http_cache
+-- WHERE ts >= now() - INTERVAL 1 DAY
+--   AND length(domain) >= 25
+--   AND match(domain, '[0-9]{4,}')
+-- GROUP BY domain
+-- ORDER BY requests DESC
+-- LIMIT 50;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Starts **M4 threat analytics** with categorization Prometheus metrics ([#105](https://github.com/onixus/bsdm-proxy/issues/105)) and starter CH/Grafana threat panels.

### Metrics (`proxy` `/metrics`)

| Metric | Notes |
|--------|--------|
| `bsdm_proxy_categorization_lookups_total{source,result}` | Hot-path lookups |
| `bsdm_proxy_categorization_cache_hits_total` / `_misses_total` | In-memory category cache |
| `bsdm_proxy_categorization_duration_seconds` | `categorize_local` histogram |
| `bsdm_proxy_categorization_category_total{category}` | Observed categories |
| `bsdm_proxy_categorization_blocked_total{category,action}` | ACL deny/redirect with categories |
| `bsdm_proxy_categorization_online_enrich_scheduled_total` | Async URLhaus/PhishTank schedule |

### Grafana / SQL

- **BSDM Proxy Dashboard**: categorization lookup + blocked rates
- **BSDM HTTP Traffic (CH)**: top blocked categories, burst domains (≥50 req)
- `scripts/clickhouse/m4_threat_queries.sql` — SOC example queries for alerts later

Docs: `docs/categorization.md`, roadmap M4 checkboxes for #105 / #102 (schema enrichment already on CH path).

## Связанные issue

- [x] `Closes #105`
- Milestone: M4
- Note: [#102](https://github.com/onixus/bsdm-proxy/issues/102) fields (`acl_action`, `threat_sources`) already shipped in M3 — OpenSearch criteria obsolete after #134

## Testing

```bash
cargo fmt --all -- --check
cargo test -p bsdm-proxy
cargo clippy -p bsdm-proxy -- -D warnings
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

