### PR TITLE
feat(alert-worker): SIEM/webhook alerting pipeline (B19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,9 @@
 
 BSDM-Proxy is a single Rust/Cargo product: a caching HTTPS forward proxy with MITM
 TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → ClickHouse
-analytics pipeline. The Cargo workspace has four crates: `proxy/` (bin `proxy`),
-`cache-indexer/` (bin `cache-indexer`), `bsdm-events/` (shared event types), and
+analytics pipeline (plus optional `alert-worker` webhook alerts). The Cargo workspace has
+five crates: `proxy/` (bin `proxy`), `cache-indexer/` (bin `cache-indexer`),
+`alert-worker/` (bin `alert-worker`), `bsdm-events/` (shared event types), and
 `e2e/` (test harness). Standard build,
 lint, test, and run commands live in `README.md` and `docs/development.md` — use those
 as the source of truth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Alert worker (B19 / #50)** — `alert-worker` polls ClickHouse threat rules and POSTs SIEM JSON webhooks; compose profile `alerts`, Dockerfile target, Prometheus scrape, docs [`docs/alerting.md`](docs/alerting.md)
 - **Web config GUI** — restored General/Cache/Kafka/Auth tabs; Performance, import `.env`, export `acl-rules.json`; compose aligned with root `docker-compose.yml` (P2-5)
 
 ### Changed
 
 - **ACL lock-free snapshot** — `AclEngineHandle` with `arc-swap`; hot path `check_access` without `tokio::RwLock` ([#40](https://github.com/onixus/bsdm-proxy/issues/40) / B9)
 - **Docs cleanup** — roadmap/README/wiki synced to v0.3.2 (M3 done, M4 started); blockers aligned with ClickHouse path; removed outdated `OPTIMIZATIONS.md` and duplicate hierarchy stub; archived GitHub bootstrap scripts under `scripts/archive/`
+- **M4 roadmap** — webhook alerting pipeline marked done; remaining: Grafana alert rules, C&C heuristics, PhishTank key
 
 ## [0.3.2] - 2026-07-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alert-worker"
+version = "0.3.2"
+dependencies = [
+ "chrono",
+ "hex",
+ "prometheus",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bsdm-events",
     "proxy",
     "cache-indexer",
+    "alert-worker",
     "e2e",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY bsdm-events ./bsdm-events
 COPY proxy ./proxy
 COPY cache-indexer ./cache-indexer
+COPY alert-worker ./alert-worker
 COPY e2e ./e2e
 
 # Настройка окружения для статической линковки
@@ -42,8 +43,9 @@ ENV OPENSSL_STATIC=1 \
     OPENSSL_INCLUDE_DIR=/usr/include \
     RUSTFLAGS="-C target-feature=+crt-static"
 
-# Собираем оба бинарника в release режиме
-RUN cargo build --release --target x86_64-unknown-linux-musl
+# Собираем бинарники workspace в release режиме
+RUN cargo build --release --target x86_64-unknown-linux-musl \
+    -p bsdm-proxy -p cache-indexer -p alert-worker
 
 # ============================================================
 # Proxy runtime
@@ -74,3 +76,17 @@ COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/cache-indexe
 
 EXPOSE 8080
 CMD ["cache-indexer"]
+
+# ============================================================
+# Alert-worker runtime (ClickHouse → webhook / SIEM)
+# ============================================================
+FROM alpine:3.21 AS alert-worker
+RUN apk add --no-cache \
+    ca-certificates \
+    libgcc \
+    wget
+
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/alert-worker /usr/local/bin/alert-worker
+
+EXPOSE 8090
+CMD ["alert-worker"]

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 | [docs/licensing.md](docs/licensing.md) | Лицензии, third-party, AGPL-заметки |
 | [NOTICE](NOTICE) | Реестр third-party компонентов |
 | [docs/clickhouse-analytics.md](docs/clickhouse-analytics.md) | ClickHouse analytics, compose, SQL |
+| [docs/alerting.md](docs/alerting.md) | Alert worker → SIEM/webhook (B19) |
 | [docs/search-api.md](docs/search-api.md) | REST Search API (`/api/search`) |
 | [docs/adr/0002-clickhouse-analytics.md](docs/adr/0002-clickhouse-analytics.md) | ADR: ClickHouse как analytics store |
 | [docs/architecture.md](docs/architecture.md) | Архитектура и блокеры |

--- a/alert-worker/Cargo.toml
+++ b/alert-worker/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "alert-worker"
+version = "0.3.2"
+edition = "2021"
+license = "MIT"
+authors = ["BSDM-Proxy Contributors"]
+description = "ClickHouse rule evaluator that posts threat alerts to a SIEM/webhook"
+repository = "https://github.com/onixus/bsdm-proxy"
+keywords = ["clickhouse", "alerting", "webhook", "siem"]
+categories = ["network-programming"]
+
+[[bin]]
+name = "alert-worker"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true }
+prometheus = "0.14"
+sha2 = "0.11"
+hex = "0.4"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/alert-worker/src/clickhouse.rs
+++ b/alert-worker/src/clickhouse.rs
@@ -1,0 +1,90 @@
+//! Minimal ClickHouse HTTP query client.
+
+use crate::config::Config;
+use reqwest::Client;
+use tracing::info;
+
+pub struct ClickHouseClient {
+    client: Client,
+    url: String,
+    user: Option<String>,
+    password: Option<String>,
+}
+
+impl ClickHouseClient {
+    pub fn new(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+        Ok(Self {
+            client,
+            url: config.clickhouse_url.trim_end_matches('/').to_string(),
+            user: config.clickhouse_user.clone(),
+            password: config.clickhouse_password.clone(),
+        })
+    }
+
+    pub async fn ping(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let ping_url = format!("{}/ping", self.url);
+        let mut req = self.client.get(&ping_url);
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        if !response.status().is_success() {
+            return Err(format!("ClickHouse ping failed: HTTP {}", response.status()).into());
+        }
+        info!("ClickHouse reachable at {}", self.url);
+        Ok(())
+    }
+
+    pub async fn query_json_each_row(
+        &self,
+        sql: &str,
+    ) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
+        let mut req = self
+            .client
+            .post(&self.url)
+            .query(&[("query", sql)])
+            .body("");
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(format!("ClickHouse query failed (HTTP {status}): {body}").into());
+        }
+        parse_json_each_row(&body)
+    }
+}
+
+pub fn parse_json_each_row(
+    body: &str,
+) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
+    let mut rows = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        rows.push(serde_json::from_str(line)?);
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_json_each_row() {
+        let body = r#"{"client_ip":"10.0.0.1","value":12}
+{"client_ip":"10.0.0.2","value":3}
+"#;
+        let rows = parse_json_each_row(body).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["value"], 12);
+    }
+}

--- a/alert-worker/src/config.rs
+++ b/alert-worker/src/config.rs
@@ -1,0 +1,127 @@
+//! Runtime configuration from environment variables.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub webhook_url: String,
+    pub webhook_timeout: Duration,
+    pub webhook_headers: HashMap<String, String>,
+    pub clickhouse_url: String,
+    pub clickhouse_database: String,
+    pub clickhouse_table: String,
+    pub clickhouse_user: Option<String>,
+    pub clickhouse_password: Option<String>,
+    pub poll_interval: Duration,
+    pub lookback: Duration,
+    pub dedupe_ttl: Duration,
+    pub metrics_port: u16,
+    pub source: String,
+    pub rules: Vec<String>,
+    pub blocked_burst_threshold: u64,
+    pub domain_burst_threshold: u64,
+    pub high_entropy_min_requests: u64,
+    pub off_hours_min_events: u64,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, String> {
+        let webhook_url = std::env::var("ALERT_WEBHOOK_URL")
+            .map_err(|_| "ALERT_WEBHOOK_URL is required".to_string())?;
+        if webhook_url.trim().is_empty() {
+            return Err("ALERT_WEBHOOK_URL must not be empty".into());
+        }
+
+        let webhook_headers = parse_headers_json(
+            &std::env::var("ALERT_WEBHOOK_HEADERS").unwrap_or_else(|_| "{}".into()),
+        )?;
+
+        let rules = parse_rules_list(&std::env::var("ALERT_RULES").unwrap_or_else(|_| {
+            "blocked_burst,domain_burst,off_hours_threat,high_entropy_domain".into()
+        }));
+
+        Ok(Self {
+            webhook_url,
+            webhook_timeout: Duration::from_secs(env_u64("ALERT_WEBHOOK_TIMEOUT_SECS", 10)),
+            webhook_headers,
+            clickhouse_url: std::env::var("CLICKHOUSE_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:8123".into()),
+            clickhouse_database: std::env::var("CLICKHOUSE_DATABASE")
+                .unwrap_or_else(|_| "bsdm".into()),
+            clickhouse_table: std::env::var("CLICKHOUSE_TABLE")
+                .unwrap_or_else(|_| "http_cache".into()),
+            clickhouse_user: std::env::var("CLICKHOUSE_USER")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            clickhouse_password: std::env::var("CLICKHOUSE_PASSWORD")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            poll_interval: Duration::from_secs(env_u64("ALERT_POLL_INTERVAL_SECS", 60)),
+            lookback: Duration::from_secs(env_u64("ALERT_LOOKBACK_SECS", 300)),
+            dedupe_ttl: Duration::from_secs(env_u64("ALERT_DEDUPE_TTL_SECS", 3600)),
+            metrics_port: env_u64("METRICS_PORT", 8090) as u16,
+            source: std::env::var("ALERT_SOURCE")
+                .unwrap_or_else(|_| "bsdm-proxy-alert-worker".into()),
+            rules,
+            blocked_burst_threshold: env_u64("ALERT_BLOCKED_BURST_THRESHOLD", 10),
+            domain_burst_threshold: env_u64("ALERT_DOMAIN_BURST_THRESHOLD", 50),
+            high_entropy_min_requests: env_u64("ALERT_HIGH_ENTROPY_MIN_REQUESTS", 5),
+            off_hours_min_events: env_u64("ALERT_OFF_HOURS_MIN_EVENTS", 1),
+        })
+    }
+
+    pub fn fq_table(&self) -> String {
+        format!("{}.{}", self.clickhouse_database, self.clickhouse_table)
+    }
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn parse_rules_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn parse_headers_json(raw: &str) -> Result<HashMap<String, String>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| format!("ALERT_WEBHOOK_HEADERS: {e}"))?;
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "ALERT_WEBHOOK_HEADERS must be a JSON object".to_string())?;
+    let mut out = HashMap::new();
+    for (k, v) in obj {
+        let s = v
+            .as_str()
+            .ok_or_else(|| format!("ALERT_WEBHOOK_HEADERS[{k}] must be a string"))?;
+        out.insert(k.clone(), s.to_string());
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_rules_list() {
+        assert_eq!(
+            parse_rules_list(" blocked_burst , domain_burst "),
+            vec!["blocked_burst", "domain_burst"]
+        );
+    }
+
+    #[test]
+    fn parses_headers_json() {
+        let h = parse_headers_json(r#"{"Authorization":"Bearer x","X-Foo":"bar"}"#).unwrap();
+        assert_eq!(h.get("Authorization").map(String::as_str), Some("Bearer x"));
+        assert_eq!(h.get("X-Foo").map(String::as_str), Some("bar"));
+    }
+}

--- a/alert-worker/src/dedupe.rs
+++ b/alert-worker/src/dedupe.rs
@@ -1,0 +1,52 @@
+//! In-memory fingerprint dedupe with TTL.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default)]
+pub struct DedupeCache {
+    seen: HashMap<String, Instant>,
+}
+
+impl DedupeCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` if this fingerprint should fire (not suppressed).
+    pub fn should_fire(&mut self, fingerprint: &str, now: Instant, ttl: Duration) -> bool {
+        self.evict(now, ttl);
+        match self.seen.get(fingerprint) {
+            Some(prev) if now.duration_since(*prev) < ttl => false,
+            _ => {
+                self.seen.insert(fingerprint.to_string(), now);
+                true
+            }
+        }
+    }
+
+    fn evict(&mut self, now: Instant, ttl: Duration) {
+        self.seen
+            .retain(|_, stamped| now.duration_since(*stamped) < ttl);
+    }
+
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suppresses_within_ttl() {
+        let mut cache = DedupeCache::new();
+        let now = Instant::now();
+        let ttl = Duration::from_secs(60);
+        assert!(cache.should_fire("fp1", now, ttl));
+        assert!(!cache.should_fire("fp1", now + Duration::from_secs(10), ttl));
+        assert!(cache.should_fire("fp1", now + Duration::from_secs(61), ttl));
+        assert!(cache.should_fire("fp2", now, ttl));
+    }
+}

--- a/alert-worker/src/main.rs
+++ b/alert-worker/src/main.rs
@@ -1,0 +1,180 @@
+mod clickhouse;
+mod config;
+mod dedupe;
+mod metrics;
+mod payload;
+mod rules;
+mod webhook;
+
+use chrono::Utc;
+use clickhouse::ClickHouseClient;
+use config::Config;
+use dedupe::DedupeCache;
+use metrics::WorkerMetrics;
+use prometheus::{Encoder, TextEncoder};
+use rules::{build_queries, findings_from_rows};
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::{error, info, warn};
+use webhook::WebhookClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,alert_worker=info".into()),
+        )
+        .init();
+
+    let config = Config::from_env().map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+    let metrics = WorkerMetrics::new()?;
+    let ch = ClickHouseClient::new(&config)?;
+    ch.ping().await?;
+    let webhook = WebhookClient::new(&config)?;
+
+    {
+        let metrics = metrics.clone();
+        let port = config.metrics_port;
+        tokio::spawn(async move {
+            run_admin_server(port, metrics).await;
+        });
+    }
+
+    info!(
+        webhook = %config.webhook_url,
+        table = %config.fq_table(),
+        poll_secs = config.poll_interval.as_secs(),
+        lookback_secs = config.lookback.as_secs(),
+        rules = ?config.rules,
+        "alert-worker started"
+    );
+
+    let mut dedupe = DedupeCache::new();
+    loop {
+        if let Err(e) = evaluate_once(&config, &ch, &webhook, &mut dedupe, &metrics).await {
+            warn!("evaluation cycle failed: {e}");
+        }
+        tokio::time::sleep(config.poll_interval).await;
+    }
+}
+
+async fn evaluate_once(
+    config: &Config,
+    ch: &ClickHouseClient,
+    webhook: &WebhookClient,
+    dedupe: &mut DedupeCache,
+    metrics: &WorkerMetrics,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let queries = build_queries(config);
+    let now = Instant::now();
+    let fired_at = Utc::now();
+
+    for (rule, sql) in queries {
+        let rows = match ch.query_json_each_row(&sql).await {
+            Ok(rows) => rows,
+            Err(e) => {
+                metrics.clickhouse_errors.inc();
+                warn!(%rule, "ClickHouse query failed: {e}");
+                continue;
+            }
+        };
+        let findings = findings_from_rows(&rule, &rows);
+        for finding in findings {
+            metrics
+                .findings
+                .with_label_values(&[finding.rule.as_str()])
+                .inc();
+            let fingerprint = finding.fingerprint();
+            if !dedupe.should_fire(&fingerprint, now, config.dedupe_ttl) {
+                metrics.dedupe_suppressed.inc();
+                continue;
+            }
+            let payload = finding.into_payload(&config.source, config.lookback.as_secs(), fired_at);
+            match webhook.send(&payload).await {
+                Ok(()) => metrics.webhook_sent.inc(),
+                Err(e) => {
+                    metrics.webhook_errors.inc();
+                    warn!(rule = %payload.rule, "webhook send failed: {e}");
+                }
+            }
+        }
+    }
+
+    metrics.evaluations.inc();
+    info!(dedupe_entries = dedupe.len(), "evaluation cycle complete");
+    Ok(())
+}
+
+async fn run_admin_server(port: u16, metrics: Arc<WorkerMetrics>) {
+    let bind_addr = format!("0.0.0.0:{port}");
+    let listener = match TcpListener::bind(&bind_addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("Failed to bind alert-worker admin on {bind_addr}: {e}");
+            return;
+        }
+    };
+    info!("alert-worker admin on {bind_addr} (/metrics, /health)");
+
+    loop {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            continue;
+        };
+        let metrics = metrics.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap_or(0);
+            if n == 0 {
+                return;
+            }
+            let req = String::from_utf8_lossy(&buf[..n]);
+            let response = handle_admin(&req, &metrics);
+            let _ = socket.write_all(&response).await;
+        });
+    }
+}
+
+fn handle_admin(req: &str, metrics: &WorkerMetrics) -> Vec<u8> {
+    let request_line = req.lines().next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("/");
+
+    if method == "GET" && path.starts_with("/metrics") {
+        let encoder = TextEncoder::new();
+        let mut buffer = Vec::new();
+        if encoder
+            .encode(&metrics.registry().gather(), &mut buffer)
+            .is_err()
+        {
+            return http_response(500, "text/plain", b"encode error");
+        }
+        return http_response(200, "text/plain; version=0.0.4", &buffer);
+    }
+    if method == "GET" && (path == "/health" || path.starts_with("/health?")) {
+        return http_response(200, "text/plain", b"ok");
+    }
+    http_response(404, "text/plain", b"not found")
+}
+
+fn http_response(status: u16, content_type: &str, body: &[u8]) -> Vec<u8> {
+    let reason = match status {
+        200 => "OK",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Error",
+    };
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let mut out = header.into_bytes();
+    out.extend_from_slice(body);
+    out
+}

--- a/alert-worker/src/metrics.rs
+++ b/alert-worker/src/metrics.rs
@@ -1,0 +1,68 @@
+//! Prometheus metrics for alert-worker.
+
+use prometheus::{IntCounter, IntCounterVec, Opts, Registry};
+use std::sync::Arc;
+
+pub struct WorkerMetrics {
+    registry: Registry,
+    pub evaluations: IntCounter,
+    pub findings: IntCounterVec,
+    pub webhook_sent: IntCounter,
+    pub webhook_errors: IntCounter,
+    pub dedupe_suppressed: IntCounter,
+    pub clickhouse_errors: IntCounter,
+}
+
+impl WorkerMetrics {
+    pub fn new() -> Result<Arc<Self>, Box<dyn std::error::Error>> {
+        let registry = Registry::new();
+        let evaluations = IntCounter::with_opts(Opts::new(
+            "alert_worker_evaluations_total",
+            "Completed rule evaluation cycles",
+        ))?;
+        let findings = IntCounterVec::new(
+            Opts::new(
+                "alert_worker_findings_total",
+                "Findings produced before dedupe",
+            ),
+            &["rule"],
+        )?;
+        let webhook_sent = IntCounter::with_opts(Opts::new(
+            "alert_worker_webhook_sent_total",
+            "Successful webhook deliveries",
+        ))?;
+        let webhook_errors = IntCounter::with_opts(Opts::new(
+            "alert_worker_webhook_errors_total",
+            "Failed webhook deliveries",
+        ))?;
+        let dedupe_suppressed = IntCounter::with_opts(Opts::new(
+            "alert_worker_dedupe_suppressed_total",
+            "Findings suppressed by fingerprint cooldown",
+        ))?;
+        let clickhouse_errors = IntCounter::with_opts(Opts::new(
+            "alert_worker_clickhouse_errors_total",
+            "ClickHouse query failures",
+        ))?;
+
+        registry.register(Box::new(evaluations.clone()))?;
+        registry.register(Box::new(findings.clone()))?;
+        registry.register(Box::new(webhook_sent.clone()))?;
+        registry.register(Box::new(webhook_errors.clone()))?;
+        registry.register(Box::new(dedupe_suppressed.clone()))?;
+        registry.register(Box::new(clickhouse_errors.clone()))?;
+
+        Ok(Arc::new(Self {
+            registry,
+            evaluations,
+            findings,
+            webhook_sent,
+            webhook_errors,
+            dedupe_suppressed,
+            clickhouse_errors,
+        }))
+    }
+
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+}

--- a/alert-worker/src/payload.rs
+++ b/alert-worker/src/payload.rs
@@ -1,0 +1,108 @@
+//! SIEM-friendly webhook JSON envelope.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct AlertPayload {
+    pub version: u8,
+    pub source: String,
+    pub alert_id: String,
+    pub rule: String,
+    pub severity: String,
+    pub title: String,
+    pub description: String,
+    pub fired_at: String,
+    pub window_secs: u64,
+    pub value: f64,
+    pub labels: BTreeMap<String, String>,
+    pub fingerprint: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub rule: String,
+    pub severity: String,
+    pub title: String,
+    pub description: String,
+    pub value: f64,
+    pub labels: BTreeMap<String, String>,
+}
+
+impl Finding {
+    pub fn fingerprint(&self) -> String {
+        fingerprint_for(&self.rule, &self.labels)
+    }
+
+    pub fn into_payload(
+        self,
+        source: &str,
+        window_secs: u64,
+        fired_at: DateTime<Utc>,
+    ) -> AlertPayload {
+        let fingerprint = self.fingerprint();
+        AlertPayload {
+            version: 1,
+            source: source.to_string(),
+            alert_id: uuid::Uuid::new_v4().to_string(),
+            rule: self.rule,
+            severity: self.severity,
+            title: self.title,
+            description: self.description,
+            fired_at: fired_at.to_rfc3339(),
+            window_secs,
+            value: self.value,
+            labels: self.labels,
+            fingerprint,
+        }
+    }
+}
+
+pub fn fingerprint_for(rule: &str, labels: &BTreeMap<String, String>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(rule.as_bytes());
+    hasher.update(b"|");
+    for (k, v) in labels {
+        hasher.update(k.as_bytes());
+        hasher.update(b"=");
+        hasher.update(v.as_bytes());
+        hasher.update(b";");
+    }
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fingerprint_is_stable() {
+        let mut labels = BTreeMap::new();
+        labels.insert("client_ip".into(), "10.0.0.1".into());
+        labels.insert("username".into(), "alice".into());
+        let a = fingerprint_for("blocked_burst", &labels);
+        let b = fingerprint_for("blocked_burst", &labels);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn payload_serializes() {
+        let mut labels = BTreeMap::new();
+        labels.insert("domain".into(), "evil.example".into());
+        let finding = Finding {
+            rule: "domain_burst".into(),
+            severity: "warning".into(),
+            title: "burst".into(),
+            description: "too many".into(),
+            value: 99.0,
+            labels,
+        };
+        let payload = finding.into_payload("test", 300, Utc::now());
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"version\":1"));
+        assert!(json.contains("domain_burst"));
+    }
+}

--- a/alert-worker/src/rules.rs
+++ b/alert-worker/src/rules.rs
@@ -1,0 +1,218 @@
+//! Built-in ClickHouse alerting rules (M4 starters).
+
+use crate::config::Config;
+use crate::payload::Finding;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+pub fn build_queries(config: &Config) -> Vec<(String, String)> {
+    let table = config.fq_table();
+    let lookback = config.lookback.as_secs();
+    let mut out = Vec::new();
+
+    for rule in &config.rules {
+        let sql = match rule.as_str() {
+            "blocked_burst" => Some(format!(
+                r#"SELECT
+  coalesce(username, '') AS username,
+  toString(client_ip) AS client_ip,
+  count() AS value
+FROM {table}
+WHERE ts >= now() - INTERVAL {lookback} SECOND
+  AND (acl_action = 'deny' OR cache_status = 'DENY')
+GROUP BY username, client_ip
+HAVING value >= {threshold}
+ORDER BY value DESC
+LIMIT 100
+FORMAT JSONEachRow"#,
+                threshold = config.blocked_burst_threshold
+            )),
+            "domain_burst" => Some(format!(
+                r#"SELECT
+  toString(client_ip) AS client_ip,
+  domain,
+  count() AS value
+FROM {table}
+WHERE ts >= now() - INTERVAL {lookback} SECOND
+  AND domain != ''
+GROUP BY client_ip, domain
+HAVING value >= {threshold}
+ORDER BY value DESC
+LIMIT 100
+FORMAT JSONEachRow"#,
+                threshold = config.domain_burst_threshold
+            )),
+            "off_hours_threat" => Some(format!(
+                r#"SELECT
+  coalesce(username, '') AS username,
+  toString(client_ip) AS client_ip,
+  domain,
+  count() AS value
+FROM {table}
+WHERE ts >= now() - INTERVAL {lookback} SECOND
+  AND (toHour(ts) >= 22 OR toHour(ts) < 6)
+  AND length(threat_sources) > 0
+GROUP BY username, client_ip, domain
+HAVING value >= {threshold}
+ORDER BY value DESC
+LIMIT 100
+FORMAT JSONEachRow"#,
+                threshold = config.off_hours_min_events
+            )),
+            "high_entropy_domain" => Some(format!(
+                r#"SELECT
+  domain,
+  count() AS value,
+  uniqExact(client_ip) AS clients
+FROM {table}
+WHERE ts >= now() - INTERVAL {lookback} SECOND
+  AND length(domain) >= 25
+  AND match(domain, '[0-9]{{4,}}')
+GROUP BY domain
+HAVING value >= {threshold}
+ORDER BY value DESC
+LIMIT 50
+FORMAT JSONEachRow"#,
+                threshold = config.high_entropy_min_requests
+            )),
+            other => {
+                tracing::warn!("unknown ALERT_RULES entry ignored: {other}");
+                None
+            }
+        };
+        if let Some(sql) = sql {
+            out.push((rule.clone(), sql));
+        }
+    }
+    out
+}
+
+pub fn findings_from_rows(rule: &str, rows: &[Value]) -> Vec<Finding> {
+    rows.iter()
+        .filter_map(|row| find_from_row(rule, row))
+        .collect()
+}
+
+fn find_from_row(rule: &str, row: &Value) -> Option<Finding> {
+    let value = json_number(row.get("value")?)?;
+    let mut labels = BTreeMap::new();
+    for key in ["username", "client_ip", "domain"] {
+        if let Some(v) = row.get(key).and_then(|x| x.as_str()) {
+            if !v.is_empty() {
+                labels.insert(key.to_string(), v.to_string());
+            }
+        }
+    }
+    if let Some(clients) = row.get("clients").and_then(json_number) {
+        labels.insert("clients".into(), clients.to_string());
+    }
+
+    let (severity, title, description) = match rule {
+        "blocked_burst" => (
+            "critical",
+            "ACL deny burst".to_string(),
+            format!(
+                "Client hit {value} blocked requests in the lookback window (user/IP threshold exceeded)"
+            ),
+        ),
+        "domain_burst" => (
+            "warning",
+            "Domain request burst".to_string(),
+            format!("Same client issued {value} requests to one domain in the lookback window"),
+        ),
+        "off_hours_threat" => (
+            "warning",
+            "Off-hours threat traffic".to_string(),
+            format!(
+                "{value} threat-tagged request(s) between 22:00–06:00 UTC in the lookback window"
+            ),
+        ),
+        "high_entropy_domain" => (
+            "warning",
+            "Suspicious high-entropy domain".to_string(),
+            format!(
+                "Domain matched long/numeric heuristic with {value} request(s) in the lookback window"
+            ),
+        ),
+        _ => return None,
+    };
+
+    Some(Finding {
+        rule: rule.to_string(),
+        severity: severity.to_string(),
+        title,
+        description,
+        value,
+        labels,
+    })
+}
+
+fn json_number(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn sample_config(rules: &[&str]) -> Config {
+        Config {
+            webhook_url: "http://example.test/hook".into(),
+            webhook_timeout: Duration::from_secs(5),
+            webhook_headers: Default::default(),
+            clickhouse_url: "http://ch:8123".into(),
+            clickhouse_database: "bsdm".into(),
+            clickhouse_table: "http_cache".into(),
+            clickhouse_user: None,
+            clickhouse_password: None,
+            poll_interval: Duration::from_secs(60),
+            lookback: Duration::from_secs(300),
+            dedupe_ttl: Duration::from_secs(3600),
+            metrics_port: 8090,
+            source: "test".into(),
+            rules: rules.iter().map(|s| (*s).to_string()).collect(),
+            blocked_burst_threshold: 10,
+            domain_burst_threshold: 50,
+            high_entropy_min_requests: 5,
+            off_hours_min_events: 1,
+        }
+    }
+
+    #[test]
+    fn builds_known_rules() {
+        let q = build_queries(&sample_config(&[
+            "blocked_burst",
+            "domain_burst",
+            "off_hours_threat",
+            "high_entropy_domain",
+            "nope",
+        ]));
+        assert_eq!(q.len(), 4);
+        assert!(q[0].1.contains("acl_action = 'deny'"));
+        assert!(q[1].1.contains("HAVING value >= 50"));
+        assert!(q[2].1.contains("toHour(ts)"));
+        assert!(q[3].1.contains("length(domain) >= 25"));
+    }
+
+    #[test]
+    fn maps_blocked_burst_row() {
+        let row = serde_json::json!({
+            "username": "alice",
+            "client_ip": "10.0.0.1",
+            "value": 15
+        });
+        let findings = findings_from_rows("blocked_burst", &[row]);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, "critical");
+        assert_eq!(
+            findings[0].labels.get("username").map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(findings[0].value, 15.0);
+    }
+}

--- a/alert-worker/src/webhook.rs
+++ b/alert-worker/src/webhook.rs
@@ -1,0 +1,49 @@
+//! HTTP POST webhook delivery.
+
+use crate::config::Config;
+use crate::payload::AlertPayload;
+use reqwest::Client;
+use tracing::{info, warn};
+
+pub struct WebhookClient {
+    client: Client,
+    url: String,
+    headers: Vec<(String, String)>,
+}
+
+impl WebhookClient {
+    pub fn new(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = Client::builder().timeout(config.webhook_timeout).build()?;
+        let headers = config
+            .webhook_headers
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        Ok(Self {
+            client,
+            url: config.webhook_url.clone(),
+            headers,
+        })
+    }
+
+    pub async fn send(&self, payload: &AlertPayload) -> Result<(), Box<dyn std::error::Error>> {
+        let mut req = self.client.post(&self.url).json(payload);
+        for (k, v) in &self.headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+        let response = req.send().await?;
+        let status = response.status();
+        if status.is_success() {
+            info!(
+                rule = %payload.rule,
+                fingerprint = %payload.fingerprint,
+                "webhook delivered"
+            );
+            Ok(())
+        } else {
+            let body = response.text().await.unwrap_or_default();
+            warn!(%status, %body, "webhook rejected");
+            Err(format!("webhook HTTP {status}: {body}").into())
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,42 @@ services:
       - bsdm-net
     restart: unless-stopped
 
+  # Optional SIEM/webhook alerts (B19 / #50). Requires ALERT_WEBHOOK_URL.
+  #   ALERT_WEBHOOK_URL=https://hooks.example/siem docker compose --profile alerts up -d alert-worker
+  alert-worker:
+    profiles: ["alerts"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: alert-worker
+    ports:
+      - "8090:8090"
+    environment:
+      - ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-}
+      - ALERT_WEBHOOK_HEADERS=${ALERT_WEBHOOK_HEADERS:-{}}
+      - ALERT_POLL_INTERVAL_SECS=${ALERT_POLL_INTERVAL_SECS:-60}
+      - ALERT_LOOKBACK_SECS=${ALERT_LOOKBACK_SECS:-300}
+      - ALERT_DEDUPE_TTL_SECS=${ALERT_DEDUPE_TTL_SECS:-3600}
+      - ALERT_RULES=${ALERT_RULES:-blocked_burst,domain_burst,off_hours_threat,high_entropy_domain}
+      - CLICKHOUSE_URL=http://clickhouse:8123
+      - CLICKHOUSE_DATABASE=bsdm
+      - CLICKHOUSE_TABLE=http_cache
+      - METRICS_PORT=8090
+      - RUST_LOG=info,alert_worker=info
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+      cache-indexer:
+        condition: service_started
+    networks:
+      - bsdm-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8090/health | grep -q ok"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
   prometheus:
     image: prom/prometheus:v3.12.0
     ports:

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -43,7 +43,7 @@
 | B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics | ✅ |
 | B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | Analytics UI (Grafana + ClickHouse; was OS Dashboards) | ✅ |
 | B18 | [#49](https://github.com/onixus/bsdm-proxy/issues/49) | Behavioral threat signals (beyond blocklists) | ❌ |
-| B19 | [#50](https://github.com/onixus/bsdm-proxy/issues/50) | Alerting pipeline to SIEM/webhook | ❌ |
+| B19 | [#50](https://github.com/onixus/bsdm-proxy/issues/50) | Alerting pipeline to SIEM/webhook | ✅ |
 | B20 | [#51](https://github.com/onixus/bsdm-proxy/issues/51) | Security analytics dashboards (historical) | 🔄 CH panels started |
 
 ## Structural

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |
+| [alerting.md](alerting.md) | Alert worker → SIEM/webhook (M4 / B19) |
 | [search-api.md](search-api.md) | REST Search API |
 
 ## Архитектура и roadmap

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,93 @@
+# Alert worker (B19 / #50)
+
+Polls ClickHouse `bsdm.http_cache`, evaluates rule-based findings, and POSTs
+SIEM-friendly JSON to a webhook. Part of M4 threat analytics.
+
+## Quick start
+
+```bash
+# Optional: echo receiver
+python3 scripts/alert-worker/webhook-echo.py 9080 &
+
+export ALERT_WEBHOOK_URL=http://127.0.0.1:9080/hooks/siem
+export CLICKHOUSE_URL=http://127.0.0.1:8123
+cargo run -p alert-worker
+```
+
+Compose profile (stack already up):
+
+```bash
+ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm \
+  docker compose --profile alerts up -d --build alert-worker
+```
+
+## Payload (v1)
+
+```json
+{
+  "version": 1,
+  "source": "bsdm-proxy-alert-worker",
+  "alert_id": "uuid",
+  "rule": "blocked_burst",
+  "severity": "critical",
+  "title": "ACL deny burst",
+  "description": "...",
+  "fired_at": "2026-07-15T12:00:00+00:00",
+  "window_secs": 300,
+  "value": 15,
+  "labels": { "username": "alice", "client_ip": "10.0.0.1" },
+  "fingerprint": "sha256-hex"
+}
+```
+
+Identical fingerprints are suppressed for `ALERT_DEDUPE_TTL_SECS` (default 1h).
+
+## Built-in rules
+
+| Rule | Severity | Default threshold |
+|------|----------|-------------------|
+| `blocked_burst` | critical | ≥10 deny/`DENY` per user+IP in lookback |
+| `domain_burst` | warning | ≥50 requests per client+domain |
+| `off_hours_threat` | warning | ≥1 threat-tagged event 22:00–06:00 UTC |
+| `high_entropy_domain` | warning | ≥5 hits on long/numeric domains |
+
+Enable a subset: `ALERT_RULES=blocked_burst,domain_burst`.
+
+Starter SQL live in [`scripts/clickhouse/m4_threat_queries.sql`](../scripts/clickhouse/m4_threat_queries.sql).
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ALERT_WEBHOOK_URL` | **required** | Destination URL |
+| `ALERT_WEBHOOK_HEADERS` | `{}` | Extra headers JSON, e.g. `{"Authorization":"Bearer …"}` |
+| `ALERT_WEBHOOK_TIMEOUT_SECS` | `10` | HTTP timeout |
+| `ALERT_POLL_INTERVAL_SECS` | `60` | Eval cycle period |
+| `ALERT_LOOKBACK_SECS` | `300` | Query window |
+| `ALERT_DEDUPE_TTL_SECS` | `3600` | Fingerprint cooldown |
+| `ALERT_RULES` | all four | Comma-separated rule ids |
+| `ALERT_BLOCKED_BURST_THRESHOLD` | `10` | |
+| `ALERT_DOMAIN_BURST_THRESHOLD` | `50` | |
+| `ALERT_HIGH_ENTROPY_MIN_REQUESTS` | `5` | |
+| `ALERT_OFF_HOURS_MIN_EVENTS` | `1` | |
+| `ALERT_SOURCE` | `bsdm-proxy-alert-worker` | Payload `source` |
+| `CLICKHOUSE_URL` | `http://127.0.0.1:8123` | |
+| `CLICKHOUSE_DATABASE` / `TABLE` | `bsdm` / `http_cache` | |
+| `CLICKHOUSE_USER` / `PASSWORD` | — | Optional basic auth |
+| `METRICS_PORT` | `8090` | `/metrics`, `/health` |
+
+## Metrics
+
+- `alert_worker_evaluations_total`
+- `alert_worker_findings_total{rule}`
+- `alert_worker_webhook_sent_total`
+- `alert_worker_webhook_errors_total`
+- `alert_worker_dedupe_suppressed_total`
+- `alert_worker_clickhouse_errors_total`
+
+Prometheus scrape (when profile enabled): job `alert-worker` → `:8090`.
+
+## Related
+
+- Blocker B19 / issue [#50](https://github.com/onixus/bsdm-proxy/issues/50)
+- [clickhouse-analytics.md](clickhouse-analytics.md) · [roadmap.md](roadmap.md) M4

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,7 +221,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 | **B16** | Event schema for analytics | ✅ Done (`session_id`, `acl_action`, `threat_sources`) | M3–M4 |
 | **B17** | Analytics UI in compose | ✅ Done (Grafana + ClickHouse; OS Dashboards removed) | M3 |
 | **B18** | Только URL-level threat | Нет DNS/timing/beacon signals | M4–M5 |
-| **B19** | Alerting pipeline | ❌ Open (CH/Grafana / webhook) | M4 |
+| **B19** | Alerting pipeline | ✅ Done (`alert-worker` → webhook) | M4 |
 | **B20** | Historical threat analytics UI | 🔄 CH panels started (#105) | M4 |
 
 ### 🔵 Structural — технический долг
@@ -243,7 +243,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 M1  ██████████████  B1–B6 ✅
 M2  ██████████████  B7–B9 B13–B14 B21–B25 ✅
 M3  █████████████░  B10–B12 B17 ✅ · B20 🔄
-M4  ███░░░░░░░░░░░  B16 ✅ · B15 B18 B19 · B20 🔄
+M4  █████░░░░░░░░░  B16 ✅ · B19 ✅ · B15 B18 · B20 🔄
 M5  ░░░░░░░░░░░░░░  + M4
 ```
 
@@ -258,9 +258,10 @@ Critical/high блокеры B1–B14, B17, B22–B26 — **закрыты**. An
 ### Волна 3 — M4/M5 foundation
 
 1. ~~**B16** — rich event schema~~ ✅ (`session_id`, `acl_action`, `threat_sources`)
-2. **B15** — analytics / alerting worker
-3. **B18 / B19** — behavioral signals + SIEM webhook
-4. ~~**B8** — online categorization off hot path~~ ✅ (#104)
+2. **B15** — analytics / ML worker (scoring beyond rule alerts)
+3. **B18** — behavioral / beacon signals (extends `alert-worker` rules)
+4. ~~**B19** — SIEM webhook~~ ✅ (`alert-worker`)
+5. ~~**B8** — online categorization off hot path~~ ✅ (#104)
 
 ---
 

--- a/docs/clickhouse-analytics.md
+++ b/docs/clickhouse-analytics.md
@@ -73,6 +73,17 @@ LIMIT 50;
 
 Метрики: `cache_indexer_inserts_total{backend="clickhouse"}`, `cache_indexer_insert_errors_total{backend}`, `cache_indexer_batch_duration_seconds`.
 
+## Alert worker (M4 / B19)
+
+`alert-worker` polls `bsdm.http_cache` and POSTs findings to `ALERT_WEBHOOK_URL` (compose profile `alerts`).
+
+```bash
+ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm \
+  docker compose --profile alerts up -d --build alert-worker
+```
+
+See [alerting.md](alerting.md).
+
 ## Миграция OpenSearch → ClickHouse (завершена)
 
 | Фаза | Статус |

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,7 +10,7 @@
 
 | Файл | Назначение |
 |------|------------|
-| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, grafana |
+| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, grafana; optional `alert-worker` (`--profile alerts`) |
 | `docker-compose.test.yml` | Smoke/E2E external (upstream + proxy) |
 | `docker-compose.redis-l2.yml` | Два proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |
@@ -25,12 +25,13 @@ Dockerfile — multi-stage: `rust:1-alpine` (builder) → `alpine:3.21` (runtime
 ```bash
 docker build --target proxy -t bsdm-proxy:proxy .
 docker build --target cache-indexer -t bsdm-proxy:indexer .
+docker build --target alert-worker -t bsdm-proxy:alert-worker .
 docker compose build proxy cache-indexer
 ```
 
 ### Требования к сборке
 
-- Workspace members в builder: `bsdm-events`, `proxy`, `cache-indexer`, `e2e`.
+- Workspace members в builder: `bsdm-events`, `proxy`, `cache-indexer`, `alert-worker`, `e2e`.
 - Rust: `rust:1-alpine` (stable ≥ 1.88).
 - Статическая линковка musl (см. Dockerfile).
 
@@ -44,6 +45,15 @@ docker compose ps
 docker compose logs -f proxy
 ```
 
+### Alert worker (SIEM webhook)
+
+```bash
+ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm \
+  docker compose --profile alerts up -d --build alert-worker
+```
+
+Docs: [alerting.md](alerting.md).
+
 ### Health checks
 
 | Сервис | Проверка |
@@ -51,6 +61,7 @@ docker compose logs -f proxy
 | proxy | `wget -q -O- http://127.0.0.1:9090/health \| grep -q ok` |
 | kafka | `kafka-broker-api-versions --bootstrap-server localhost:9092` |
 | clickhouse | HTTP `:8123/ping` |
+| alert-worker | `wget … /health` (profile `alerts`) |
 | prometheus | `wget --spider http://localhost:9090/-/healthy` |
 | grafana | `curl -f http://localhost:3000/api/health` |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,9 +116,9 @@ Rule-based обнаружение угроз поверх ClickHouse.
 - [x] Schema enrichment / blocked threat events in CH ([#102](https://github.com/onixus/bsdm-proxy/issues/102))
 - [x] Categorization Prometheus metrics ([#105](https://github.com/onixus/bsdm-proxy/issues/105))
 - [x] Starter threat panels + SQL (`scripts/clickhouse/m4_threat_queries.sql`)
-- [ ] Rule-based alerts (Grafana / webhook)
-- [ ] C&C heuristics (beacon, high-entropy domains)
-- [ ] Alerting pipeline to SIEM ([#50](https://github.com/onixus/bsdm-proxy/issues/50))
+- [x] Alerting pipeline to SIEM / webhook ([#50](https://github.com/onixus/bsdm-proxy/issues/50) / B19) — `alert-worker`, see [alerting.md](alerting.md)
+- [ ] Rule-based alerts in Grafana (optional panels / Alertmanager)
+- [ ] C&C heuristics (beacon, richer high-entropy)
 - [ ] PhishTank API key wiring
 
 **Критерий:** автоалерт на beacon-паттерн + threat dashboard.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -8,6 +8,7 @@
 |-------|------|------------|
 | `bsdm-proxy` | `proxy/` | HTTPS forward proxy (MITM, cache, auth, ACL, Kafka producer) |
 | `cache-indexer` | `cache-indexer/` | Kafka consumer → ClickHouse, Search API, `/metrics` |
+| `alert-worker` | `alert-worker/` | ClickHouse threat rules → SIEM/webhook (M4 / B19) |
 | `bsdm-events` | `bsdm-events/` | Общие типы событий (`CacheEvent`) для proxy и indexer |
 | `e2e` | `e2e/` | Smoke и E2E тесты (subprocess proxy + mock upstream) |
 
@@ -24,6 +25,7 @@ bsdm-proxy/
 │       ├── peer_fetch.rs, hierarchy_config.rs, cache_key.rs
 │       └── tls.rs, metrics.rs, policy_config.rs
 ├── cache-indexer/          # Kafka → ClickHouse indexer + Search API
+├── alert-worker/           # CH rule polling → webhook / SIEM
 ├── bsdm-events/            # Shared event schema
 ├── e2e/                    # Integration tests
 ├── charts/bsdm/            # Helm chart (K8s proxy Deployment)
@@ -35,8 +37,8 @@ bsdm-proxy/
 ├── prometheus/             # Scrape config
 ├── web-config/             # Web UI для генерации .env / compose
 ├── certs/                  # MITM CA (gitignored, генерируется локально)
-├── Dockerfile              # Multi-stage: proxy + cache-indexer targets
-├── docker-compose.yml      # Полный стек (proxy, Kafka, ClickHouse, monitoring)
+├── Dockerfile              # Multi-stage: proxy + cache-indexer + alert-worker
+├── docker-compose.yml      # Полный стек (+ profile `alerts`)
 ├── docker-compose.*.yml    # Профили: test, redis-l2, hierarchy, ha
 └── AGENTS.md               # Инструкции для Cursor Cloud Agent
 ```
@@ -45,7 +47,7 @@ bsdm-proxy/
 
 | Файл | Сервисы |
 |------|---------|
-| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, grafana |
+| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, grafana; optional `alert-worker` (`--profile alerts`) |
 | `docker-compose.test.yml` | Минимальный стек для smoke/E2E |
 | `docker-compose.redis-l2.yml` | 2× proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -10,6 +10,7 @@
 |------|-------------|
 | `bin/proxy` | HTTPS caching proxy |
 | `bin/cache-indexer` | Kafka → ClickHouse indexer |
+| `bin/alert-worker` | ClickHouse → SIEM/webhook alerts (optional) |
 | `config/*.example` | Environment and ACL templates |
 | `systemd/` | systemd unit files |
 | `install.sh` | Installer script |

--- a/packaging/config/alert-worker.env.example
+++ b/packaging/config/alert-worker.env.example
@@ -1,0 +1,24 @@
+# BSDM-Proxy alert-worker configuration
+# Copy to /etc/bsdm-proxy/alert-worker.env and set ALERT_WEBHOOK_URL.
+# Docs: docs/alerting.md
+
+ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm
+# ALERT_WEBHOOK_HEADERS={"Authorization":"Bearer CHANGE_ME"}
+# ALERT_WEBHOOK_TIMEOUT_SECS=10
+
+CLICKHOUSE_URL=http://127.0.0.1:8123
+CLICKHOUSE_DATABASE=bsdm
+CLICKHOUSE_TABLE=http_cache
+# CLICKHOUSE_USER=default
+# CLICKHOUSE_PASSWORD=
+
+ALERT_POLL_INTERVAL_SECS=60
+ALERT_LOOKBACK_SECS=300
+ALERT_DEDUPE_TTL_SECS=3600
+ALERT_RULES=blocked_burst,domain_burst,off_hours_threat,high_entropy_domain
+# ALERT_BLOCKED_BURST_THRESHOLD=10
+# ALERT_DOMAIN_BURST_THRESHOLD=50
+
+METRICS_PORT=8090
+RUST_LOG=info,alert_worker=info
+RUST_BACKTRACE=0

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -75,6 +75,7 @@ fi
 install -d -m 0755 "${PREFIX}/bin"
 install -m 0755 "${SCRIPT_DIR}/bin/proxy" "${PREFIX}/bin/proxy"
 install -m 0755 "${SCRIPT_DIR}/bin/cache-indexer" "${PREFIX}/bin/cache-indexer"
+install -m 0755 "${SCRIPT_DIR}/bin/alert-worker" "${PREFIX}/bin/alert-worker"
 
 install -d -m 0755 "${ETC_DIR}"
 if [[ ! -f "${ETC_DIR}/bsdm-proxy.env" ]]; then
@@ -84,6 +85,10 @@ fi
 if [[ ! -f "${ETC_DIR}/cache-indexer.env" ]]; then
   install -m 0640 "${SCRIPT_DIR}/config/cache-indexer.env.example" "${ETC_DIR}/cache-indexer.env"
   echo "Installed ${ETC_DIR}/cache-indexer.env"
+fi
+if [[ ! -f "${ETC_DIR}/alert-worker.env" ]]; then
+  install -m 0640 "${SCRIPT_DIR}/config/alert-worker.env.example" "${ETC_DIR}/alert-worker.env"
+  echo "Installed ${ETC_DIR}/alert-worker.env"
 fi
 if [[ ! -f "${ETC_DIR}/acl-rules.json" ]]; then
   install -m 0644 "${SCRIPT_DIR}/config/acl-rules.example.json" "${ETC_DIR}/acl-rules.json"
@@ -97,7 +102,7 @@ if $CREATE_USER; then
 fi
 
 if $INSTALL_SYSTEMD; then
-  for unit in bsdm-proxy bsdm-cache-indexer; do
+  for unit in bsdm-proxy bsdm-cache-indexer bsdm-alert-worker; do
     sed "s|/opt/bsdm-proxy|${PREFIX}|g" \
       "${SCRIPT_DIR}/systemd/${unit}.service" \
       >"/etc/systemd/system/${unit}.service"
@@ -106,6 +111,7 @@ if $INSTALL_SYSTEMD; then
   echo "Systemd units installed. Start with:"
   echo "  systemctl enable --now bsdm-proxy"
   echo "  systemctl enable --now bsdm-cache-indexer  # optional"
+  echo "  systemctl enable --now bsdm-alert-worker   # optional; set ALERT_WEBHOOK_URL first"
 fi
 
 cat <<EOF

--- a/packaging/systemd/bsdm-alert-worker.service
+++ b/packaging/systemd/bsdm-alert-worker.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=BSDM-Proxy alert-worker (ClickHouse to SIEM webhook)
+Documentation=https://github.com/onixus/bsdm-proxy/blob/main/docs/alerting.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bsdm-proxy
+Group=bsdm-proxy
+EnvironmentFile=-/etc/bsdm-proxy/alert-worker.env
+ExecStart=/opt/bsdm-proxy/bin/alert-worker
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -20,6 +20,14 @@ scrape_configs:
           service: 'cache-indexer'
           component: 'bsdm-indexer'
 
+  # Present when compose profile `alerts` is enabled (scrapes fail quietly otherwise).
+  - job_name: 'alert-worker'
+    static_configs:
+      - targets: ['alert-worker:8090']
+        labels:
+          service: 'alert-worker'
+          component: 'bsdm-alerts'
+
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']

--- a/scripts/alert-worker/webhook-echo.py
+++ b/scripts/alert-worker/webhook-echo.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Minimal webhook echo receiver for local alert-worker tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body.decode("utf-8"))
+            print(json.dumps(payload, indent=2, ensure_ascii=False), flush=True)
+        except Exception as exc:  # noqa: BLE001
+            print(f"raw body ({exc}): {body!r}", flush=True)
+        self.send_response(204)
+        self.end_headers()
+
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        sys.stderr.write("%s - %s\n" % (self.address_string(), fmt % args))
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 9080
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    print(f"listening on http://0.0.0.0:{port}", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -15,13 +15,13 @@ PACKAGE_NAME="bsdm-proxy-${PACKAGE_VERSION}-${OS}-${ARCH}"
 STAGING="${ROOT}/dist/${PACKAGE_NAME}"
 
 echo "==> Building release binaries (v${VERSION})"
-cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer
+cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer -p alert-worker --bin alert-worker
 
 echo "==> Assembling package ${PACKAGE_NAME}"
 rm -rf "$STAGING"
 mkdir -p "$STAGING"/{bin,config,systemd}
 
-cp target/release/proxy target/release/cache-indexer "$STAGING/bin/"
+cp target/release/proxy target/release/cache-indexer target/release/alert-worker "$STAGING/bin/"
 cp packaging/config/*.example "$STAGING/config/"
 cp config/acl-rules.example.json "$STAGING/config/"
 cp packaging/systemd/*.service "$STAGING/systemd/"

--- a/scripts/clickhouse/m4_threat_queries.sql
+++ b/scripts/clickhouse/m4_threat_queries.sql
@@ -42,3 +42,6 @@
 -- GROUP BY domain
 -- ORDER BY requests DESC
 -- LIMIT 50;
+
+-- Wired into alert-worker rules (blocked_burst, domain_burst, off_hours_threat,
+-- high_entropy_domain). See docs/alerting.md and cargo crate alert-worker/.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`alert-worker`**: polls ClickHouse `bsdm.http_cache`, evaluates M4 starter rules, dedupes by fingerprint, and POSTs SIEM-friendly JSON to `ALERT_WEBHOOK_URL`.

Closes the custom webhook path for blocker **B19** / issue **#50** (OpenSearch Alerting is obsolete after the CH migration).

## What’s included

- New workspace crate `alert-worker` with rules: `blocked_burst`, `domain_burst`, `off_hours_threat`, `high_entropy_domain`
- `/metrics` + `/health` on `METRICS_PORT` (default 8090)
- Dockerfile target `alert-worker`
- Compose profile `alerts` + Prometheus scrape job
- Packaging: binary, `alert-worker.env.example`, `bsdm-alert-worker.service`
- Docs: [`docs/alerting.md`](docs/alerting.md); roadmap/BLOCKERS updated

## Usage

```bash
ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm \
  docker compose --profile alerts up -d --build alert-worker
```

## Связанные issue

- [x] `Closes #50`
- Milestone / блокер: M4, **B19**

## Testing

```bash
cargo test -p alert-worker
cargo clippy -p alert-worker --all-targets -- -D warnings
cargo fmt --check -p alert-worker
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена
- [x] `docs/BLOCKERS.md` / `docs/roadmap.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

