### PR TITLE
feat(lite): SQLite/memory INDEX_STORE + HTTP event sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Lite SQLite indexer** — `INDEX_STORE=sqlite|memory`, `POST /api/events`, proxy `EVENT_SINK_URL`; Lite compose includes indexer ([#Lite](docs/lite.md))
 - **Lite compose (Phase 1)** — [`docker-compose.lite.yml`](docker-compose.lite.yml) standalone proxy (no Kafka/CH); [`scripts/gen-ca.sh`](scripts/gen-ca.sh); docs [`docs/lite.md`](docs/lite.md)
 - **Alert worker (B19 / #50)** — `alert-worker` polls ClickHouse threat rules and POSTs SIEM JSON webhooks; compose profile `alerts`, Dockerfile target, Prometheus scrape, docs [`docs/alerting.md`](docs/alerting.md)
 - **Strategic roadmap** — Lite / DX / Wasm / AI-traffic phases in [`docs/strategic-roadmap.md`](docs/strategic-roadmap.md); linked from README and [`docs/roadmap.md`](docs/roadmap.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +430,7 @@ dependencies = [
  "prometheus",
  "rdkafka",
  "reqwest 0.13.4",
+ "rusqlite",
  "serde",
  "serde_json",
  "tokio",
@@ -838,6 +851,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,9 +1107,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hex"
@@ -1364,7 +1407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1531,6 +1574,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libz-sys"
@@ -2218,7 +2272,7 @@ checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
  "equivalent",
  "foldhash",
- "hashbrown",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
@@ -2608,6 +2662,20 @@ dependencies = [
  "signature",
  "spki",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ CMD ["proxy"]
 FROM alpine:3.21 AS cache-indexer
 RUN apk add --no-cache \
     ca-certificates \
-    libgcc
+    libgcc \
+    wget
 
 # Копируем скомпилированный бинарник
 COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/cache-indexer /usr/local/bin/cache-indexer

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 
 | Фаза | Фокус |
 |------|--------|
-| **1. Lite** | Прокси без обязательных Kafka/ClickHouse; SQLite/in-memory; `docker-compose.lite.yml` ([docs/lite.md](docs/lite.md) — compose shipped) |
+| **1. Lite** | Прокси без обязательных Kafka/ClickHouse; SQLite Search API; `docker-compose.lite.yml` ([docs/lite.md](docs/lite.md)) |
 | **2. DX** | Control Plane API, hot reload, cache purge, lite metrics без Grafana |
 | **3. Wasm** | Wasmtime-плагины, SDK, модульность ядра |
 | **4. AI-трафик** | Token-bucket RL, semantic cache для LLM, request coalescing |

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -24,3 +24,4 @@ prometheus = "0.14"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 bytes = { workspace = true }
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/cache-indexer/src/admin_server.rs
+++ b/cache-indexer/src/admin_server.rs
@@ -1,4 +1,4 @@
-//! HTTP admin server: /metrics, /health, /api/search
+//! HTTP admin server: /metrics, /health, /api/search, /api/events
 
 use crate::metrics::IndexerMetrics;
 use crate::search_api::SearchApi;
@@ -22,12 +22,11 @@ pub async fn run_admin_server(
             return;
         }
     };
-    let search_note = if search_api.is_some() {
-        ", /api/search"
-    } else {
-        ""
+    let extras = match &search_api {
+        Some(_) => ", /api/search, /api/events",
+        None => "",
     };
-    info!("cache-indexer admin on {bind_addr} (/metrics, /health{search_note})");
+    info!("cache-indexer admin on {bind_addr} (/metrics, /health{extras})");
 
     loop {
         let Ok((mut socket, _)) = listener.accept().await else {
@@ -36,24 +35,76 @@ pub async fn run_admin_server(
         let metrics = metrics.clone();
         let search_api = search_api.clone();
         tokio::spawn(async move {
-            let mut buf = vec![0u8; 8192];
+            let mut buf = vec![0u8; 64 * 1024];
             let n = socket.read(&mut buf).await.unwrap_or(0);
             if n == 0 {
                 return;
             }
-            let req = String::from_utf8_lossy(&buf[..n]);
-            let response = handle_request(&req, &metrics, search_api.as_deref()).await;
+            let (header_end, content_length) = match parse_header_end_and_cl(&buf[..n]) {
+                Some(v) => v,
+                None => {
+                    let _ = socket
+                        .write_all(&http_response(400, "text/plain", b"bad request"))
+                        .await;
+                    return;
+                }
+            };
+            let mut body = if header_end < n {
+                buf[header_end..n].to_vec()
+            } else {
+                Vec::new()
+            };
+            while body.len() < content_length {
+                let mut chunk = vec![0u8; 64 * 1024];
+                let m = socket.read(&mut chunk).await.unwrap_or(0);
+                if m == 0 {
+                    break;
+                }
+                body.extend_from_slice(&chunk[..m]);
+                if body.len() >= content_length {
+                    break;
+                }
+            }
+            if body.len() > content_length {
+                body.truncate(content_length);
+            }
+            let header = String::from_utf8_lossy(&buf[..header_end.min(n)]);
+            let response = handle_request(&header, &body, &metrics, search_api.as_deref()).await;
             let _ = socket.write_all(&response).await;
         });
     }
 }
 
+fn parse_header_end_and_cl(buf: &[u8]) -> Option<(usize, usize)> {
+    let header_end = find_header_end(buf)?;
+    let header = std::str::from_utf8(&buf[..header_end]).ok()?;
+    let mut content_length = 0usize;
+    for line in header.lines().skip(1) {
+        if line.is_empty() {
+            break;
+        }
+        if let Some(v) = line
+            .strip_prefix("Content-Length:")
+            .or_else(|| line.strip_prefix("content-length:"))
+        {
+            content_length = v.trim().parse().unwrap_or(0);
+        }
+    }
+    // Cap POST body for ingest to 4 MiB
+    Some((header_end, content_length.min(4 * 1024 * 1024)))
+}
+
+fn find_header_end(buf: &[u8]) -> Option<usize> {
+    buf.windows(4).position(|w| w == b"\r\n\r\n").map(|i| i + 4)
+}
+
 async fn handle_request(
-    req: &str,
+    header: &str,
+    body: &[u8],
     metrics: &IndexerMetrics,
     search_api: Option<&SearchApi>,
 ) -> Vec<u8> {
-    let mut lines = req.lines();
+    let mut lines = header.lines();
     let Some(request_line) = lines.next() else {
         return http_response(400, "text/plain", b"bad request");
     };
@@ -99,17 +150,38 @@ async fn handle_request(
             return http_response(401, "application/json", br#"{"error":"unauthorized"}"#);
         }
         let query = parse_query_string(path_query);
-        match api.handle_get(&query).await {
+        return match api.handle_get(&query).await {
             Ok((code, content_type, body)) => http_response(code, &content_type, &body),
             Err(e) => {
                 warn!("search api error: {e}");
                 let msg = format!(r#"{{"error":"{}"}}"#, escape_json(&e.to_string()));
                 http_response(500, "application/json", msg.as_bytes())
             }
-        }
-    } else {
-        http_response(404, "text/plain", b"not found")
+        };
     }
+
+    if method == "POST" && path_query.starts_with("/api/events") {
+        let Some(api) = search_api else {
+            return http_response(
+                404,
+                "application/json",
+                br#"{"error":"ingest api disabled"}"#,
+            );
+        };
+        if !api.is_ingest_authorized(auth.as_deref()) {
+            return http_response(401, "application/json", br#"{"error":"unauthorized"}"#);
+        }
+        return match api.handle_ingest(body).await {
+            Ok((code, content_type, body)) => http_response(code, &content_type, &body),
+            Err(e) => {
+                warn!("ingest api error: {e}");
+                let msg = format!(r#"{{"error":"{}"}}"#, escape_json(&e.to_string()));
+                http_response(400, "application/json", msg.as_bytes())
+            }
+        };
+    }
+
+    http_response(404, "text/plain", b"not found")
 }
 
 fn parse_query_string(path_query: &str) -> HashMap<String, String> {
@@ -155,6 +227,7 @@ fn escape_json(s: &str) -> String {
 fn http_response(status_code: u16, content_type: &str, body: &[u8]) -> Vec<u8> {
     let status = match status_code {
         200 => "200 OK",
+        202 => "202 Accepted",
         400 => "400 Bad Request",
         401 => "401 Unauthorized",
         404 => "404 Not Found",
@@ -179,5 +252,13 @@ mod tests {
         let q = parse_query_string("/api/search?domain=example.com&limit=10");
         assert_eq!(q.get("domain").map(String::as_str), Some("example.com"));
         assert_eq!(q.get("limit").map(String::as_str), Some("10"));
+    }
+
+    #[test]
+    fn finds_header_end() {
+        let req = b"POST /api/events HTTP/1.1\r\nContent-Length: 2\r\n\r\n{}";
+        let (end, cl) = parse_header_end_and_cl(req).unwrap();
+        assert_eq!(cl, 2);
+        assert!(end > 10);
     }
 }

--- a/cache-indexer/src/clickhouse.rs
+++ b/cache-indexer/src/clickhouse.rs
@@ -2,15 +2,8 @@
 
 use bsdm_events::json_each_row_lines;
 use bsdm_events::CacheEvent;
-use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
-use rdkafka::message::Message;
 use reqwest::Client;
-use std::sync::Arc;
-use std::time::Instant;
-use tracing::{error, info, warn};
-
-use crate::kafka::create_consumer;
-use crate::metrics::IndexerMetrics;
+use tracing::{error, info};
 
 pub struct ClickHouseConfig {
     pub url: String,
@@ -132,96 +125,6 @@ impl ClickHouseWriter {
             let err_body = response.text().await.unwrap_or_default();
             error!("ClickHouse insert failed (HTTP {}): {}", status, err_body);
             Err(format!("ClickHouse insert failed: {err_body}").into())
-        }
-    }
-}
-
-pub struct ClickHouseIndexer {
-    writer: Arc<ClickHouseWriter>,
-    consumer: StreamConsumer,
-    metrics: Arc<IndexerMetrics>,
-}
-
-impl ClickHouseIndexer {
-    pub async fn new(
-        kafka_brokers: &str,
-        kafka_topic: &str,
-        kafka_group: &str,
-        writer: Arc<ClickHouseWriter>,
-        metrics: Arc<IndexerMetrics>,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let consumer = create_consumer(kafka_brokers, kafka_topic, kafka_group)?;
-        Ok(Self {
-            writer,
-            consumer,
-            metrics,
-        })
-    }
-
-    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
-        let mut batch: Vec<CacheEvent> = Vec::new();
-        let batch_size = 50;
-        let batch_timeout = std::time::Duration::from_secs(5);
-        let mut last_commit = tokio::time::Instant::now();
-
-        loop {
-            match tokio::time::timeout(batch_timeout, self.consumer.recv()).await {
-                Ok(Ok(message)) => {
-                    if let Some(payload) = message.payload() {
-                        match serde_json::from_slice::<CacheEvent>(payload) {
-                            Ok(event) => {
-                                batch.push(event);
-                                if batch.len() >= batch_size {
-                                    self.flush_batch(&batch).await?;
-                                    batch.clear();
-                                    self.consumer.commit_consumer_state(CommitMode::Async)?;
-                                    last_commit = tokio::time::Instant::now();
-                                }
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Failed to parse event: {} - Payload: {}",
-                                    e,
-                                    String::from_utf8_lossy(payload)
-                                );
-                            }
-                        }
-                    }
-                }
-                Ok(Err(e)) => {
-                    error!("Kafka error: {}", e);
-                }
-                Err(_) => {
-                    if !batch.is_empty() {
-                        self.flush_batch(&batch).await?;
-                        batch.clear();
-                        self.consumer.commit_consumer_state(CommitMode::Async)?;
-                        last_commit = tokio::time::Instant::now();
-                    }
-                }
-            }
-
-            if last_commit.elapsed() > std::time::Duration::from_secs(30) && !batch.is_empty() {
-                self.flush_batch(&batch).await?;
-                batch.clear();
-                self.consumer.commit_consumer_state(CommitMode::Async)?;
-                last_commit = tokio::time::Instant::now();
-            }
-        }
-    }
-
-    async fn flush_batch(&self, batch: &[CacheEvent]) -> Result<(), Box<dyn std::error::Error>> {
-        let started = Instant::now();
-        match self.writer.insert_batch(batch).await {
-            Ok(()) => {
-                self.metrics
-                    .record_success("clickhouse", batch.len(), started);
-                Ok(())
-            }
-            Err(e) => {
-                self.metrics.record_error("clickhouse");
-                Err(e)
-            }
         }
     }
 }

--- a/cache-indexer/src/kafka_ingest.rs
+++ b/cache-indexer/src/kafka_ingest.rs
@@ -1,0 +1,105 @@
+//! Kafka → EventStore consumer (optional when KAFKA_BROKERS is set).
+
+use crate::kafka::create_consumer;
+use crate::metrics::IndexerMetrics;
+use crate::store::EventStore;
+use bsdm_events::CacheEvent;
+use rdkafka::consumer::{CommitMode, Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use std::sync::Arc;
+use std::time::Instant;
+use tracing::{error, warn};
+
+pub struct KafkaStoreIndexer {
+    store: Arc<EventStore>,
+    consumer: StreamConsumer,
+    metrics: Arc<IndexerMetrics>,
+}
+
+impl KafkaStoreIndexer {
+    pub async fn new(
+        kafka_brokers: &str,
+        kafka_topic: &str,
+        kafka_group: &str,
+        store: Arc<EventStore>,
+        metrics: Arc<IndexerMetrics>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let consumer = create_consumer(kafka_brokers, kafka_topic, kafka_group)?;
+        Ok(Self {
+            store,
+            consumer,
+            metrics,
+        })
+    }
+
+    pub async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut batch: Vec<CacheEvent> = Vec::new();
+        let batch_size = 50;
+        let batch_timeout = std::time::Duration::from_secs(5);
+        let mut last_commit = tokio::time::Instant::now();
+        let backend = self.store.backend_name();
+
+        loop {
+            match tokio::time::timeout(batch_timeout, self.consumer.recv()).await {
+                Ok(Ok(message)) => {
+                    if let Some(payload) = message.payload() {
+                        match serde_json::from_slice::<CacheEvent>(payload) {
+                            Ok(event) => {
+                                batch.push(event);
+                                if batch.len() >= batch_size {
+                                    self.flush_batch(&batch, backend).await?;
+                                    batch.clear();
+                                    self.consumer.commit_consumer_state(CommitMode::Async)?;
+                                    last_commit = tokio::time::Instant::now();
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse event: {} - Payload: {}",
+                                    e,
+                                    String::from_utf8_lossy(payload)
+                                );
+                            }
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    error!("Kafka error: {}", e);
+                }
+                Err(_) => {
+                    if !batch.is_empty() {
+                        self.flush_batch(&batch, backend).await?;
+                        batch.clear();
+                        self.consumer.commit_consumer_state(CommitMode::Async)?;
+                        last_commit = tokio::time::Instant::now();
+                    }
+                }
+            }
+
+            if last_commit.elapsed() > std::time::Duration::from_secs(30) && !batch.is_empty() {
+                self.flush_batch(&batch, backend).await?;
+                batch.clear();
+                self.consumer.commit_consumer_state(CommitMode::Async)?;
+                last_commit = tokio::time::Instant::now();
+            }
+        }
+    }
+
+    async fn flush_batch(
+        &self,
+        batch: &[CacheEvent],
+        backend: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let started = Instant::now();
+        match self.store.insert_batch(batch).await {
+            Ok(()) => {
+                self.metrics.record_success(backend, batch.len(), started);
+                Ok(())
+            }
+            Err(e) => {
+                self.metrics.record_error(backend);
+                Err(e.to_string().into())
+            }
+        }
+    }
+}

--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -1,14 +1,18 @@
 mod admin_server;
 mod clickhouse;
 mod kafka;
+mod kafka_ingest;
 mod metrics;
 mod search_api;
+mod store;
 
 use admin_server::run_admin_server;
-use clickhouse::{load_config_from_env, ClickHouseIndexer, ClickHouseWriter};
+use clickhouse::{load_config_from_env, ClickHouseWriter};
+use kafka_ingest::KafkaStoreIndexer;
 use metrics::IndexerMetrics;
 use search_api::{SearchApi, SearchApiConfig};
 use std::sync::Arc;
+use store::EventStore;
 use tracing::info;
 
 fn metrics_port() -> u16 {
@@ -25,11 +29,21 @@ fn search_api_enabled() -> bool {
     true
 }
 
-async fn bootstrap_clickhouse_writer() -> Result<Arc<ClickHouseWriter>, Box<dyn std::error::Error>>
-{
-    Ok(Arc::new(
-        ClickHouseWriter::bootstrap(load_config_from_env()).await?,
-    ))
+fn index_store_kind() -> String {
+    std::env::var("INDEX_STORE")
+        .unwrap_or_else(|_| "clickhouse".into())
+        .to_ascii_lowercase()
+}
+
+async fn bootstrap_store() -> Result<Arc<EventStore>, Box<dyn std::error::Error>> {
+    match index_store_kind().as_str() {
+        "clickhouse" => {
+            let writer = Arc::new(ClickHouseWriter::bootstrap(load_config_from_env()).await?);
+            Ok(Arc::new(EventStore::ClickHouse(writer)))
+        }
+        "memory" | "sqlite" => store::open_from_env().map_err(|e| e.to_string().into()),
+        other => Err(format!("unknown INDEX_STORE={other}").into()),
+    }
 }
 
 #[tokio::main]
@@ -41,15 +55,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
-    let kafka_brokers = std::env::var("KAFKA_BROKERS").unwrap_or_else(|_| "kafka:9092".to_string());
+    let kafka_brokers = std::env::var("KAFKA_BROKERS")
+        .ok()
+        .filter(|s| !s.is_empty());
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
     let kafka_group =
         std::env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "cache-indexer-group".to_string());
     let metrics = Arc::new(IndexerMetrics::new()?);
-    let ch_writer = bootstrap_clickhouse_writer().await?;
+    let store = bootstrap_store().await?;
+    let backend = store.backend_name();
+
     let search_api = if search_api_enabled() {
         Some(Arc::new(SearchApi::new(
-            ch_writer.clone(),
+            store.clone(),
             SearchApiConfig::from_env(),
         )))
     } else {
@@ -64,26 +82,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
     };
 
-    info!("Starting cache-indexer (backend=clickhouse)");
-    info!("ClickHouse URL: {}", load_config_from_env().url);
-    info!("Kafka brokers: {kafka_brokers}");
-    info!("Kafka topic: {kafka_topic}");
-    info!("Kafka group: {kafka_group}");
+    info!("Starting cache-indexer (backend={backend})");
+    if backend == "clickhouse" {
+        info!("ClickHouse URL: {}", load_config_from_env().url);
+    }
     info!("Admin port: {port}");
     if search_api.is_some() {
-        info!("Search API enabled on :{port}/api/search");
+        info!("Search API on :{port}/api/search · ingest POST :{port}/api/events");
     }
 
-    let indexer = ClickHouseIndexer::new(
-        &kafka_brokers,
-        &kafka_topic,
-        &kafka_group,
-        ch_writer,
-        metrics,
-    )
-    .await?;
+    let result = if let Some(brokers) = kafka_brokers {
+        info!("Kafka brokers: {brokers}");
+        info!("Kafka topic: {kafka_topic}");
+        info!("Kafka group: {kafka_group}");
+        let indexer =
+            KafkaStoreIndexer::new(&brokers, &kafka_topic, &kafka_group, store, metrics).await?;
+        indexer.run().await
+    } else {
+        info!("KAFKA_BROKERS unset — HTTP ingest only (POST /api/events)");
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    };
 
-    let result = indexer.run().await;
     admin_task.abort();
     result
 }

--- a/cache-indexer/src/search_api.rs
+++ b/cache-indexer/src/search_api.rs
@@ -1,6 +1,7 @@
-//! REST Search API over ClickHouse (`/api/search` on cache-indexer admin port).
+//! REST Search API (`/api/search`) and HTTP ingest (`/api/events`).
 
-use crate::clickhouse::ClickHouseWriter;
+use crate::store::{EventStore, SearchQuery};
+use bsdm_events::CacheEvent;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::warn;
@@ -8,6 +9,7 @@ use tracing::warn;
 #[derive(Clone)]
 pub struct SearchApiConfig {
     pub api_token: Option<String>,
+    pub ingest_token: Option<String>,
     pub max_limit: u32,
     pub default_days: u32,
 }
@@ -17,6 +19,10 @@ impl SearchApiConfig {
         let api_token = std::env::var("SEARCH_API_TOKEN")
             .ok()
             .filter(|t| !t.is_empty());
+        let ingest_token = std::env::var("INGEST_API_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .or_else(|| api_token.clone());
         let max_limit = std::env::var("SEARCH_API_MAX_LIMIT")
             .ok()
             .and_then(|v| v.parse().ok())
@@ -27,6 +33,7 @@ impl SearchApiConfig {
             .unwrap_or(30);
         Self {
             api_token,
+            ingest_token,
             max_limit,
             default_days,
         }
@@ -34,28 +41,21 @@ impl SearchApiConfig {
 }
 
 pub struct SearchApi {
-    clickhouse: Arc<ClickHouseWriter>,
+    store: Arc<EventStore>,
     config: SearchApiConfig,
-    table_fqn: String,
 }
 
 impl SearchApi {
-    pub fn new(clickhouse: Arc<ClickHouseWriter>, config: SearchApiConfig) -> Self {
-        let table_fqn = format!("{}.{}", clickhouse.database(), clickhouse.table());
-        Self {
-            clickhouse,
-            config,
-            table_fqn,
-        }
+    pub fn new(store: Arc<EventStore>, config: SearchApiConfig) -> Self {
+        Self { store, config }
     }
 
     pub fn is_authorized(&self, auth_header: Option<&str>) -> bool {
-        let Some(expected) = &self.config.api_token else {
-            return true;
-        };
-        auth_header
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .is_some_and(|token| token == expected)
+        check_bearer(self.config.api_token.as_deref(), auth_header)
+    }
+
+    pub fn is_ingest_authorized(&self, auth_header: Option<&str>) -> bool {
+        check_bearer(self.config.ingest_token.as_deref(), auth_header)
     }
 
     pub async fn handle_get(
@@ -88,58 +88,60 @@ impl SearchApi {
             .unwrap_or(now);
 
         let format = query.get("format").map(String::as_str).unwrap_or("json");
-        let order = if session_id.is_empty() {
-            "ts DESC"
-        } else {
-            // Session timeline: chronological redirect chain
-            "ts ASC"
+        let search = SearchQuery {
+            from_ts: from,
+            to_ts: to,
+            domain,
+            username,
+            session_id: session_id.clone(),
+            limit,
+            session_timeline: !session_id.is_empty(),
         };
 
-        let sql = format!(
-            "SELECT ts, username, client_ip, url, method, status, cache_status, domain, \
-             event_id, session_id, parent_event_id, redirect_url \
-             FROM {table} \
-             WHERE ts >= fromUnixTimestamp({{from:UInt32}}) \
-               AND ts <= fromUnixTimestamp({{to:UInt32}}) \
-               AND (length({{domain:String}}) = 0 OR domain = {{domain:String}}) \
-               AND (length({{username:String}}) = 0 OR username = {{username:String}}) \
-               AND (length({{session_id:String}}) = 0 OR session_id = {{session_id:String}}) \
-             ORDER BY {order} \
-             LIMIT {{limit:UInt32}} \
-             FORMAT JSONEachRow",
-            table = self.table_fqn,
-            order = order
-        );
-
-        let params = vec![
-            ("from", from.to_string()),
-            ("to", to.to_string()),
-            ("domain", domain),
-            ("username", username),
-            ("session_id", session_id),
-            ("limit", limit.to_string()),
-        ];
-
-        let body = self.clickhouse.query_with_params(&sql, &params).await?;
-
+        let hits = self
+            .store
+            .search(&search)
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
         if format == "csv" {
-            let csv = json_each_row_to_csv(&body)?;
+            let csv = hits_to_csv(&hits);
             return Ok((200, "text/csv; charset=utf-8".to_string(), csv.into_bytes()));
         }
 
-        let json = if body.trim().is_empty() {
-            "[]".to_string()
-        } else {
-            let rows: Vec<serde_json::Value> = body
-                .lines()
-                .filter(|l| !l.trim().is_empty())
-                .filter_map(|line| serde_json::from_str(line).ok())
-                .collect();
-            serde_json::to_string(&rows)?
-        };
-
+        let rows: Vec<serde_json::Value> = hits.iter().map(|h| h.to_json()).collect();
+        let json = serde_json::to_string(&rows)?;
         Ok((200, "application/json".to_string(), json.into_bytes()))
     }
+
+    pub async fn handle_ingest(
+        &self,
+        body: &[u8],
+    ) -> Result<(u16, String, Vec<u8>), Box<dyn std::error::Error>> {
+        let events = parse_ingest_body(body)?;
+        if events.is_empty() {
+            return Ok((
+                400,
+                "application/json".into(),
+                br#"{"error":"no events"}"#.to_vec(),
+            ));
+        }
+        let n = events.len();
+        self.store
+            .insert_batch(&events)
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+        let msg = format!(r#"{{"accepted":{n}}}"#);
+        Ok((202, "application/json".into(), msg.into_bytes()))
+    }
+}
+
+fn check_bearer(expected: Option<&str>, auth_header: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    auth_header
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .is_some_and(|token| token == expected)
 }
 
 fn sanitize_filter(value: &str) -> String {
@@ -157,46 +159,88 @@ fn sanitize_filter(value: &str) -> String {
     }
 }
 
-fn json_each_row_to_csv(ndjson: &str) -> Result<String, Box<dyn std::error::Error>> {
-    let mut lines = ndjson.lines().filter(|l| !l.trim().is_empty());
-    let Some(first) = lines.next() else {
-        return Ok(String::new());
-    };
-    let row: serde_json::Map<String, serde_json::Value> = serde_json::from_str(first)?;
-    let headers: Vec<&str> = row.keys().map(String::as_str).collect();
-    let mut out = headers.join(",");
-    out.push('\n');
-    out.push_str(&csv_row(&row, &headers));
-    for line in lines {
-        let row: serde_json::Map<String, serde_json::Value> = serde_json::from_str(line)?;
-        out.push('\n');
-        out.push_str(&csv_row(&row, &headers));
+pub fn parse_ingest_body(body: &[u8]) -> Result<Vec<CacheEvent>, Box<dyn std::error::Error>> {
+    let text = std::str::from_utf8(body)?;
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    if trimmed.starts_with('[') {
+        return Ok(serde_json::from_str(trimmed)?);
+    }
+    if trimmed.starts_with('{') {
+        // Single object or {"events":[...]}
+        let v: serde_json::Value = serde_json::from_str(trimmed)?;
+        if let Some(arr) = v.get("events").and_then(|e| e.as_array()) {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                out.push(serde_json::from_value(item.clone())?);
+            }
+            return Ok(out);
+        }
+        return Ok(vec![serde_json::from_value(v)?]);
+    }
+    // NDJSON
+    let mut out = Vec::new();
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        out.push(serde_json::from_str(line)?);
     }
     Ok(out)
 }
 
-fn csv_row(row: &serde_json::Map<String, serde_json::Value>, headers: &[&str]) -> String {
-    headers
-        .iter()
-        .map(|h| {
-            let v = row.get(*h).map(value_to_csv).unwrap_or_default();
-            if v.contains(',') || v.contains('"') {
-                format!("\"{}\"", v.replace('"', "\"\""))
-            } else {
-                v
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(",")
-}
-
-fn value_to_csv(v: &serde_json::Value) -> String {
-    match v {
-        serde_json::Value::String(s) => s.clone(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Null => String::new(),
-        other => other.to_string(),
+fn hits_to_csv(hits: &[crate::store::SearchHit]) -> String {
+    let headers = [
+        "ts",
+        "username",
+        "client_ip",
+        "url",
+        "method",
+        "status",
+        "cache_status",
+        "domain",
+        "event_id",
+        "session_id",
+        "parent_event_id",
+        "redirect_url",
+    ];
+    let mut out = headers.join(",");
+    out.push('\n');
+    for (i, h) in hits.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        let row = [
+            h.ts.to_string(),
+            h.username.clone().unwrap_or_default(),
+            h.client_ip.clone(),
+            h.url.clone(),
+            h.method.clone(),
+            h.status.to_string(),
+            h.cache_status.clone(),
+            h.domain.clone(),
+            h.event_id.clone(),
+            h.session_id.clone(),
+            h.parent_event_id.clone().unwrap_or_default(),
+            h.redirect_url.clone().unwrap_or_default(),
+        ];
+        out.push_str(
+            &row.iter()
+                .map(|v| {
+                    if v.contains(',') || v.contains('"') {
+                        format!("\"{}\"", v.replace('"', "\"\""))
+                    } else {
+                        v.clone()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(","),
+        );
     }
+    out
 }
 
 #[cfg(test)]
@@ -214,10 +258,10 @@ mod tests {
     }
 
     #[test]
-    fn csv_from_ndjson() {
-        let ndjson = "{\"domain\":\"a.com\",\"status\":200}\n";
-        let csv = json_each_row_to_csv(ndjson).unwrap();
-        assert!(csv.contains("domain,status"));
-        assert!(csv.contains("a.com,200"));
+    fn parse_single_and_array() {
+        let one = br#"{"url":"https://a/","method":"GET","status":200,"cache_key":"k","timestamp":1,"client_ip":"1.1.1.1","domain":"a","response_size":0,"request_duration_ms":1,"event_id":"e1"}"#;
+        assert_eq!(parse_ingest_body(one).unwrap().len(), 1);
+        let arr = format!("[{}]", std::str::from_utf8(one).unwrap());
+        assert_eq!(parse_ingest_body(arr.as_bytes()).unwrap().len(), 1);
     }
 }

--- a/cache-indexer/src/store/memory.rs
+++ b/cache-indexer/src/store/memory.rs
@@ -1,0 +1,145 @@
+//! In-memory ring buffer event store (Lite / tests).
+
+use crate::store::{SearchHit, SearchQuery};
+use bsdm_events::{document_id, CacheEvent};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+pub struct MemoryStore {
+    max_rows: usize,
+    rows: Mutex<VecDeque<CacheEvent>>,
+}
+
+impl MemoryStore {
+    pub fn new(max_rows: usize) -> Self {
+        Self {
+            max_rows: max_rows.max(1),
+            rows: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub fn insert_batch(&self, events: &[CacheEvent]) {
+        let mut guard = self.rows.lock().expect("memory store lock");
+        for event in events {
+            let mut e = event.clone();
+            if e.event_id.is_empty() {
+                e.event_id = document_id(&e);
+            }
+            guard.push_back(e);
+            while guard.len() > self.max_rows {
+                guard.pop_front();
+            }
+        }
+    }
+
+    pub fn search(&self, query: &SearchQuery) -> Vec<SearchHit> {
+        let guard = self.rows.lock().expect("memory store lock");
+        let mut hits: Vec<SearchHit> = guard
+            .iter()
+            .filter(|e| e.timestamp >= query.from_ts && e.timestamp <= query.to_ts)
+            .filter(|e| query.domain.is_empty() || e.domain == query.domain)
+            .filter(|e| {
+                query.username.is_empty()
+                    || e.username.as_deref().unwrap_or("") == query.username.as_str()
+            })
+            .filter(|e| query.session_id.is_empty() || e.session_id == query.session_id)
+            .map(event_to_hit)
+            .collect();
+        if query.session_timeline {
+            hits.sort_by_key(|h| h.ts);
+        } else {
+            hits.sort_by_key(|h| std::cmp::Reverse(h.ts));
+        }
+        hits.truncate(query.limit as usize);
+        hits
+    }
+}
+
+fn event_to_hit(e: &CacheEvent) -> SearchHit {
+    SearchHit {
+        ts: e.timestamp,
+        username: e.username.clone(),
+        client_ip: e.client_ip.clone(),
+        url: e.url.clone(),
+        method: e.method.clone(),
+        status: e.status,
+        cache_status: e.cache_status.clone(),
+        domain: e.domain.clone(),
+        event_id: if e.event_id.is_empty() {
+            document_id(e)
+        } else {
+            e.event_id.clone()
+        },
+        session_id: e.session_id.clone(),
+        parent_event_id: e.parent_event_id.clone(),
+        redirect_url: e.redirect_url.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn sample(domain: &str, ts: u64) -> CacheEvent {
+        CacheEvent {
+            url: format!("https://{domain}/"),
+            method: "GET".into(),
+            status: 200,
+            cache_key: "k".into(),
+            cache_status: "MISS".into(),
+            timestamp: ts,
+            headers: HashMap::new(),
+            user_id: None,
+            username: Some("alice".into()),
+            client_ip: "10.0.0.1".into(),
+            domain: domain.into(),
+            response_size: 1,
+            request_duration_ms: 1,
+            content_type: None,
+            user_agent: None,
+            categories: vec![],
+            threat_sources: vec![],
+            acl_action: None,
+            session_id: "s1".into(),
+            parent_event_id: None,
+            redirect_url: None,
+            event_id: format!("e-{ts}"),
+        }
+    }
+
+    #[test]
+    fn filters_and_limits() {
+        let store = MemoryStore::new(100);
+        store.insert_batch(&[sample("a.com", 100), sample("b.com", 200)]);
+        let hits = store.search(&SearchQuery {
+            from_ts: 0,
+            to_ts: 1000,
+            domain: "a.com".into(),
+            username: String::new(),
+            session_id: String::new(),
+            limit: 10,
+            session_timeline: false,
+        });
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].domain, "a.com");
+    }
+
+    #[test]
+    fn rings_at_max() {
+        let store = MemoryStore::new(2);
+        store.insert_batch(&[sample("a.com", 1), sample("a.com", 2), sample("a.com", 3)]);
+        let hits = store.search(&SearchQuery {
+            from_ts: 0,
+            to_ts: 100,
+            domain: String::new(),
+            username: String::new(),
+            session_id: String::new(),
+            limit: 10,
+            session_timeline: true,
+        });
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].ts, 2);
+        assert_eq!(hits[1].ts, 3);
+    }
+}

--- a/cache-indexer/src/store/mod.rs
+++ b/cache-indexer/src/store/mod.rs
@@ -1,0 +1,220 @@
+//! Pluggable event stores for Lite (memory/sqlite) and full (ClickHouse).
+
+mod memory;
+mod sqlite;
+
+pub use memory::MemoryStore;
+pub use sqlite::SqliteStore;
+
+use bsdm_events::CacheEvent;
+use std::sync::Arc;
+
+use crate::clickhouse::ClickHouseWriter;
+
+#[derive(Debug, Clone)]
+pub struct SearchQuery {
+    pub from_ts: u64,
+    pub to_ts: u64,
+    pub domain: String,
+    pub username: String,
+    pub session_id: String,
+    pub limit: u32,
+    pub session_timeline: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchHit {
+    pub ts: u64,
+    pub username: Option<String>,
+    pub client_ip: String,
+    pub url: String,
+    pub method: String,
+    pub status: u16,
+    pub cache_status: String,
+    pub domain: String,
+    pub event_id: String,
+    pub session_id: String,
+    pub parent_event_id: Option<String>,
+    pub redirect_url: Option<String>,
+}
+
+impl SearchHit {
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "ts": self.ts,
+            "username": self.username,
+            "client_ip": self.client_ip,
+            "url": self.url,
+            "method": self.method,
+            "status": self.status,
+            "cache_status": self.cache_status,
+            "domain": self.domain,
+            "event_id": self.event_id,
+            "session_id": self.session_id,
+            "parent_event_id": self.parent_event_id,
+            "redirect_url": self.redirect_url,
+        })
+    }
+}
+
+pub enum EventStore {
+    Memory(MemoryStore),
+    Sqlite(SqliteStore),
+    ClickHouse(Arc<ClickHouseWriter>),
+}
+
+impl EventStore {
+    pub fn backend_name(&self) -> &'static str {
+        match self {
+            Self::Memory(_) => "memory",
+            Self::Sqlite(_) => "sqlite",
+            Self::ClickHouse(_) => "clickhouse",
+        }
+    }
+
+    pub async fn insert_batch(
+        &self,
+        events: &[CacheEvent],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            Self::Memory(s) => {
+                s.insert_batch(events);
+                Ok(())
+            }
+            Self::Sqlite(s) => s.insert_batch(events),
+            Self::ClickHouse(w) => w
+                .insert_batch(events)
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() }),
+        }
+    }
+
+    pub async fn search(
+        &self,
+        query: &SearchQuery,
+    ) -> Result<Vec<SearchHit>, Box<dyn std::error::Error + Send + Sync>> {
+        match self {
+            Self::Memory(s) => Ok(s.search(query)),
+            Self::Sqlite(s) => s.search(query),
+            Self::ClickHouse(w) => search_clickhouse(w, query).await,
+        }
+    }
+}
+
+async fn search_clickhouse(
+    writer: &ClickHouseWriter,
+    query: &SearchQuery,
+) -> Result<Vec<SearchHit>, Box<dyn std::error::Error + Send + Sync>> {
+    let table = format!("{}.{}", writer.database(), writer.table());
+    let order = if query.session_timeline {
+        "ts ASC"
+    } else {
+        "ts DESC"
+    };
+    let sql = format!(
+        "SELECT toUnixTimestamp(ts) AS ts, username, toString(client_ip) AS client_ip, url, method, status, \
+         cache_status, domain, event_id, session_id, parent_event_id, redirect_url \
+         FROM {table} \
+         WHERE ts >= fromUnixTimestamp({{from:UInt32}}) \
+           AND ts <= fromUnixTimestamp({{to:UInt32}}) \
+           AND (length({{domain:String}}) = 0 OR domain = {{domain:String}}) \
+           AND (length({{username:String}}) = 0 OR username = {{username:String}}) \
+           AND (length({{session_id:String}}) = 0 OR session_id = {{session_id:String}}) \
+         ORDER BY {order} \
+         LIMIT {{limit:UInt32}} \
+         FORMAT JSONEachRow"
+    );
+    let params = vec![
+        ("from", query.from_ts.to_string()),
+        ("to", query.to_ts.to_string()),
+        ("domain", query.domain.clone()),
+        ("username", query.username.clone()),
+        ("session_id", query.session_id.clone()),
+        ("limit", query.limit.to_string()),
+    ];
+    let body = writer
+        .query_with_params(&sql, &params)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() })?;
+    parse_search_ndjson(&body)
+}
+
+pub fn parse_search_ndjson(
+    body: &str,
+) -> Result<Vec<SearchHit>, Box<dyn std::error::Error + Send + Sync>> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line)?;
+        out.push(SearchHit {
+            ts: json_u64(&v, "ts").unwrap_or(0),
+            username: json_opt_string(&v, "username"),
+            client_ip: json_string(&v, "client_ip"),
+            url: json_string(&v, "url"),
+            method: json_string(&v, "method"),
+            status: json_u64(&v, "status").unwrap_or(0) as u16,
+            cache_status: json_string(&v, "cache_status"),
+            domain: json_string(&v, "domain"),
+            event_id: json_string(&v, "event_id"),
+            session_id: json_string(&v, "session_id"),
+            parent_event_id: json_opt_string(&v, "parent_event_id"),
+            redirect_url: json_opt_string(&v, "redirect_url"),
+        });
+    }
+    Ok(out)
+}
+
+fn json_string(v: &serde_json::Value, key: &str) -> String {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn json_opt_string(v: &serde_json::Value, key: &str) -> Option<String> {
+    match v.get(key) {
+        Some(serde_json::Value::Null) | None => None,
+        Some(serde_json::Value::String(s)) if s.is_empty() => None,
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(other) => Some(other.to_string()),
+    }
+}
+
+fn json_u64(v: &serde_json::Value, key: &str) -> Option<u64> {
+    v.get(key).and_then(|x| {
+        x.as_u64()
+            .or_else(|| x.as_i64().map(|i| i as u64))
+            .or_else(|| x.as_str().and_then(|s| s.parse().ok()))
+    })
+}
+
+pub fn open_from_env() -> Result<Arc<EventStore>, Box<dyn std::error::Error + Send + Sync>> {
+    let kind = std::env::var("INDEX_STORE")
+        .unwrap_or_else(|_| "clickhouse".into())
+        .to_ascii_lowercase();
+    match kind.as_str() {
+        "memory" => {
+            let max = env_usize("SQLITE_MAX_ROWS", 100_000);
+            Ok(Arc::new(EventStore::Memory(MemoryStore::new(max))))
+        }
+        "sqlite" => {
+            let path = std::env::var("SQLITE_PATH")
+                .unwrap_or_else(|_| "/var/lib/cache-indexer/events.db".into());
+            let max = env_usize("SQLITE_MAX_ROWS", 1_000_000);
+            Ok(Arc::new(EventStore::Sqlite(SqliteStore::open(&path, max)?)))
+        }
+        "clickhouse" => Err("clickhouse store is bootstrapped separately".into()),
+        other => Err(format!("unknown INDEX_STORE={other} (memory|sqlite|clickhouse)").into()),
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(default)
+}

--- a/cache-indexer/src/store/sqlite.rs
+++ b/cache-indexer/src/store/sqlite.rs
@@ -1,0 +1,231 @@
+//! SQLite-backed event store for Lite analytics.
+
+use crate::store::{SearchHit, SearchQuery};
+use bsdm_events::{document_id, CacheEvent};
+use rusqlite::{params, Connection};
+use std::path::Path;
+use std::sync::Mutex;
+
+pub struct SqliteStore {
+    conn: Mutex<Connection>,
+    max_rows: usize,
+}
+
+impl SqliteStore {
+    pub fn open(
+        path: &str,
+        max_rows: usize,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        if path != ":memory:" {
+            if let Some(parent) = Path::new(path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        let conn = Connection::open(path)?;
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS events (
+              event_id TEXT PRIMARY KEY,
+              ts INTEGER NOT NULL,
+              domain TEXT NOT NULL,
+              username TEXT,
+              client_ip TEXT NOT NULL,
+              url TEXT NOT NULL,
+              method TEXT NOT NULL,
+              status INTEGER NOT NULL,
+              cache_status TEXT NOT NULL,
+              session_id TEXT NOT NULL DEFAULT '',
+              parent_event_id TEXT,
+              redirect_url TEXT,
+              payload TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
+            CREATE INDEX IF NOT EXISTS idx_events_domain_ts ON events(domain, ts);
+            CREATE INDEX IF NOT EXISTS idx_events_user_ts ON events(username, ts);
+            CREATE INDEX IF NOT EXISTS idx_events_session_ts ON events(session_id, ts);
+            "#,
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+            max_rows: max_rows.max(1),
+        })
+    }
+
+    pub fn insert_batch(
+        &self,
+        events: &[CacheEvent],
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let mut conn = self.conn.lock().expect("sqlite lock");
+        let tx = conn.transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                r#"
+                INSERT INTO events (
+                  event_id, ts, domain, username, client_ip, url, method, status,
+                  cache_status, session_id, parent_event_id, redirect_url, payload
+                ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
+                ON CONFLICT(event_id) DO UPDATE SET
+                  ts=excluded.ts,
+                  domain=excluded.domain,
+                  username=excluded.username,
+                  client_ip=excluded.client_ip,
+                  url=excluded.url,
+                  method=excluded.method,
+                  status=excluded.status,
+                  cache_status=excluded.cache_status,
+                  session_id=excluded.session_id,
+                  parent_event_id=excluded.parent_event_id,
+                  redirect_url=excluded.redirect_url,
+                  payload=excluded.payload
+                "#,
+            )?;
+            for event in events {
+                let mut e = event.clone();
+                if e.event_id.is_empty() {
+                    e.event_id = document_id(&e);
+                }
+                let payload = serde_json::to_string(&e)?;
+                stmt.execute(params![
+                    e.event_id,
+                    e.timestamp as i64,
+                    e.domain,
+                    e.username,
+                    e.client_ip,
+                    e.url,
+                    e.method,
+                    e.status as i64,
+                    e.cache_status,
+                    e.session_id,
+                    e.parent_event_id,
+                    e.redirect_url,
+                    payload,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        drop(conn);
+
+        let conn = self.conn.lock().expect("sqlite lock");
+        let count: i64 = conn.query_row("SELECT count(*) FROM events", [], |r| r.get(0))?;
+        if count as usize > self.max_rows {
+            let excess = count as usize - self.max_rows;
+            conn.execute(
+                "DELETE FROM events WHERE event_id IN (
+                   SELECT event_id FROM events ORDER BY ts ASC LIMIT ?1
+                 )",
+                params![excess as i64],
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn search(
+        &self,
+        query: &SearchQuery,
+    ) -> Result<Vec<SearchHit>, Box<dyn std::error::Error + Send + Sync>> {
+        let order = if query.session_timeline {
+            "ts ASC"
+        } else {
+            "ts DESC"
+        };
+        let sql = format!(
+            "SELECT ts, username, client_ip, url, method, status, cache_status, domain, \
+             event_id, session_id, parent_event_id, redirect_url \
+             FROM events \
+             WHERE ts >= ?1 AND ts <= ?2 \
+               AND (?3 = '' OR domain = ?3) \
+               AND (?4 = '' OR username = ?4) \
+               AND (?5 = '' OR session_id = ?5) \
+             ORDER BY {order} \
+             LIMIT ?6"
+        );
+        let conn = self.conn.lock().expect("sqlite lock");
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(
+            params![
+                query.from_ts as i64,
+                query.to_ts as i64,
+                query.domain,
+                query.username,
+                query.session_id,
+                query.limit as i64,
+            ],
+            |row| {
+                Ok(SearchHit {
+                    ts: row.get::<_, i64>(0)? as u64,
+                    username: row.get(1)?,
+                    client_ip: row.get(2)?,
+                    url: row.get(3)?,
+                    method: row.get(4)?,
+                    status: row.get::<_, i64>(5)? as u16,
+                    cache_status: row.get(6)?,
+                    domain: row.get(7)?,
+                    event_id: row.get(8)?,
+                    session_id: row.get(9)?,
+                    parent_event_id: row.get(10)?,
+                    redirect_url: row.get(11)?,
+                })
+            },
+        )?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn sample(domain: &str, ts: u64, id: &str) -> CacheEvent {
+        CacheEvent {
+            url: format!("https://{domain}/"),
+            method: "GET".into(),
+            status: 200,
+            cache_key: "k".into(),
+            cache_status: "HIT".into(),
+            timestamp: ts,
+            headers: HashMap::new(),
+            user_id: None,
+            username: Some("bob".into()),
+            client_ip: "10.0.0.2".into(),
+            domain: domain.into(),
+            response_size: 2,
+            request_duration_ms: 2,
+            content_type: None,
+            user_agent: None,
+            categories: vec![],
+            threat_sources: vec![],
+            acl_action: None,
+            session_id: "sess".into(),
+            parent_event_id: None,
+            redirect_url: None,
+            event_id: id.into(),
+        }
+    }
+
+    #[test]
+    fn sqlite_roundtrip() {
+        let store = SqliteStore::open(":memory:", 100).unwrap();
+        store
+            .insert_batch(&[sample("ex.com", 50, "e1"), sample("other.com", 60, "e2")])
+            .unwrap();
+        let hits = store
+            .search(&SearchQuery {
+                from_ts: 0,
+                to_ts: 100,
+                domain: "ex.com".into(),
+                username: String::new(),
+                session_id: String::new(),
+                limit: 10,
+                session_timeline: false,
+            })
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].event_id, "e1");
+    }
+}

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -1,15 +1,42 @@
-# Zero-config Lite profile: standalone caching HTTPS proxy.
-# No Kafka, ClickHouse, Prometheus, Grafana, or cache-indexer.
+# Zero-config Lite profile: caching HTTPS proxy + optional SQLite search.
+# No Kafka / ClickHouse / Prometheus / Grafana.
 #
 # Usage:
 #   ./scripts/gen-ca.sh
 #   docker compose -f docker-compose.lite.yml up -d --build
 #   curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
-#   curl http://127.0.0.1:9090/health
+#   curl 'http://127.0.0.1:8080/api/search?limit=5'
 #
 # Docs: docs/lite.md · docs/strategic-roadmap.md (Phase 1)
 
 services:
+  cache-indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: cache-indexer
+    ports:
+      - "8080:8080"
+    environment:
+      - INDEX_STORE=sqlite
+      - SQLITE_PATH=/var/lib/cache-indexer/events.db
+      - SQLITE_MAX_ROWS=1000000
+      - METRICS_PORT=8080
+      - SEARCH_API_ENABLED=true
+      # KAFKA_BROKERS / CLICKHOUSE_* intentionally unset
+      - RUST_LOG=info,cache_indexer=info
+    volumes:
+      - lite-indexer:/var/lib/cache-indexer
+    networks:
+      - bsdm-lite
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8080/health | grep -q ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
   proxy:
     build:
       context: .
@@ -32,12 +59,16 @@ services:
       - CACHE_SPILL_DIR=/var/cache/bsdm-spill
       - CACHE_SPILL_THRESHOLD_BYTES=65536
       - SHUTDOWN_TIMEOUT_SECONDS=30
-      # Kafka intentionally unset — standalone Lite (no analytics bus)
+      - EVENT_SINK_URL=http://cache-indexer:8080/api/events
+      # Kafka intentionally unset — HTTP sink to SQLite indexer
       - RUST_LOG=info,bsdm_proxy=info
       - RUST_BACKTRACE=0
     volumes:
       - ./certs:/certs:ro
       - lite-spill:/var/cache/bsdm-spill
+    depends_on:
+      cache-indexer:
+        condition: service_healthy
     networks:
       - bsdm-lite
     restart: unless-stopped
@@ -54,4 +85,6 @@ networks:
 
 volumes:
   lite-spill:
+    driver: local
+  lite-indexer:
     driver: local

--- a/docs/lite.md
+++ b/docs/lite.md
@@ -1,6 +1,6 @@
 # Lite mode (Strategic Phase 1)
 
-Standalone caching HTTPS proxy without Kafka, ClickHouse, Prometheus, Grafana, or `cache-indexer`.
+Standalone caching HTTPS proxy with optional SQLite Search API — **no Kafka or ClickHouse**.
 
 See [strategic-roadmap.md](strategic-roadmap.md) Phase 1.
 
@@ -13,35 +13,43 @@ docker compose -f docker-compose.lite.yml up -d --build
 
 | Service | Port | Notes |
 |---------|------|--------|
-| proxy | 1488 | Forward proxy, MITM on, L1 + spill volume |
-| metrics | 9090 | `/health`, `/ready`, `/metrics` (no Grafana needed) |
+| proxy | 1488 | Forward proxy, MITM, L1 + spill |
+| proxy metrics | 9090 | `/health`, `/metrics` |
+| cache-indexer | 8080 | `INDEX_STORE=sqlite`, `/api/search`, `POST /api/events` |
 
-Kafka is **not** configured (`KAFKA_BROKERS` unset) — events are not published.
+Proxy posts `CacheEvent` JSON to `EVENT_SINK_URL` (Kafka unset).
 
 ## Verify
 
 ```bash
 curl http://127.0.0.1:9090/health
 curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
-curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get   # expect cache HIT on 2nd
-curl http://127.0.0.1:9090/metrics | grep bsdm_proxy_cache
+sleep 1
+curl 'http://127.0.0.1:8080/api/search?domain=httpbin.org&limit=5'
 ```
 
-## Defaults
+## Indexer stores
 
-| Env | Lite default |
-|-----|----------------|
-| `MITM_ENABLED` | `true` (needs `./certs` from `gen-ca.sh`) |
-| `CACHE_CAPACITY` | `5000` |
-| `CACHE_SPILL_DIR` | `/var/cache/bsdm-spill` (named volume) |
-| Auth / ACL / categorization | off |
+| `INDEX_STORE` | Needs | Notes |
+|---------------|-------|--------|
+| `sqlite` | `SQLITE_PATH` | Default for Lite compose |
+| `memory` | — | Ring buffer; tests / ephemeral |
+| `clickhouse` | `CLICKHOUSE_*` | Full-stack default; Kafka optional |
+
+| Env | Default | Description |
+|-----|---------|-------------|
+| `SQLITE_PATH` | `/var/lib/cache-indexer/events.db` | File or `:memory:` |
+| `SQLITE_MAX_ROWS` | `1000000` | Prune oldest when exceeded |
+| `KAFKA_BROKERS` | unset = off | Optional Kafka → store |
+| `EVENT_SINK_URL` | — | Proxy → `POST /api/events` |
+| `EVENT_SINK_TOKEN` / `INGEST_API_TOKEN` | — | Optional Bearer |
 
 ## Full analytics stack
 
-Use root [`docker-compose.yml`](../docker-compose.yml) when you need Kafka → ClickHouse → Search API / Grafana / `alert-worker`.
+Root [`docker-compose.yml`](../docker-compose.yml): Kafka → ClickHouse → Grafana / `alert-worker`.
 
-## Roadmap leftovers (not in this slice)
+## Roadmap leftovers
 
-- [ ] `cache-indexer` without mandatory Kafka/ClickHouse
-- [ ] SQLite / in-memory metadata store
-- [ ] Cargo features to drop `rdkafka` from Lite binary (related: B21 / #52)
+- [x] `cache-indexer` without mandatory Kafka/ClickHouse (`INDEX_STORE` + HTTP ingest)
+- [x] SQLite / in-memory metadata store
+- [ ] Cargo features to drop `rdkafka` from Lite binary (B21 / #52)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -165,7 +165,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
-| **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml`; next: indexer без Kafka/CH, SQLite |
+| **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; next: Cargo features без rdkafka (B21) |
 | **2. DX** | Control plane | REST/gRPC API, hot reload ACL/upstream, cache purge по tags/regex, lite metrics |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
 | **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |

--- a/docs/search-api.md
+++ b/docs/search-api.md
@@ -1,25 +1,26 @@
-# Search API (ClickHouse)
+# Search API
 
-REST endpoint for SOC retro-search over `bsdm.http_cache`. Implemented in **cache-indexer** admin HTTP server (same port as `/metrics`).
-
-REST retro-search over ClickHouse (shipped in [#125](https://github.com/onixus/bsdm-proxy/issues/125) / [#130](https://github.com/onixus/bsdm-proxy/issues/130)).
+REST retro-search on **cache-indexer** admin port (same as `/metrics`). Backends: ClickHouse (full stack), SQLite / memory (Lite).
 
 ## Enable
 
-Enabled by default on cache-indexer admin port.
-
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `INDEX_STORE` | `clickhouse` | `clickhouse` \| `sqlite` \| `memory` |
 | `SEARCH_API_ENABLED` | `true` | `true` / `false` |
-| `SEARCH_API_TOKEN` | — | Bearer token; if set, `Authorization: Bearer <token>` required |
+| `SEARCH_API_TOKEN` | — | Bearer for `GET /api/search` |
+| `INGEST_API_TOKEN` | = search token | Bearer for `POST /api/events` |
 | `SEARCH_API_MAX_LIMIT` | `10000` | Max rows per request |
 | `SEARCH_API_DEFAULT_DAYS` | `30` | Default lookback when `from` omitted |
-| `METRICS_PORT` | `8080` | Admin port (`/metrics`, `/health`, `/api/search`) |
+| `METRICS_PORT` | `8080` | Admin port |
+| `SQLITE_PATH` | `/var/lib/cache-indexer/events.db` | When `INDEX_STORE=sqlite` |
+| `KAFKA_BROKERS` | unset = off | Optional Kafka consumer → store |
 
-## Endpoint
+## Endpoints
 
 ```
-GET /api/search
+GET  /api/search
+POST /api/events
 ```
 
 ### Query parameters
@@ -62,18 +63,24 @@ curl -H "Authorization: Bearer secret" 'http://127.0.0.1:8080/api/search?limit=5
 
 ### Response
 
-JSON array of objects with fields: `ts`, `username`, `client_ip`, `url`, `method`, `status`, `cache_status`, `domain`, `event_id`, `session_id`, `parent_event_id`, `redirect_url`.
+JSON array of objects with fields: `ts` (unix seconds), `username`, `client_ip`, `url`, `method`, `status`, `cache_status`, `domain`, `event_id`, `session_id`, `parent_event_id`, `redirect_url`.
 
 Errors: `401` (unauthorized), `404` (search disabled), `500` (query failure).
+
+## Ingest (`POST /api/events`)
+
+Body: one `CacheEvent` JSON, a JSON array, `{"events":[...]}`, or NDJSON. Response `202 {"accepted":N}`.
+
+Lite proxy sets `EVENT_SINK_URL=http://cache-indexer:8080/api/events` (no Kafka). See [lite.md](lite.md).
 
 ## Security
 
 - Filters are sanitized server-side; invalid characters are rejected (empty filter).
-- Queries use ClickHouse parameterized SQL (`{param:Type}`), not string concatenation.
-- Prefer setting `SEARCH_API_TOKEN` in production; do not expose port 8080 publicly without auth.
+- ClickHouse queries use parameterized SQL (`{param:Type}`); SQLite uses bound params.
+- Prefer setting `SEARCH_API_TOKEN` / `INGEST_API_TOKEN` in production; do not expose port 8080 publicly without auth.
 
 ## Grafana alternative
 
-For interactive dashboards use Grafana + ClickHouse datasource (`docker compose up`). Search API is for scripted export and integrations.
+For interactive dashboards use Grafana + ClickHouse datasource (`docker compose up`). Lite uses SQLite Search API only.
 
-See [clickhouse-analytics.md](clickhouse-analytics.md).
+See [clickhouse-analytics.md](clickhouse-analytics.md) · [lite.md](lite.md).

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -15,10 +15,10 @@
 
 *Фокус: снижение порога входа и адаптация под небольшие инфраструктуры (VPS, edge-узлы).*
 
-- **Отвязка от тяжелых зависимостей:** рефакторинг `cache-indexer` для работы без обязательной связки с Kafka и ClickHouse. *(pending)*
-- **Встроенное хранилище:** SQLite или in-memory для индексов и метаданных по умолчанию. *(pending)*
-- **Standalone-архитектура:** независимый бинарник / lightweight container — proxy уже работает без `KAFKA_BROKERS`. *(partial)*
-- **Zero-Config профили:** ✅ [`docker-compose.lite.yml`](../docker-compose.lite.yml) + [`scripts/gen-ca.sh`](../scripts/gen-ca.sh) — см. [lite.md](lite.md).
+- **Отвязка от тяжелых зависимостей:** ✅ `INDEX_STORE=sqlite|memory` + optional Kafka; HTTP `POST /api/events` (см. [lite.md](lite.md)).
+- **Встроенное хранилище:** ✅ SQLite / in-memory event store на cache-indexer.
+- **Standalone-архитектура:** независимый бинарник / lightweight container — proxy уже работает без `KAFKA_BROKERS`; Lite compose + SQLite. *(partial — rdkafka still linked, B21)*
+- **Zero-Config профили:** ✅ [`docker-compose.lite.yml`](../docker-compose.lite.yml) + [`scripts/gen-ca.sh`](../scripts/gen-ca.sh).
 
 ---
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -65,7 +65,7 @@ pub use peer_discovery::{run_peer_discovery, PeerDiscoveryConfig};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
 pub use perf::{bind_http_listeners, PerfConfig};
-pub use pipeline::KafkaEventPipeline;
+pub use pipeline::{HttpEventPipeline, KafkaEventPipeline};
 pub use policy_cache::{PolicyCacheConfig, PolicyDecisionCache};
 pub use proxy_service::{ProxyPolicy, ProxyService};
 pub use rate_limit::{RateLimitConfig, RateLimitViolation, RateLimiter};

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -7,9 +7,9 @@ use bsdm_proxy::{
     htcp_peer_port, htcp_server_bind_addr, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, metrics_server, run_peer_discovery, should_start_htcp_server,
     should_start_icp_server, wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache,
-    HtcpServer, IcpServer, KafkaEventPipeline, L2CacheConfig, Metrics, PeerDiscoveryConfig,
-    PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig,
-    RedisL2Cache, UpstreamTlsConfig,
+    HtcpServer, HttpEventPipeline, IcpServer, KafkaEventPipeline, L2CacheConfig, Metrics,
+    PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy,
+    ProxyService, RateLimitConfig, RedisL2Cache, UpstreamTlsConfig,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -138,6 +138,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kafka_pipeline = kafka_brokers
         .as_deref()
         .and_then(|brokers| KafkaEventPipeline::spawn(brokers, kafka_topic, metrics.clone()));
+    let http_pipeline = if kafka_pipeline.is_none() {
+        std::env::var("EVENT_SINK_URL")
+            .ok()
+            .filter(|u| !u.is_empty())
+            .and_then(|url| {
+                let token = std::env::var("EVENT_SINK_TOKEN")
+                    .ok()
+                    .filter(|t| !t.is_empty());
+                HttpEventPipeline::spawn(url, token, metrics.clone())
+            })
+    } else {
+        None
+    };
     let cache_config = CacheConfig::from_env();
     if cache_config.spill_threshold_bytes > 0 {
         if let Err(e) = ensure_private_spill_dir(&cache_config.spill_dir) {
@@ -195,6 +208,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cache_config.clone(),
         l2_cache,
         kafka_pipeline,
+        http_pipeline,
         metrics.clone(),
         mitm_enabled,
         auth,

--- a/proxy/src/pipeline.rs
+++ b/proxy/src/pipeline.rs
@@ -1,4 +1,4 @@
-//! Kafka cache-event pipeline with bounded in-memory queue (#106).
+//! HTTP and Kafka cache-event pipelines with bounded in-memory queue (#106).
 
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
@@ -104,6 +104,76 @@ impl KafkaEventPipeline {
 
     pub fn producer(&self) -> Arc<FutureProducer> {
         self.producer.clone()
+    }
+}
+
+/// HTTP POST sink for Lite indexer (`EVENT_SINK_URL` → POST /api/events).
+pub struct HttpEventPipeline {
+    sender: mpsc::Sender<CacheEvent>,
+}
+
+impl HttpEventPipeline {
+    pub fn spawn(url: String, token: Option<String>, metrics: Arc<Metrics>) -> Option<Arc<Self>> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .ok()?;
+        let capacity = queue_capacity_from_env();
+        let (sender, mut receiver) = mpsc::channel::<CacheEvent>(capacity);
+        let metrics_worker = metrics.clone();
+
+        let url_log = url.clone();
+        tokio::spawn(async move {
+            while let Some(event) = receiver.recv().await {
+                match serde_json::to_vec(&event) {
+                    Ok(payload) => {
+                        let mut req = client
+                            .post(&url)
+                            .header("Content-Type", "application/json")
+                            .body(payload);
+                        if let Some(t) = &token {
+                            req = req.bearer_auth(t);
+                        }
+                        match req.send().await {
+                            Ok(resp)
+                                if resp.status().is_success() || resp.status().as_u16() == 202 =>
+                            {
+                                metrics_worker.kafka_events_sent.inc();
+                            }
+                            Ok(resp) => {
+                                warn!("EVENT_SINK_URL HTTP {}", resp.status());
+                                metrics_worker.kafka_send_errors.inc();
+                            }
+                            Err(e) => {
+                                warn!("EVENT_SINK_URL send failed: {e}");
+                                metrics_worker.kafka_send_errors.inc();
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("Event serialization failed: {}", e);
+                        metrics_worker.kafka_send_errors.inc();
+                    }
+                }
+            }
+        });
+
+        info!(
+            "HTTP event sink started (url={url_log}, queue capacity={capacity}, drop=policy:drop_new)"
+        );
+        Some(Arc::new(Self { sender }))
+    }
+
+    pub fn try_enqueue(&self, event: CacheEvent, metrics: &Metrics) {
+        match self.sender.try_send(event) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                metrics.kafka_queue_dropped_total.inc();
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                metrics.kafka_send_errors.inc();
+            }
+        }
     }
 }
 

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -34,7 +34,9 @@ use crate::metrics::{FastRequestScope, Metrics, RequestMetricsGuard};
 use crate::peer_fetch::fetch_via_peer;
 use crate::peers::CachePeer;
 use crate::perf::PerfConfig;
-use crate::pipeline::{flush_kafka, new_event_id, CacheEvent, KafkaEventPipeline};
+use crate::pipeline::{
+    flush_kafka, new_event_id, CacheEvent, HttpEventPipeline, KafkaEventPipeline,
+};
 use crate::policy_cache::PolicyDecisionCache;
 use crate::rate_limit::{RateLimitViolation, RateLimiter};
 use crate::session::{header_ci, resolve_location, SessionCorrelator};
@@ -57,6 +59,7 @@ struct MissCompletionHandle {
     hierarchy: Option<Arc<HierarchyManager>>,
     metrics: Arc<Metrics>,
     kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
+    http_pipeline: Option<Arc<HttpEventPipeline>>,
     perf: PerfConfig,
     digest_registry: Option<Arc<DigestRegistry>>,
     sessions: Arc<SessionCorrelator>,
@@ -86,6 +89,8 @@ impl MissCompletionHandle {
             return;
         }
         if let Some(pipeline) = &self.kafka_pipeline {
+            pipeline.try_enqueue(event, &self.metrics);
+        } else if let Some(pipeline) = &self.http_pipeline {
             pipeline.try_enqueue(event, &self.metrics);
         }
     }
@@ -232,6 +237,7 @@ pub struct ProxyService {
     l2_cache: Option<RedisL2Cache>,
     cache_config: CacheConfig,
     kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
+    http_pipeline: Option<Arc<HttpEventPipeline>>,
     http_client:
         hyper_util::client::legacy::Client<hyper_rustls::HttpsConnector<HttpConnector>, Body>,
     pub(crate) metrics: Arc<Metrics>,
@@ -276,6 +282,7 @@ impl ProxyService {
             hierarchy: self.hierarchy.clone(),
             metrics: self.metrics.clone(),
             kafka_pipeline: self.kafka_pipeline.clone(),
+            http_pipeline: self.http_pipeline.clone(),
             perf: self.perf.clone(),
             digest_registry: self.digest_registry.clone(),
             sessions: self.sessions.clone(),
@@ -288,6 +295,7 @@ impl ProxyService {
         cache_config: CacheConfig,
         l2_cache: Option<RedisL2Cache>,
         kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
+        http_pipeline: Option<Arc<HttpEventPipeline>>,
         metrics: Arc<Metrics>,
         mitm_enabled: bool,
         auth: Option<Arc<AuthManager>>,
@@ -318,6 +326,7 @@ impl ProxyService {
             l2_cache,
             cache_config,
             kafka_pipeline,
+            http_pipeline,
             http_client,
             metrics,
             mitm_enabled,
@@ -933,6 +942,8 @@ impl ProxyService {
             return;
         }
         if let Some(pipeline) = &self.kafka_pipeline {
+            pipeline.try_enqueue(event, &self.metrics);
+        } else if let Some(pipeline) = &self.http_pipeline {
             pipeline.try_enqueue(event, &self.metrics);
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Второй срез **Lite Phase 1**: `cache-indexer` без обязательных Kafka/ClickHouse — SQLite/memory store + HTTP ingest; proxy шлёт события через `EVENT_SINK_URL`.

## Changes

- `INDEX_STORE=clickhouse|sqlite|memory` (default `clickhouse` — full stack unchanged)
- `POST /api/events` ingest; `GET /api/search` поверх любого store (`ts` = unix seconds)
- `KAFKA_BROKERS` optional (unset = HTTP-only ingest)
- Proxy: `EVENT_SINK_URL` / `EVENT_SINK_TOKEN` when Kafka unset
- `docker-compose.lite.yml`: proxy + sqlite indexer
- Docs: `docs/lite.md`, `docs/search-api.md`, strategic roadmap checkboxes

## Lite usage

```bash
./scripts/gen-ca.sh
docker compose -f docker-compose.lite.yml up -d --build
curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
curl 'http://127.0.0.1:8080/api/search?limit=5'
```

## Out of scope

- Cargo features to strip `rdkafka` from proxy (B21 / #52)

## Testing

```bash
cargo test -p cache-indexer --bins
cargo clippy -p cache-indexer --bins -- -D warnings
cargo test -p bsdm-proxy --lib
cargo clippy -p bsdm-proxy --bins -- -D warnings
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10818de5-9bd8-47ec-8af1-9102dab2add7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

