### PR TITLE
bench: v0.5.0 HTTP Archive results + warm-only metrics

### DIFF
--- a/docs/benchmarks-httparchive.md
+++ b/docs/benchmarks-httparchive.md
@@ -102,10 +102,16 @@ PAGE_CONCURRENCY=6 python3 scripts/httparchive-page-load.py \
 Warm goodput — фаза **warm repeats** из вывода `httparchive-sites-bench.py`.  
 Перемеряйте на своём железе: `BENCH_PROFILE=warm ./scripts/compare-squid-bsdm-httparchive.sh`.
 
-| Дата | Профиль | `WORKER_COUNT` | BSDM warm Mbit/s | Squid warm Mbit/s | Примечание |
-|------|---------|----------------|------------------|-------------------|------------|
-| 2026-03 (ADR 0001) | cold | 4 | ~500 | ~657 | до tiered L1 tuning |
-| 2026-06 (backlog) | cold | 4 | ~538 | ~593 | post P0 perf + tiered L1 |
-| — | **warm** | **1** | **цель ≥560** | ~593 | рекомендуемый профиль для M2.5 gate |
+| Дата | Версия | Профиль | `WORKER_COUNT` | BSDM warm Mbit/s | Squid warm Mbit/s | Примечание |
+|------|--------|---------|----------------|------------------|-------------------|------------|
+| 2026-03 (ADR 0001) | 0.3.x | cold | 4 | ~500 | ~657 | до tiered L1 tuning |
+| 2026-06 (backlog) | 0.3.x | cold | 4 | ~538 | ~593 | post P0 perf + tiered L1 |
+| 2026-07-01 | 0.3.x | cold* | 4 | ~478 | ~535 | total 481 vs 537; Squid rock×4 |
+| **2026-07-16** | **0.5.0** | **warm** | **1** | **477** | **527** | gate profile; Squid w1+mem (host SMP broken) |
+| **2026-07-16** | **0.5.0** | **cold** | **4** | **516** | **469** | BSDM cold path 714; Squid same w1+mem |
 
-Gap warm profile vs Squid: цель M2.5 — **≥ Squid −5%** на warm goodput ([roadmap](roadmap.md)).
+\*До введения `BENCH_PROFILE`; эквивалент сегодняшнего `cold` (`WORKER_COUNT=4`).
+
+Gap warm profile vs Squid: цель M2.5 — **≥ Squid −5%** на warm goodput ([roadmap](roadmap.md)).  
+Прогон 2026-07-16 warm: BSDM **477** vs Squid **527** → **−9.5%** (цель ≥560 / −5% не достигнута).  
+На том же хосте `cold` (WC=4) дал BSDM warm **516** (−3.4% к Squid rock×4 ~535 из 2026-07-01).

--- a/scripts/compare-squid-bsdm-httparchive.sh
+++ b/scripts/compare-squid-bsdm-httparchive.sh
@@ -12,7 +12,7 @@ cd "$ROOT"
 source "${ROOT}/scripts/bench-profile.sh"
 apply_bench_profile
 
-SQUID_CONF="${ROOT}/scripts/squid-benchmark-tuned.conf"
+SQUID_CONF="${SQUID_CONF:-${ROOT}/scripts/squid-benchmark-tuned.conf}"
 SQUID_PORT=13128
 BSDM_PORT=12788
 BSDM_METRICS=19190
@@ -42,12 +42,22 @@ stop_squid() {
 
 start_squid() {
   stop_squid
+  sudo mkdir -p /var/spool/squid /var/log/squid
+  sudo chown proxy:proxy /var/spool/squid /var/log/squid 2>/dev/null \
+    || sudo chown squid:squid /var/spool/squid /var/log/squid
+  # Optional rock dir (only used if conf has cache_dir rock)
   sudo mkdir -p /var/spool/squid-rock
-  sudo chown proxy:proxy /var/spool/squid-rock 2>/dev/null || sudo chown squid:squid /var/spool/squid-rock
+  sudo chown proxy:proxy /var/spool/squid-rock 2>/dev/null || true
   sudo squid -k parse -f "$SQUID_CONF"
-  sudo squid -z -f "$SQUID_CONF" 2>&1 | tail -3
+  if grep -qE '^[[:space:]]*cache_dir[[:space:]]' "$SQUID_CONF"; then
+    sudo squid -z -f "$SQUID_CONF" 2>&1 | tail -3
+    sleep 2
+    sudo killall squid 2>/dev/null || true
+    sudo rm -f /run/squid.pid
+    sleep 1
+  fi
   sudo squid -f "$SQUID_CONF"
-  for _ in 1 2 3 4 5 6 7 8 9 10; do
+  for _ in $(seq 1 30); do
     if curl -sf -x "http://127.0.0.1:${SQUID_PORT}" "${UPSTREAM}/ping" >/dev/null 2>&1; then
       echo "Squid ready (${SQUID_PORT}), workers: $(pgrep -c -x squid || echo ?)"
       return 0
@@ -55,6 +65,7 @@ start_squid() {
     sleep 1
   done
   echo "Squid failed to start" >&2
+  sudo tail -40 /var/log/squid/cache.log 2>/dev/null || true
   exit 1
 }
 

--- a/scripts/httparchive-sites-bench.py
+++ b/scripts/httparchive-sites-bench.py
@@ -136,11 +136,17 @@ def main() -> int:
     print("")
     print(f"==> phase 2: warm ({args.warm_repeats} repeats to the same sites)")
     warm_bytes = 0
+    warm_hits = warm_misses = warm_reqs = 0
+    warm_elapsed = 0.0
     for rep in range(1, args.warm_repeats + 1):
         h, m, b, r, e = run_batch(
             urls, args.proxy, args.proxy_user, args.concurrency, args.timeout
         )
         warm_bytes += b
+        warm_hits += h
+        warm_misses += m
+        warm_reqs += r
+        warm_elapsed += e
         total_hits += h
         total_misses += m
         total_bytes += b
@@ -159,6 +165,9 @@ def main() -> int:
         )
         return 1
 
+    print("")
+    print("==> warm-only")
+    print_phase("warm phases", warm_hits, warm_misses, warm_bytes, warm_reqs, warm_elapsed)
     print("")
     print("==> totals")
     print_phase("all phases", total_hits, total_misses, total_bytes, total_reqs, total_elapsed)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-ran the HTTP Archive Top 1k sites bench on **BSDM v0.5.0** with the new `BENCH_PROFILE` methodology (`warm` WC=1 / `cold` WC=4) and compared against prior runs.

### Harness

- `httparchive-sites-bench.py` now prints aggregated **warm-only** goodput (gate metric)
- `compare-squid-bsdm-httparchive.sh`: `SQUID_CONF` override, optional `squid -z`, longer readiness wait
- Results table updated in `docs/benchmarks-httparchive.md`

### Key numbers (4 vCPU lab, desktop, 70×12×20)

| Profile | BSDM warm | Squid warm | Notes |
|---------|-----------|------------|-------|
| warm (WC=1) | **477** Mbit/s | **527** Mbit/s | −9.5% vs Squid; gate target ≥560 / −5% not met |
| cold (WC=4) | **516** Mbit/s | **469** Mbit/s* | BSDM cold path **714** Mbit/s |

\*This host cannot run Squid `workers>1` / rock (IPv6 SMP bind ENOENT); Squid used workers=1 + 1 GB mem. Historical Squid rock×4 warm was ~535 Mbit/s (2026-07-01).

### vs previous (2026-07-01, WC=4)

- BSDM warm: ~478 → **516** (cold profile) / **477** (warm profile)
- Squid warm (rock×4 historical): ~535; this host Squid w1: 527 / 469 (run variance)

Artifacts under `/opt/cursor/artifacts/httparchive-v050/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

