### PR TITLE
feat(m5): ml-worker + ClickHouse feature store scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@
 
 BSDM-Proxy is a single Rust/Cargo product: a caching HTTPS forward proxy with MITM
 TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → ClickHouse
-analytics pipeline (plus optional `alert-worker` webhook alerts). The Cargo workspace has
-five crates: `proxy/` (bin `proxy`), `cache-indexer/` (bin `cache-indexer`),
-`alert-worker/` (bin `alert-worker`), `bsdm-events/` (shared event types), and
+analytics pipeline (plus optional `alert-worker` webhook alerts and `ml-worker`
+feature-store scoring). The Cargo workspace has six crates: `proxy/` (bin `proxy`),
+`cache-indexer/` (bin `cache-indexer`), `alert-worker/` (bin `alert-worker`),
+`ml-worker/` (bin `ml-worker`), `bsdm-events/` (shared event types), and
 `e2e/` (test harness). Standard build,
 lint, test, and run commands live in `README.md` and `docs/development.md` — use those
 as the source of truth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **M5.1 ML worker scaffold** — crate `ml-worker` extracts entity windows into ClickHouse `entity_features`, scores with `anomaly_stub_v0` into `ml_scores`, optional webhook; compose profile `ml`, packaging/systemd; ADR 0003 / [docs/ml-security.md](docs/ml-security.md) (B15 / #46)
+
 ## [0.5.0] - 2026-07-16
 
 Milestone **M4 Threat analytics**: rule-based alerts, C&C / Shannon heuristics, Grafana Unified Alerting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -1701,6 +1702,21 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-worker"
+version = "0.5.0"
+dependencies = [
+ "chrono",
+ "prometheus",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "proxy",
     "cache-indexer",
     "alert-worker",
+    "ml-worker",
     "e2e",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY bsdm-events ./bsdm-events
 COPY proxy ./proxy
 COPY cache-indexer ./cache-indexer
 COPY alert-worker ./alert-worker
+COPY ml-worker ./ml-worker
 COPY e2e ./e2e
 
 # Настройка окружения для статической линковки
@@ -45,7 +46,7 @@ ENV OPENSSL_STATIC=1 \
 
 # Собираем бинарники workspace в release режиме
 RUN cargo build --release --target x86_64-unknown-linux-musl \
-    -p bsdm-proxy -p cache-indexer -p alert-worker
+    -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker
 
 # ============================================================
 # Proxy runtime
@@ -91,3 +92,17 @@ COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/alert-worker
 
 EXPOSE 8090
 CMD ["alert-worker"]
+
+# ============================================================
+# ML-worker runtime (ClickHouse features + scores, M5)
+# ============================================================
+FROM alpine:3.21 AS ml-worker
+RUN apk add --no-cache \
+    ca-certificates \
+    libgcc \
+    wget
+
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/ml-worker /usr/local/bin/ml-worker
+
+EXPOSE 8091
+CMD ["ml-worker"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 | **Безопасность** | Proxy-auth (Basic / LDAP / NTLM / Kerberos), **connection-level auth cache**, ACL + REST API, **policy decision cache**, категоризация URL, rate limiting |
 | **Производительность** | Multi-worker accept (`WORKER_COUNT`), perf fast path (`PERF_FAST_CACHE_HIT`), HTTP Archive bench profiles (`BENCH_PROFILE=warm\|cold`) |
 | **Наблюдаемость** | Prometheus (proxy + cache-indexer), Grafana (Prometheus + ClickHouse), `/health`, `/ready`, `/metrics` |
-| **Аналитика** | Kafka → cache-indexer → **ClickHouse** (`bsdm.http_cache`); Grafana **HTTP Traffic**; REST **Search API** (`/api/search`) |
+| **Аналитика** | Kafka → cache-indexer → **ClickHouse** (`bsdm.http_cache`); Grafana **HTTP Traffic**; REST **Search API** (`/api/search`); optional **ml-worker** features/scores (M5) |
 | **Эксплуатация** | Graceful shutdown, Helm chart `charts/bsdm/`, release-пакет + systemd |
 
 ## Архитектура
@@ -62,6 +62,7 @@
 | **ICP** | 3130 | UDP-запросы между cache peers (при `HIERARCHY_ENABLED=true`) |
 | **metrics** | 9090 | `/health`, `/ready`, `/metrics` |
 | **cache-indexer** | 8080 | Kafka → ClickHouse, `/api/search` |
+| **ml-worker** | 8091 | M5: entity features + scores (compose profile `ml`) |
 | **Kafka** | 9092 | Очередь событий кеша |
 | **ClickHouse** | 8123 / 9000 | Аналитика HTTP-трафика |
 | **Prometheus** | 9091 | Сбор метрик |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ./scripts/clickhouse/http_cache.sql:/docker-entrypoint-initdb.d/01-http_cache.sql:ro
+      - ./scripts/clickhouse/ml_features.sql:/docker-entrypoint-initdb.d/02-ml_features.sql:ro
     networks:
       - bsdm-net
     restart: unless-stopped
@@ -163,6 +164,44 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8090/health | grep -q ok"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
+  # Optional M5 feature store / scoring (ADR 0003).
+  #   docker compose --profile ml up -d --build ml-worker
+  # Optional SIEM: ML_WEBHOOK_URL=https://hooks.example/siem
+  ml-worker:
+    profiles: ["ml"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: ml-worker
+    ports:
+      - "8091:8091"
+    environment:
+      - CLICKHOUSE_URL=http://clickhouse:8123
+      - CLICKHOUSE_DATABASE=bsdm
+      - CLICKHOUSE_TABLE=http_cache
+      - ML_FEATURES_TABLE=entity_features
+      - ML_SCORES_TABLE=ml_scores
+      - ML_POLL_INTERVAL_SECS=${ML_POLL_INTERVAL_SECS:-120}
+      - ML_LOOKBACK_SECS=${ML_LOOKBACK_SECS:-300}
+      - ML_ENTITY_TYPES=${ML_ENTITY_TYPES:-client_ip}
+      - ML_MIN_REQUESTS=${ML_MIN_REQUESTS:-10}
+      - ML_MODEL=${ML_MODEL:-anomaly_stub_v0}
+      - ML_SCORE_THRESHOLD=${ML_SCORE_THRESHOLD:-0.8}
+      - ML_WEBHOOK_URL=${ML_WEBHOOK_URL:-}
+      - METRICS_PORT=8091
+      - RUST_LOG=info,ml_worker=info
+    depends_on:
+      clickhouse:
+        condition: service_healthy
+    networks:
+      - bsdm-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8091/health | grep -q ok"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,8 @@
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |
 | [alerting.md](alerting.md) | Alert worker + Grafana/AM (M4) |
+| [ml-security.md](ml-security.md) | ML worker + feature store (M5) |
+| [adr/0003-ml-worker-feature-store.md](adr/0003-ml-worker-feature-store.md) | ADR: CH feature store |
 | [search-api.md](search-api.md) | REST Search API |
 
 ## Архитектура и roadmap

--- a/docs/adr/0003-ml-worker-feature-store.md
+++ b/docs/adr/0003-ml-worker-feature-store.md
@@ -1,0 +1,36 @@
+# ADR 0003: ML worker + ClickHouse feature store (M5)
+
+**Status:** Accepted  
+**Date:** 2026-07-16  
+**Relates:** [#46](https://github.com/onixus/bsdm-proxy/issues/46) (B15), [roadmap M5](../roadmap.md), [ADR 0002](0002-clickhouse-analytics.md)
+
+## Context
+
+M4 delivers **rule-based** threat analytics via `alert-worker` (ClickHouse SQL → webhook / Grafana).  
+M5 needs **ML / scoring** (anomaly, phishing, C&C) without putting inference on the proxy hot path ([architecture.md](../architecture.md)).
+
+B15 originally said “read OpenSearch/Kafka”. Analytics storage is now **ClickHouse-only** (ADR 0002). Alerting exists as `alert-worker`; scoring does not.
+
+## Decision
+
+1. **Async CH-backed `ml-worker`** (new crate), sibling to `alert-worker`:
+   - Poll `bsdm.http_cache`
+   - Aggregate **entity features** into `bsdm.entity_features`
+   - Compute **scores** into `bsdm.ml_scores` (v0 = heuristic stub; later real models)
+   - Optionally POST findings to the same SIEM webhook shape as alert-worker
+2. **Feature store = ClickHouse tables** (not a separate OLTP store). Batch SQL aggregation is the first extractor; Materialized Views optional later.
+3. **Proxy stays ML-free** on the hot path until a proven async score + TTL cache design (M5.5). Doc stub `ML_ENABLED` remains unimplemented.
+4. **`alert-worker` stays rules-only**; do not merge ML into it. Share patterns (CH HTTP client, metrics, webhook JSON), not a shared library yet.
+
+## Consequences
+
+- New workspace member `ml-worker`, compose profile `ml`, packaging unit/env.
+- M5.1 ships scaffolding + stub scorer; M5.2+ replace stub with trained models offline → ONNX/score file load.
+- Closes the design half of B15/#46; implementation tracked under M5 epic issues.
+
+## Non-goals (M5.1)
+
+- ONNX / Python training in-repo
+- Inline proxy scoring
+- New Kafka consumer (CH poll is enough)
+- DLP / ICAP

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ flowchart TB
 | MITM | `proxy/src/tls.rs` | ✅ |
 | Hierarchy / ICP | `hierarchy.rs`, `peer_fetch.rs`, `icp.rs`, `hierarchy_config.rs` | ✅ opt-in (`HIERARCHY_ENABLED`) |
 | Event indexer | `cache-indexer/src/main.rs` | ✅ |
-| ML / analytics worker | — | ❌ не существует |
+| ML / analytics worker | `ml-worker` (:8091) | ✅ M5.1 scaffold (CH features + stub score); models TBD |
 
 ---
 
@@ -217,7 +217,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 
 | ID | Блокер | Описание | Milestone |
 |----|--------|----------|-----------|
-| **B15** | Нет analytics/ML сервиса | Нужен worker для scoring, alerts | M4–M5 |
+| **B15** | Analytics/ML worker | ✅ M5.1 scaffold (`ml-worker` + CH feature store); models → M5.2+ | M5 |
 | **B16** | Event schema for analytics | ✅ Done (`session_id`, `acl_action`, `threat_sources`) | M3–M4 |
 | **B17** | Analytics UI in compose | ✅ Done (Grafana + ClickHouse; OS Dashboards removed) | M3 |
 | **B18** | Behavioral / beacon signals | ✅ Done (`beacon_periodic` in alert-worker) | M4 |
@@ -243,8 +243,8 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 M1  ██████████████  B1–B6 ✅
 M2  ██████████████  B7–B9 B13–B14 B21–B25 ✅
 M3  █████████████░  B10–B12 B17 ✅ · B20 ✅
-M4  ██████████████  B16 ✅ · B18 ✅ · B19 ✅ · B20 ✅ · B15 → M5
-M5  ░░░░░░░░░░░░░░  B15 + ML```
+M4  ██████████████  B16 ✅ · B18 ✅ · B19 ✅ · B20 ✅
+M5  ██░░░░░░░░░░░░  B15 scaffold ✅ · models M5.2+```
 
 ---
 
@@ -257,7 +257,7 @@ Critical/high блокеры B1–B14, B17, B22–B26 — **закрыты**. An
 ### Волна 3 — M4/M5 foundation
 
 1. ~~**B16** — rich event schema~~ ✅ (`session_id`, `acl_action`, `threat_sources`)
-2. **B15** — analytics / ML worker (scoring beyond rule alerts)
+2. ~~**B15** — analytics / ML worker scaffold~~ ✅ (`ml-worker`, ADR 0003); trained models still open
 3. ~~**B18** — behavioral / beacon signals~~ ✅ (`beacon_periodic`)
 4. ~~**B19** — SIEM webhook~~ ✅ (`alert-worker`)
 5. ~~**B8** — online categorization off hot path~~ ✅ (#104)
@@ -292,4 +292,4 @@ flowchart LR
 
 ---
 
-*Версия документа: 0.5.0 · M1–M4 done · M5 ML next*
+*Версия документа: 0.5.0 · M1–M4 done · M5.1 ml-worker scaffold*

--- a/docs/ml-security.md
+++ b/docs/ml-security.md
@@ -1,0 +1,92 @@
+# M5 — ML security
+
+Async threat scoring on ClickHouse. Design: [ADR 0003](adr/0003-ml-worker-feature-store.md) · Roadmap: [M5](roadmap.md#m5--ml-security-v10x).
+
+> Proxy hot path stays free of ML inference. Rule alerts remain in [`alert-worker`](alerting.md).
+
+## Architecture
+
+```
+bsdm.http_cache ──► ml-worker ──► bsdm.entity_features
+                      │
+                      ├──► bsdm.ml_scores
+                      └──► optional webhook (same JSON shape as alert-worker)
+```
+
+| Component | Role |
+|-----------|------|
+| `ml-worker` | Poll CH, extract features, score, optional SIEM POST |
+| `entity_features` | Per-entity window aggregates |
+| `ml_scores` | Model / stub scores + severity |
+| `alert-worker` | Unchanged rule engine (M4) |
+
+## Quick start
+
+```bash
+# Apply DDL (also mounted in docker-compose)
+clickhouse-client --multiquery < scripts/clickhouse/ml_features.sql
+
+# Local binary
+CLICKHOUSE_URL=http://127.0.0.1:8123 \
+  ML_ENTITY_TYPES=client_ip \
+  METRICS_PORT=8091 \
+  cargo run -p ml-worker --release
+
+# Compose profile
+docker compose --profile ml up -d --build ml-worker
+```
+
+Optional webhook (fires when stub score ≥ threshold):
+
+```bash
+ML_WEBHOOK_URL=https://hooks.example/siem \
+  ML_SCORE_THRESHOLD=0.7 \
+  docker compose --profile ml up -d ml-worker
+```
+
+## Environment
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLICKHOUSE_URL` | `http://127.0.0.1:8123` | CH HTTP |
+| `CLICKHOUSE_DATABASE` | `bsdm` | Database |
+| `CLICKHOUSE_TABLE` | `http_cache` | Source events |
+| `ML_FEATURES_TABLE` | `entity_features` | Feature store |
+| `ML_SCORES_TABLE` | `ml_scores` | Score store |
+| `ML_POLL_INTERVAL_SECS` | `120` | Cycle interval |
+| `ML_LOOKBACK_SECS` | `300` | Window length |
+| `ML_ENTITY_TYPES` | `client_ip` | Comma list: `client_ip`, `username`, `domain` |
+| `ML_MIN_REQUESTS` | `10` | Min events per entity window |
+| `ML_MODEL` | `anomaly_stub_v0` | Score model id |
+| `ML_SCORE_THRESHOLD` | `0.8` | Webhook / severity cut |
+| `ML_WEBHOOK_URL` | — | Optional SIEM URL |
+| `METRICS_PORT` | `8091` | `/health`, `/metrics` |
+
+## Models
+
+| Model | Phase | Behaviour |
+|-------|-------|-----------|
+| `anomaly_stub_v0` | M5.1 | Heuristic: elevated request rate + deny/threat ratio |
+| *(planned)* UEBA / isolation | M5.2 | Unsupervised anomaly on feature windows |
+| *(planned)* lexical phishing | M5.3 | Domain/URL features + weak labels |
+| *(planned)* C&C ML | M5.4 | Augment `beacon_periodic` with gap/volume model |
+
+## Verify
+
+```bash
+curl http://127.0.0.1:8091/health
+clickhouse-client -q "SELECT count() FROM bsdm.entity_features"
+clickhouse-client -q "SELECT entity_id, score, severity FROM bsdm.ml_scores ORDER BY scored_at DESC LIMIT 10"
+```
+
+## Phases
+
+Epic: [#165](https://github.com/onixus/bsdm-proxy/issues/165) · [roadmap](roadmap.md#m5--ml-security-v10x)
+
+| Phase | Issue |
+|-------|-------|
+| M5.1 scaffold | this tree / ADR 0003 |
+| M5.2 anomaly / UEBA | [#166](https://github.com/onixus/bsdm-proxy/issues/166) |
+| M5.3 phishing lexical | [#167](https://github.com/onixus/bsdm-proxy/issues/167) |
+| M5.4 C&C ML | [#168](https://github.com/onixus/bsdm-proxy/issues/168) |
+| M5.5 score write-back | [#169](https://github.com/onixus/bsdm-proxy/issues/169) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@
 | [M2.5 — Data plane](#m25--data-plane-throughput-v03x) | v0.3.x–0.3.2 | Tiered L1, streaming, P1 hot path | ✅ Done |
 | [M3 — Retro-search](#m3--retro-search) | v0.3.1+ | ClickHouse, Search API, Grafana, k8s CHI | ✅ Done (~95%) |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C / Shannon | ✅ Done |
-| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | ML anomaly, phishing, C&C ML | ~0% |
+| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | Feature store, anomaly / phishing / C&C ML | ~10% (M5.1 scaffold) |
 
 ```mermaid
 gantt
@@ -130,18 +130,32 @@ Rule-based обнаружение угроз поверх ClickHouse. **Крит
 
 ## M5 — ML security (v1.0.x)
 
-- [ ] Feature store, anomaly / phishing / C&C ML, optional inline score
+Async scoring off the proxy hot path. Design: [ADR 0003](adr/0003-ml-worker-feature-store.md) · Ops: [ml-security.md](ml-security.md).
+
+### M5.1 — Scaffolding (in progress / this release track)
+
+- [x] ADR 0003 — CH feature store + `ml-worker` (closes design half of [#46](https://github.com/onixus/bsdm-proxy/issues/46) / B15)
+- [x] DDL `bsdm.entity_features` + `bsdm.ml_scores` (`scripts/clickhouse/ml_features.sql`)
+- [x] Crate `ml-worker` — extract → insert features → `anomaly_stub_v0` scores → optional webhook
+- [x] Compose profile `ml`, packaging/systemd, docs
+
+### Planned
+
+- [ ] **M5.2** Unsupervised UEBA / anomaly on entity windows (replace stub)
+- [ ] **M5.3** Lexical phishing score + weak labels (PhishTank / UT1)
+- [ ] **M5.4** C&C ML augmenting `beacon_periodic`
+- [ ] **M5.5** Optional `threat_score` write-back / cached inline score (not on hot path until proven)
 
 ---
 
 ## Матрица зрелости
 
-| Столп | Сейчас (0.5.0) | После M4 | После M5 |
-|-------|----------------|----------|----------|
-| Squid parity | **~92%** | ~92% | ~93% |
-| Ретропоиск | **~90%** | ~92% | ~95% |
-| ML / C&C / phishing | **~25%** | ~25% | ~75% |
-| **Итого** | **~70%** | ~70% | ~85% |
+| Столп | Сейчас (0.5.0 + M5.1) | После M5 |
+|-------|----------------------|----------|
+| Squid parity | **~92%** | ~93% |
+| Ретропоиск | **~90%** | ~95% |
+| ML / C&C / phishing | **~30%** | ~75% |
+| **Итого** | **~72%** | ~85% |
 
 ---
 
@@ -154,7 +168,7 @@ Rule-based обнаружение угроз поверх ClickHouse. **Крит
 | M2.5 Data plane | 0.3.1–0.3.2 | #94–#109 |
 | M3 Retro-search | 0.3.1+ | #114, #125, #135 |
 | M4 Threat analytics | 0.5.0 | #50, #105, #51 |
-| M5 ML security | 1.0.x | — |
+| M5 ML security | 1.0.x | [#165](https://github.com/onixus/bsdm-proxy/issues/165) epic · [#46](https://github.com/onixus/bsdm-proxy/issues/46) · [#166](https://github.com/onixus/bsdm-proxy/issues/166)–[#169](https://github.com/onixus/bsdm-proxy/issues/169) |
 
 Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 
@@ -191,4 +205,4 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 
 ---
 
-*Обновлено: 2026-07-16 — v0.5.0 (M4 done); next M5 ML; strategic roadmap (Lite/DX/Wasm/AI)*
+*Обновлено: 2026-07-16 — v0.5.0 (M4 done); M5.1 ml-worker + feature store scaffold; next M5.2 anomaly*

--- a/ml-worker/Cargo.toml
+++ b/ml-worker/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ml-worker"
+version = "0.5.0"
+edition = "2021"
+license = "MIT"
+authors = ["BSDM-Proxy Contributors"]
+description = "ClickHouse feature extraction and threat scoring worker (M5)"
+repository = "https://github.com/onixus/bsdm-proxy"
+keywords = ["clickhouse", "ml", "anomaly", "security"]
+categories = ["network-programming"]
+
+[[bin]]
+name = "ml-worker"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+prometheus = "0.14"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/ml-worker/src/clickhouse.rs
+++ b/ml-worker/src/clickhouse.rs
@@ -1,0 +1,121 @@
+//! Minimal ClickHouse HTTP client (query + insert JSONEachRow).
+
+use crate::config::Config;
+use reqwest::Client;
+use tracing::info;
+
+pub struct ClickHouseClient {
+    client: Client,
+    url: String,
+    user: Option<String>,
+    password: Option<String>,
+}
+
+impl ClickHouseClient {
+    pub fn new(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()?;
+        Ok(Self {
+            client,
+            url: config.clickhouse_url.trim_end_matches('/').to_string(),
+            user: config.clickhouse_user.clone(),
+            password: config.clickhouse_password.clone(),
+        })
+    }
+
+    pub async fn ping(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let ping_url = format!("{}/ping", self.url);
+        let mut req = self.client.get(&ping_url);
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        if !response.status().is_success() {
+            return Err(format!("ClickHouse ping failed: HTTP {}", response.status()).into());
+        }
+        info!("ClickHouse reachable at {}", self.url);
+        Ok(())
+    }
+
+    pub async fn query_json_each_row(
+        &self,
+        sql: &str,
+    ) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
+        let mut req = self
+            .client
+            .post(&self.url)
+            .query(&[("query", sql)])
+            .body("");
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if !status.is_success() {
+            return Err(format!("ClickHouse query failed (HTTP {status}): {body}").into());
+        }
+        parse_json_each_row(&body)
+    }
+
+    /// Insert rows as JSONEachRow into `table` (fully-qualified).
+    pub async fn insert_json_each_row(
+        &self,
+        table: &str,
+        rows: &[serde_json::Value],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let mut body = String::new();
+        for row in rows {
+            body.push_str(&serde_json::to_string(row)?);
+            body.push('\n');
+        }
+        let query = format!("INSERT INTO {table} FORMAT JSONEachRow");
+        let mut req = self
+            .client
+            .post(&self.url)
+            .query(&[("query", query.as_str())])
+            .header(reqwest::header::CONTENT_TYPE, "application/x-ndjson")
+            .body(body);
+        if let (Some(user), Some(password)) = (&self.user, &self.password) {
+            req = req.basic_auth(user, Some(password));
+        }
+        let response = req.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("ClickHouse insert failed (HTTP {status}): {text}").into());
+        }
+        Ok(())
+    }
+}
+
+pub fn parse_json_each_row(
+    body: &str,
+) -> Result<Vec<serde_json::Value>, Box<dyn std::error::Error>> {
+    let mut rows = Vec::new();
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        rows.push(serde_json::from_str(line)?);
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_json_each_row() {
+        let body = "{\"entity_id\":\"10.0.0.1\",\"request_count\":12}\n";
+        let rows = parse_json_each_row(body).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["request_count"], 12);
+    }
+}

--- a/ml-worker/src/config.rs
+++ b/ml-worker/src/config.rs
@@ -25,11 +25,12 @@ pub struct Config {
 
 impl Config {
     pub fn from_env() -> Result<Self, String> {
-        let entity_types = parse_list(&std::env::var("ML_ENTITY_TYPES").unwrap_or_else(|_| {
-            "client_ip".into()
-        }));
+        let entity_types =
+            parse_list(&std::env::var("ML_ENTITY_TYPES").unwrap_or_else(|_| "client_ip".into()));
         if entity_types.is_empty() {
-            return Err("ML_ENTITY_TYPES must list at least one of client_ip,username,domain".into());
+            return Err(
+                "ML_ENTITY_TYPES must list at least one of client_ip,username,domain".into(),
+            );
         }
         for t in &entity_types {
             if !matches!(t.as_str(), "client_ip" | "username" | "domain") {
@@ -51,8 +52,7 @@ impl Config {
                 .unwrap_or_else(|_| "http_cache".into()),
             features_table: std::env::var("ML_FEATURES_TABLE")
                 .unwrap_or_else(|_| "entity_features".into()),
-            scores_table: std::env::var("ML_SCORES_TABLE")
-                .unwrap_or_else(|_| "ml_scores".into()),
+            scores_table: std::env::var("ML_SCORES_TABLE").unwrap_or_else(|_| "ml_scores".into()),
             clickhouse_user: std::env::var("CLICKHOUSE_USER")
                 .ok()
                 .filter(|s| !s.is_empty()),
@@ -68,8 +68,7 @@ impl Config {
             webhook_url,
             webhook_timeout: Duration::from_secs(env_u64("ML_WEBHOOK_TIMEOUT_SECS", 10)),
             metrics_port: env_u64("METRICS_PORT", 8091) as u16,
-            source: std::env::var("ML_SOURCE")
-                .unwrap_or_else(|_| "bsdm-proxy-ml-worker".into()),
+            source: std::env::var("ML_SOURCE").unwrap_or_else(|_| "bsdm-proxy-ml-worker".into()),
         })
     }
 

--- a/ml-worker/src/config.rs
+++ b/ml-worker/src/config.rs
@@ -1,0 +1,123 @@
+//! Runtime configuration from environment variables.
+
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub clickhouse_url: String,
+    pub clickhouse_database: String,
+    pub clickhouse_table: String,
+    pub features_table: String,
+    pub scores_table: String,
+    pub clickhouse_user: Option<String>,
+    pub clickhouse_password: Option<String>,
+    pub poll_interval: Duration,
+    pub lookback: Duration,
+    pub entity_types: Vec<String>,
+    pub min_requests: u64,
+    pub model: String,
+    pub score_threshold: f64,
+    pub webhook_url: Option<String>,
+    pub webhook_timeout: Duration,
+    pub metrics_port: u16,
+    pub source: String,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, String> {
+        let entity_types = parse_list(&std::env::var("ML_ENTITY_TYPES").unwrap_or_else(|_| {
+            "client_ip".into()
+        }));
+        if entity_types.is_empty() {
+            return Err("ML_ENTITY_TYPES must list at least one of client_ip,username,domain".into());
+        }
+        for t in &entity_types {
+            if !matches!(t.as_str(), "client_ip" | "username" | "domain") {
+                return Err(format!("unsupported ML_ENTITY_TYPES entry: {t}"));
+            }
+        }
+
+        let webhook_url = std::env::var("ML_WEBHOOK_URL")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        Ok(Self {
+            clickhouse_url: std::env::var("CLICKHOUSE_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:8123".into()),
+            clickhouse_database: std::env::var("CLICKHOUSE_DATABASE")
+                .unwrap_or_else(|_| "bsdm".into()),
+            clickhouse_table: std::env::var("CLICKHOUSE_TABLE")
+                .unwrap_or_else(|_| "http_cache".into()),
+            features_table: std::env::var("ML_FEATURES_TABLE")
+                .unwrap_or_else(|_| "entity_features".into()),
+            scores_table: std::env::var("ML_SCORES_TABLE")
+                .unwrap_or_else(|_| "ml_scores".into()),
+            clickhouse_user: std::env::var("CLICKHOUSE_USER")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            clickhouse_password: std::env::var("CLICKHOUSE_PASSWORD")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            poll_interval: Duration::from_secs(env_u64("ML_POLL_INTERVAL_SECS", 120)),
+            lookback: Duration::from_secs(env_u64("ML_LOOKBACK_SECS", 300)),
+            entity_types,
+            min_requests: env_u64("ML_MIN_REQUESTS", 10),
+            model: std::env::var("ML_MODEL").unwrap_or_else(|_| "anomaly_stub_v0".into()),
+            score_threshold: env_f64("ML_SCORE_THRESHOLD", 0.8)?,
+            webhook_url,
+            webhook_timeout: Duration::from_secs(env_u64("ML_WEBHOOK_TIMEOUT_SECS", 10)),
+            metrics_port: env_u64("METRICS_PORT", 8091) as u16,
+            source: std::env::var("ML_SOURCE")
+                .unwrap_or_else(|_| "bsdm-proxy-ml-worker".into()),
+        })
+    }
+
+    pub fn fq_source(&self) -> String {
+        format!("{}.{}", self.clickhouse_database, self.clickhouse_table)
+    }
+
+    pub fn fq_features(&self) -> String {
+        format!("{}.{}", self.clickhouse_database, self.features_table)
+    }
+
+    pub fn fq_scores(&self) -> String {
+        format!("{}.{}", self.clickhouse_database, self.scores_table)
+    }
+}
+
+fn parse_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_f64(key: &str, default: f64) -> Result<f64, String> {
+    match std::env::var(key) {
+        Ok(v) => v
+            .parse()
+            .map_err(|_| format!("{key} must be a float, got {v:?}")),
+        Err(_) => Ok(default),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_entity_list() {
+        assert_eq!(
+            parse_list("client_ip, username,domain"),
+            vec!["client_ip", "username", "domain"]
+        );
+    }
+}

--- a/ml-worker/src/features.rs
+++ b/ml-worker/src/features.rs
@@ -1,0 +1,224 @@
+//! Feature extraction SQL and row parsing.
+
+use crate::config::Config;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EntityFeatures {
+    pub window_start: DateTime<Utc>,
+    pub window_secs: u32,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub request_count: u64,
+    pub unique_domains: u64,
+    pub unique_urls: u64,
+    pub deny_count: u64,
+    pub threat_hit_count: u64,
+    pub avg_response_size: f64,
+    pub avg_duration_ms: f64,
+    pub gap_cv: f64,
+    pub max_domain_len: u64,
+    pub extracted_at: DateTime<Utc>,
+}
+
+impl EntityFeatures {
+    pub fn to_insert_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "window_start": self.window_start.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "window_secs": self.window_secs,
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "request_count": self.request_count,
+            "unique_domains": self.unique_domains,
+            "unique_urls": self.unique_urls,
+            "deny_count": self.deny_count,
+            "threat_hit_count": self.threat_hit_count,
+            "avg_response_size": self.avg_response_size,
+            "avg_duration_ms": self.avg_duration_ms,
+            "gap_cv": self.gap_cv,
+            "max_domain_len": self.max_domain_len,
+            "extracted_at": self.extracted_at.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+        })
+    }
+}
+
+/// Build aggregation SQL for one entity type over the lookback window.
+pub fn extract_sql(config: &Config, entity_type: &str) -> String {
+    let entity_expr = match entity_type {
+        "client_ip" => "toString(client_ip)",
+        "username" => "ifNull(username, '')",
+        "domain" => "domain",
+        other => panic!("unsupported entity_type: {other}"),
+    };
+    let lookback = config.lookback.as_secs();
+    let min_req = config.min_requests;
+    let table = config.fq_source();
+
+    // gap_cv: coefficient of variation of inter-arrival times (0 if <2 events).
+    format!(
+        r#"
+SELECT
+  min(ts) AS window_start,
+  toUInt32({lookback}) AS window_secs,
+  '{entity_type}' AS entity_type,
+  {entity_expr} AS entity_id,
+  count() AS request_count,
+  uniqExact(domain) AS unique_domains,
+  uniqExact(url) AS unique_urls,
+  countIf(acl_action = 'deny' OR cache_status = 'DENY') AS deny_count,
+  countIf(length(threat_sources) > 0) AS threat_hit_count,
+  avg(response_size) AS avg_response_size,
+  avg(request_duration_ms) AS avg_duration_ms,
+  if(
+    count() < 3,
+    0.0,
+    ifNull(
+      arrayReduce(
+        'stddevPop',
+        arrayDifference(arraySort(groupArray(toUnixTimestamp64Milli(ts))))
+      )
+      / nullIf(
+        arrayReduce(
+          'avg',
+          arrayDifference(arraySort(groupArray(toUnixTimestamp64Milli(ts))))
+        ),
+        0
+      ),
+      0.0
+    )
+  ) AS gap_cv,
+  max(length(domain)) AS max_domain_len,
+  now64(3) AS extracted_at
+FROM {table}
+WHERE ts >= now() - INTERVAL {lookback} SECOND
+  AND {entity_expr} != ''
+GROUP BY entity_id
+HAVING request_count >= {min_req}
+FORMAT JSONEachRow
+"#
+    )
+}
+
+pub fn features_from_row(
+    row: &serde_json::Value,
+) -> Result<EntityFeatures, Box<dyn std::error::Error>> {
+    let window_start = parse_ch_datetime(row.get("window_start"))?;
+    let extracted_at = parse_ch_datetime(row.get("extracted_at")).unwrap_or_else(|_| Utc::now());
+    Ok(EntityFeatures {
+        window_start,
+        window_secs: as_u64(row.get("window_secs"))? as u32,
+        entity_type: as_string(row.get("entity_type"))?,
+        entity_id: as_string(row.get("entity_id"))?,
+        request_count: as_u64(row.get("request_count"))?,
+        unique_domains: as_u64(row.get("unique_domains"))?,
+        unique_urls: as_u64(row.get("unique_urls"))?,
+        deny_count: as_u64(row.get("deny_count"))?,
+        threat_hit_count: as_u64(row.get("threat_hit_count"))?,
+        avg_response_size: as_f64(row.get("avg_response_size"))?,
+        avg_duration_ms: as_f64(row.get("avg_duration_ms"))?,
+        gap_cv: as_f64(row.get("gap_cv")).unwrap_or(0.0),
+        max_domain_len: as_u64(row.get("max_domain_len"))?,
+        extracted_at,
+    })
+}
+
+fn parse_ch_datetime(v: Option<&serde_json::Value>) -> Result<DateTime<Utc>, String> {
+    let s = v
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| "missing datetime".to_string())?;
+    // ClickHouse JSONEachRow: "2026-07-16 12:00:00.000"
+    let normalized = if s.contains('T') {
+        s.to_string()
+    } else {
+        s.replace(' ', "T") + "Z"
+    };
+    DateTime::parse_from_rfc3339(&normalized)
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S%.3f")
+                .or_else(|_| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S"))
+                .map(|ndt| ndt.and_utc())
+                .map_err(|e| e.to_string())
+        })
+}
+
+fn as_string(v: Option<&serde_json::Value>) -> Result<String, String> {
+    v.and_then(|x| x.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "expected string".into())
+}
+
+fn as_u64(v: Option<&serde_json::Value>) -> Result<u64, String> {
+    match v {
+        Some(serde_json::Value::Number(n)) => n
+            .as_u64()
+            .or_else(|| n.as_f64().map(|f| f as u64))
+            .ok_or_else(|| "bad number".into()),
+        Some(serde_json::Value::String(s)) => s.parse().map_err(|e| format!("{e}")),
+        _ => Err("expected u64".into()),
+    }
+}
+
+fn as_f64(v: Option<&serde_json::Value>) -> Result<f64, String> {
+    match v {
+        Some(serde_json::Value::Number(n)) => n.as_f64().ok_or_else(|| "bad float".into()),
+        Some(serde_json::Value::String(s)) => s.parse().map_err(|e| format!("{e}")),
+        _ => Err("expected f64".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_sql_mentions_entity_and_table() {
+        let cfg = Config {
+            clickhouse_url: "http://x".into(),
+            clickhouse_database: "bsdm".into(),
+            clickhouse_table: "http_cache".into(),
+            features_table: "entity_features".into(),
+            scores_table: "ml_scores".into(),
+            clickhouse_user: None,
+            clickhouse_password: None,
+            poll_interval: std::time::Duration::from_secs(60),
+            lookback: std::time::Duration::from_secs(300),
+            entity_types: vec!["client_ip".into()],
+            min_requests: 10,
+            model: "anomaly_stub_v0".into(),
+            score_threshold: 0.8,
+            webhook_url: None,
+            webhook_timeout: std::time::Duration::from_secs(10),
+            metrics_port: 8091,
+            source: "test".into(),
+        };
+        let sql = extract_sql(&cfg, "client_ip");
+        assert!(sql.contains("bsdm.http_cache"));
+        assert!(sql.contains("toString(client_ip)"));
+        assert!(sql.contains("HAVING request_count >= 10"));
+    }
+
+    #[test]
+    fn parses_feature_row() {
+        let row = serde_json::json!({
+            "window_start": "2026-07-16 12:00:00.000",
+            "window_secs": 300,
+            "entity_type": "client_ip",
+            "entity_id": "10.0.0.1",
+            "request_count": 42,
+            "unique_domains": 5,
+            "unique_urls": 10,
+            "deny_count": 2,
+            "threat_hit_count": 1,
+            "avg_response_size": 1024.5,
+            "avg_duration_ms": 12.0,
+            "gap_cv": 0.1,
+            "max_domain_len": 24,
+            "extracted_at": "2026-07-16 12:05:00.000"
+        });
+        let f = features_from_row(&row).unwrap();
+        assert_eq!(f.entity_id, "10.0.0.1");
+        assert_eq!(f.request_count, 42);
+    }
+}

--- a/ml-worker/src/main.rs
+++ b/ml-worker/src/main.rs
@@ -92,13 +92,16 @@ async fn cycle_once(
     ch.insert_json_each_row(&config.fq_features(), &feature_jsons)
         .await?;
     metrics.features_written.inc_by(feature_jsons.len() as u64);
-    metrics
-        .last_cycle_features
-        .set(feature_jsons.len() as i64);
+    metrics.last_cycle_features.set(feature_jsons.len() as i64);
 
     let mut score_jsons = Vec::new();
     for f in &all_features {
-        let scored = score_features(f, &config.model, config.min_requests, config.score_threshold);
+        let scored = score_features(
+            f,
+            &config.model,
+            config.min_requests,
+            config.score_threshold,
+        );
         if let Some(wh) = webhook {
             if scored.score >= config.score_threshold {
                 if let Err(e) = wh.post_score(&scored).await {

--- a/ml-worker/src/main.rs
+++ b/ml-worker/src/main.rs
@@ -1,0 +1,168 @@
+mod clickhouse;
+mod config;
+mod features;
+mod metrics;
+mod scoring;
+mod webhook;
+
+use clickhouse::ClickHouseClient;
+use config::Config;
+use features::{extract_sql, features_from_row};
+use metrics::WorkerMetrics;
+use scoring::score_features;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::{error, info, warn};
+use webhook::WebhookClient;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,ml_worker=info".into()),
+        )
+        .init();
+
+    let config = Config::from_env().map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+    let metrics = WorkerMetrics::new()?;
+    let ch = ClickHouseClient::new(&config)?;
+    ch.ping().await?;
+    let webhook = match WebhookClient::new(&config) {
+        Some(Ok(w)) => Some(w),
+        Some(Err(e)) => return Err(e),
+        None => None,
+    };
+
+    {
+        let metrics = metrics.clone();
+        let port = config.metrics_port;
+        tokio::spawn(async move {
+            run_admin_server(port, metrics).await;
+        });
+    }
+
+    info!(
+        source = %config.fq_source(),
+        features = %config.fq_features(),
+        scores = %config.fq_scores(),
+        model = %config.model,
+        entities = ?config.entity_types,
+        poll_secs = config.poll_interval.as_secs(),
+        lookback_secs = config.lookback.as_secs(),
+        webhook = webhook.is_some(),
+        "ml-worker started (M5.1 feature store + anomaly_stub_v0)"
+    );
+
+    loop {
+        if let Err(e) = cycle_once(&config, &ch, webhook.as_ref(), &metrics).await {
+            metrics.errors.inc();
+            warn!("ml-worker cycle failed: {e}");
+        }
+        tokio::time::sleep(config.poll_interval).await;
+    }
+}
+
+async fn cycle_once(
+    config: &Config,
+    ch: &ClickHouseClient,
+    webhook: Option<&WebhookClient>,
+    metrics: &WorkerMetrics,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut all_features = Vec::new();
+    for entity_type in &config.entity_types {
+        let sql = extract_sql(config, entity_type);
+        let rows = ch.query_json_each_row(&sql).await?;
+        for row in rows {
+            match features_from_row(&row) {
+                Ok(f) => all_features.push(f),
+                Err(e) => {
+                    warn!("skip feature row: {e}");
+                    metrics.errors.inc();
+                }
+            }
+        }
+    }
+
+    let feature_jsons: Vec<_> = all_features.iter().map(|f| f.to_insert_json()).collect();
+    ch.insert_json_each_row(&config.fq_features(), &feature_jsons)
+        .await?;
+    metrics.features_written.inc_by(feature_jsons.len() as u64);
+    metrics
+        .last_cycle_features
+        .set(feature_jsons.len() as i64);
+
+    let mut score_jsons = Vec::new();
+    for f in &all_features {
+        let scored = score_features(f, &config.model, config.min_requests, config.score_threshold);
+        if let Some(wh) = webhook {
+            if scored.score >= config.score_threshold {
+                if let Err(e) = wh.post_score(&scored).await {
+                    warn!("webhook failed for {}: {e}", scored.entity_id);
+                    metrics.errors.inc();
+                } else {
+                    metrics.webhooks_sent.inc();
+                }
+            }
+        }
+        score_jsons.push(scored.to_insert_json());
+    }
+    ch.insert_json_each_row(&config.fq_scores(), &score_jsons)
+        .await?;
+    metrics.scores_written.inc_by(score_jsons.len() as u64);
+    metrics.cycles.inc();
+
+    info!(
+        features = feature_jsons.len(),
+        scores = score_jsons.len(),
+        "cycle complete"
+    );
+    Ok(())
+}
+
+async fn run_admin_server(port: u16, metrics: WorkerMetrics) {
+    let addr = format!("0.0.0.0:{port}");
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("metrics bind {addr}: {e}");
+            return;
+        }
+    };
+    info!("ml-worker metrics on http://{addr}/metrics");
+    let metrics = Arc::new(metrics);
+    loop {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            continue;
+        };
+        let metrics = metrics.clone();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let _ = socket.read(&mut buf).await;
+            let req = String::from_utf8_lossy(&buf);
+            let (status, body, ctype) = if req.starts_with("GET /health") {
+                (
+                    "200 OK",
+                    r#"{"status":"ok","service":"ml-worker"}"#.to_string(),
+                    "application/json",
+                )
+            } else if req.starts_with("GET /metrics") {
+                match metrics.encode() {
+                    Ok(b) => ("200 OK", b, "text/plain; version=0.0.4"),
+                    Err(_) => ("500 Internal Server Error", String::new(), "text/plain"),
+                }
+            } else {
+                ("404 Not Found", "not found".into(), "text/plain")
+            };
+            let resp = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(resp.as_bytes()).await;
+        });
+    }
+}

--- a/ml-worker/src/metrics.rs
+++ b/ml-worker/src/metrics.rs
@@ -1,0 +1,66 @@
+//! Prometheus metrics for ml-worker.
+
+use prometheus::{IntCounter, IntGauge, Opts, Registry, TextEncoder, Encoder};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct WorkerMetrics {
+    pub registry: Arc<Registry>,
+    pub cycles: IntCounter,
+    pub features_written: IntCounter,
+    pub scores_written: IntCounter,
+    pub webhooks_sent: IntCounter,
+    pub errors: IntCounter,
+    pub last_cycle_features: IntGauge,
+}
+
+impl WorkerMetrics {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let registry = Registry::new();
+        let cycles = IntCounter::with_opts(Opts::new(
+            "bsdm_ml_worker_cycles_total",
+            "Completed extract/score cycles",
+        ))?;
+        let features_written = IntCounter::with_opts(Opts::new(
+            "bsdm_ml_worker_features_written_total",
+            "Rows inserted into entity_features",
+        ))?;
+        let scores_written = IntCounter::with_opts(Opts::new(
+            "bsdm_ml_worker_scores_written_total",
+            "Rows inserted into ml_scores",
+        ))?;
+        let webhooks_sent = IntCounter::with_opts(Opts::new(
+            "bsdm_ml_worker_webhooks_sent_total",
+            "Webhook POSTs for high scores",
+        ))?;
+        let errors = IntCounter::with_opts(Opts::new(
+            "bsdm_ml_worker_errors_total",
+            "Failed cycles or CH/webhook errors",
+        ))?;
+        let last_cycle_features = IntGauge::with_opts(Opts::new(
+            "bsdm_ml_worker_last_cycle_features",
+            "Feature rows in the last successful cycle",
+        ))?;
+        registry.register(Box::new(cycles.clone()))?;
+        registry.register(Box::new(features_written.clone()))?;
+        registry.register(Box::new(scores_written.clone()))?;
+        registry.register(Box::new(webhooks_sent.clone()))?;
+        registry.register(Box::new(errors.clone()))?;
+        registry.register(Box::new(last_cycle_features.clone()))?;
+        Ok(Self {
+            registry: Arc::new(registry),
+            cycles,
+            features_written,
+            scores_written,
+            webhooks_sent,
+            errors,
+            last_cycle_features,
+        })
+    }
+
+    pub fn encode(&self) -> Result<String, Box<dyn std::error::Error>> {
+        let mut buf = Vec::new();
+        TextEncoder::new().encode(&self.registry.gather(), &mut buf)?;
+        Ok(String::from_utf8(buf)?)
+    }
+}

--- a/ml-worker/src/metrics.rs
+++ b/ml-worker/src/metrics.rs
@@ -1,6 +1,6 @@
 //! Prometheus metrics for ml-worker.
 
-use prometheus::{IntCounter, IntGauge, Opts, Registry, TextEncoder, Encoder};
+use prometheus::{Encoder, IntCounter, IntGauge, Opts, Registry, TextEncoder};
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/ml-worker/src/scoring.rs
+++ b/ml-worker/src/scoring.rs
@@ -1,0 +1,140 @@
+//! Scoring models. M5.1 ships `anomaly_stub_v0` only.
+
+use crate::features::EntityFeatures;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ScoreResult {
+    pub scored_at: DateTime<Utc>,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub window_start: DateTime<Utc>,
+    pub model: String,
+    pub score: f64,
+    pub severity: String,
+    pub features_json: String,
+}
+
+impl ScoreResult {
+    pub fn to_insert_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "scored_at": self.scored_at.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "window_start": self.window_start.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+            "model": self.model,
+            "score": self.score,
+            "severity": self.severity,
+            "features_json": self.features_json,
+        })
+    }
+}
+
+/// Heuristic anomaly score in \[0, 1\].
+///
+/// Combines request intensity (relative to min_requests), deny ratio, and threat hits.
+/// Not a trained model — baseline for M5.1 scaffolding and Grafana wiring.
+pub fn anomaly_stub_v0(features: &EntityFeatures, min_requests: u64) -> f64 {
+    let min_r = min_requests.max(1) as f64;
+    let rate_component = ((features.request_count as f64) / (min_r * 5.0)).min(1.0);
+    let deny_ratio = if features.request_count == 0 {
+        0.0
+    } else {
+        features.deny_count as f64 / features.request_count as f64
+    };
+    let threat_ratio = if features.request_count == 0 {
+        0.0
+    } else {
+        features.threat_hit_count as f64 / features.request_count as f64
+    };
+    let domain_spread = ((features.unique_domains as f64) / 20.0).min(1.0);
+    // Low gap_cv with high rate can hint periodicity (beacon-like); mild contribution.
+    let beacon_hint = if features.request_count >= 5 && features.gap_cv > 0.0 && features.gap_cv < 0.25
+    {
+        0.15
+    } else {
+        0.0
+    };
+
+    let raw = 0.35 * rate_component
+        + 0.30 * deny_ratio
+        + 0.20 * threat_ratio
+        + 0.10 * domain_spread
+        + beacon_hint;
+    raw.clamp(0.0, 1.0)
+}
+
+pub fn severity_for(score: f64, threshold: f64) -> &'static str {
+    if score >= threshold.max(0.9) {
+        "critical"
+    } else if score >= threshold {
+        "high"
+    } else if score >= threshold * 0.6 {
+        "medium"
+    } else {
+        "low"
+    }
+}
+
+pub fn score_features(
+    features: &EntityFeatures,
+    model: &str,
+    min_requests: u64,
+    threshold: f64,
+) -> ScoreResult {
+    let score = if model == "anomaly_stub_v0" || model.is_empty() {
+        anomaly_stub_v0(features, min_requests)
+    } else {
+        // Unknown model ids fall back to stub until M5.2+ loaders land.
+        anomaly_stub_v0(features, min_requests)
+    };
+    let features_json = serde_json::to_string(features).unwrap_or_else(|_| "{}".into());
+    ScoreResult {
+        scored_at: Utc::now(),
+        entity_type: features.entity_type.clone(),
+        entity_id: features.entity_id.clone(),
+        window_start: features.window_start,
+        model: model.to_string(),
+        score,
+        severity: severity_for(score, threshold).to_string(),
+        features_json,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn sample(requests: u64, deny: u64, threat: u64) -> EntityFeatures {
+        EntityFeatures {
+            window_start: Utc.with_ymd_and_hms(2026, 7, 16, 12, 0, 0).unwrap(),
+            window_secs: 300,
+            entity_type: "client_ip".into(),
+            entity_id: "10.0.0.1".into(),
+            request_count: requests,
+            unique_domains: 3,
+            unique_urls: 5,
+            deny_count: deny,
+            threat_hit_count: threat,
+            avg_response_size: 100.0,
+            avg_duration_ms: 10.0,
+            gap_cv: 0.5,
+            max_domain_len: 12,
+            extracted_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn quiet_entity_scores_low() {
+        let s = anomaly_stub_v0(&sample(10, 0, 0), 10);
+        assert!(s < 0.5, "score={s}");
+    }
+
+    #[test]
+    fn burst_deny_scores_high() {
+        let s = anomaly_stub_v0(&sample(100, 80, 40), 10);
+        assert!(s >= 0.65, "score={s}");
+    }
+}

--- a/ml-worker/src/scoring.rs
+++ b/ml-worker/src/scoring.rs
@@ -50,12 +50,12 @@ pub fn anomaly_stub_v0(features: &EntityFeatures, min_requests: u64) -> f64 {
     };
     let domain_spread = ((features.unique_domains as f64) / 20.0).min(1.0);
     // Low gap_cv with high rate can hint periodicity (beacon-like); mild contribution.
-    let beacon_hint = if features.request_count >= 5 && features.gap_cv > 0.0 && features.gap_cv < 0.25
-    {
-        0.15
-    } else {
-        0.0
-    };
+    let beacon_hint =
+        if features.request_count >= 5 && features.gap_cv > 0.0 && features.gap_cv < 0.25 {
+            0.15
+        } else {
+            0.0
+        };
 
     let raw = 0.35 * rate_component
         + 0.30 * deny_ratio

--- a/ml-worker/src/webhook.rs
+++ b/ml-worker/src/webhook.rs
@@ -1,0 +1,54 @@
+//! Optional SIEM webhook (compatible payload shape with alert-worker).
+
+use crate::config::Config;
+use crate::scoring::ScoreResult;
+use reqwest::Client;
+use uuid::Uuid;
+
+pub struct WebhookClient {
+    client: Client,
+    url: String,
+    source: String,
+}
+
+impl WebhookClient {
+    pub fn new(config: &Config) -> Option<Result<Self, Box<dyn std::error::Error>>> {
+        let url = config.webhook_url.as_ref()?;
+        let client = match Client::builder().timeout(config.webhook_timeout).build() {
+            Ok(c) => c,
+            Err(e) => return Some(Err(e.into())),
+        };
+        Some(Ok(Self {
+            client,
+            url: url.clone(),
+            source: config.source.clone(),
+        }))
+    }
+
+    pub async fn post_score(
+        &self,
+        score: &ScoreResult,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let body = serde_json::json!({
+            "alert_id": Uuid::new_v4().to_string(),
+            "rule": "ml_anomaly",
+            "model": score.model,
+            "severity": score.severity,
+            "score": score.score,
+            "entity_type": score.entity_type,
+            "entity_id": score.entity_id,
+            "window_start": score.window_start.to_rfc3339(),
+            "scored_at": score.scored_at.to_rfc3339(),
+            "source": self.source,
+            "features": serde_json::from_str::<serde_json::Value>(&score.features_json)
+                .unwrap_or(serde_json::json!({})),
+        });
+        let response = self.client.post(&self.url).json(&body).send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            return Err(format!("webhook HTTP {status}: {text}").into());
+        }
+        Ok(())
+    }
+}

--- a/ml-worker/src/webhook.rs
+++ b/ml-worker/src/webhook.rs
@@ -25,10 +25,7 @@ impl WebhookClient {
         }))
     }
 
-    pub async fn post_score(
-        &self,
-        score: &ScoreResult,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn post_score(&self, score: &ScoreResult) -> Result<(), Box<dyn std::error::Error>> {
         let body = serde_json::json!({
             "alert_id": Uuid::new_v4().to_string(),
             "rule": "ml_anomaly",

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -11,6 +11,7 @@
 | `bin/proxy` | HTTPS caching proxy |
 | `bin/cache-indexer` | Kafka → ClickHouse indexer |
 | `bin/alert-worker` | ClickHouse → SIEM/webhook alerts (optional) |
+| `bin/ml-worker` | ClickHouse → entity features + ML scores (M5, optional) |
 | `config/*.example` | Environment and ACL templates |
 | `systemd/` | systemd unit files |
 | `install.sh` | Installer script |
@@ -36,6 +37,8 @@ sudo systemctl start bsdm-proxy
 
 Optional SIEM alerts: configure `config/alert-worker.env.example` → `/etc/bsdm-proxy/alert-worker.env`, then `systemctl enable --now bsdm-alert-worker`.
 
+Optional M5 ML worker: apply `scripts/clickhouse/ml_features.sql`, configure `ml-worker.env`, then `systemctl enable --now bsdm-ml-worker` (see [docs/ml-security.md](../docs/ml-security.md)).
+
 ## Manual run
 
 ```bash
@@ -54,6 +57,7 @@ set +a
 | Metrics / health | 9090 |
 | cache-indexer admin / Search API | 8080 |
 | alert-worker metrics | 8090 |
+| ml-worker metrics | 8091 |
 
 ## Verify
 

--- a/packaging/config/ml-worker.env.example
+++ b/packaging/config/ml-worker.env.example
@@ -1,0 +1,21 @@
+# ml-worker (M5) — ClickHouse feature store + scoring
+# Copy to /etc/bsdm-proxy/ml-worker.env
+
+CLICKHOUSE_URL=http://127.0.0.1:8123
+CLICKHOUSE_DATABASE=bsdm
+CLICKHOUSE_TABLE=http_cache
+ML_FEATURES_TABLE=entity_features
+ML_SCORES_TABLE=ml_scores
+
+ML_POLL_INTERVAL_SECS=120
+ML_LOOKBACK_SECS=300
+ML_ENTITY_TYPES=client_ip
+ML_MIN_REQUESTS=10
+ML_MODEL=anomaly_stub_v0
+ML_SCORE_THRESHOLD=0.8
+
+# Optional SIEM webhook (same JSON family as alert-worker)
+# ML_WEBHOOK_URL=https://siem.example/hooks/bsdm-ml
+
+METRICS_PORT=8091
+RUST_LOG=info,ml_worker=info

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -76,6 +76,9 @@ install -d -m 0755 "${PREFIX}/bin"
 install -m 0755 "${SCRIPT_DIR}/bin/proxy" "${PREFIX}/bin/proxy"
 install -m 0755 "${SCRIPT_DIR}/bin/cache-indexer" "${PREFIX}/bin/cache-indexer"
 install -m 0755 "${SCRIPT_DIR}/bin/alert-worker" "${PREFIX}/bin/alert-worker"
+if [[ -x "${SCRIPT_DIR}/bin/ml-worker" ]]; then
+  install -m 0755 "${SCRIPT_DIR}/bin/ml-worker" "${PREFIX}/bin/ml-worker"
+fi
 
 install -d -m 0755 "${ETC_DIR}"
 if [[ ! -f "${ETC_DIR}/bsdm-proxy.env" ]]; then
@@ -90,6 +93,10 @@ if [[ ! -f "${ETC_DIR}/alert-worker.env" ]]; then
   install -m 0640 "${SCRIPT_DIR}/config/alert-worker.env.example" "${ETC_DIR}/alert-worker.env"
   echo "Installed ${ETC_DIR}/alert-worker.env"
 fi
+if [[ -f "${SCRIPT_DIR}/config/ml-worker.env.example" && ! -f "${ETC_DIR}/ml-worker.env" ]]; then
+  install -m 0640 "${SCRIPT_DIR}/config/ml-worker.env.example" "${ETC_DIR}/ml-worker.env"
+  echo "Installed ${ETC_DIR}/ml-worker.env"
+fi
 if [[ ! -f "${ETC_DIR}/acl-rules.json" ]]; then
   install -m 0644 "${SCRIPT_DIR}/config/acl-rules.example.json" "${ETC_DIR}/acl-rules.json"
   echo "Installed ${ETC_DIR}/acl-rules.json"
@@ -102,16 +109,19 @@ if $CREATE_USER; then
 fi
 
 if $INSTALL_SYSTEMD; then
-  for unit in bsdm-proxy bsdm-cache-indexer bsdm-alert-worker; do
-    sed "s|/opt/bsdm-proxy|${PREFIX}|g" \
-      "${SCRIPT_DIR}/systemd/${unit}.service" \
-      >"/etc/systemd/system/${unit}.service"
+  for unit in bsdm-proxy bsdm-cache-indexer bsdm-alert-worker bsdm-ml-worker; do
+    if [[ -f "${SCRIPT_DIR}/systemd/${unit}.service" ]]; then
+      sed "s|/opt/bsdm-proxy|${PREFIX}|g" \
+        "${SCRIPT_DIR}/systemd/${unit}.service" \
+        >"/etc/systemd/system/${unit}.service"
+    fi
   done
   systemctl daemon-reload
   echo "Systemd units installed. Start with:"
   echo "  systemctl enable --now bsdm-proxy"
   echo "  systemctl enable --now bsdm-cache-indexer  # optional"
   echo "  systemctl enable --now bsdm-alert-worker   # optional; set ALERT_WEBHOOK_URL first"
+  echo "  systemctl enable --now bsdm-ml-worker      # optional; M5 feature store"
 fi
 
 cat <<EOF

--- a/packaging/systemd/bsdm-ml-worker.service
+++ b/packaging/systemd/bsdm-ml-worker.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=BSDM-Proxy ML worker (ClickHouse features + scores)
+Documentation=https://github.com/onixus/bsdm-proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bsdm-proxy
+Group=bsdm-proxy
+EnvironmentFile=-/etc/bsdm-proxy/ml-worker.env
+ExecStart=/opt/bsdm-proxy/bin/ml-worker
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -15,13 +15,18 @@ PACKAGE_NAME="bsdm-proxy-${PACKAGE_VERSION}-${OS}-${ARCH}"
 STAGING="${ROOT}/dist/${PACKAGE_NAME}"
 
 echo "==> Building release binaries (v${VERSION})"
-cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer -p alert-worker --bin alert-worker
+cargo build --release \
+  -p bsdm-proxy --bin proxy \
+  -p cache-indexer --bin cache-indexer \
+  -p alert-worker --bin alert-worker \
+  -p ml-worker --bin ml-worker
 
 echo "==> Assembling package ${PACKAGE_NAME}"
 rm -rf "$STAGING"
 mkdir -p "$STAGING"/{bin,config,systemd}
 
-cp target/release/proxy target/release/cache-indexer target/release/alert-worker "$STAGING/bin/"
+cp target/release/proxy target/release/cache-indexer \
+  target/release/alert-worker target/release/ml-worker "$STAGING/bin/"
 cp packaging/config/*.example "$STAGING/config/"
 cp config/acl-rules.example.json "$STAGING/config/"
 cp packaging/systemd/*.service "$STAGING/systemd/"

--- a/scripts/clickhouse/ml_features.sql
+++ b/scripts/clickhouse/ml_features.sql
@@ -1,0 +1,56 @@
+-- M5 feature store tables (ADR 0003)
+-- Applied via docker-entrypoint-initdb.d or:
+--   clickhouse-client --multiquery < scripts/clickhouse/ml_features.sql
+
+CREATE DATABASE IF NOT EXISTS bsdm;
+
+-- Rolling entity windows extracted by ml-worker from http_cache.
+CREATE TABLE IF NOT EXISTS bsdm.entity_features
+(
+    window_start DateTime64(3, 'UTC'),
+    window_secs UInt32,
+    entity_type LowCardinality(String),
+    entity_id String,
+    request_count UInt64,
+    unique_domains UInt64,
+    unique_urls UInt64,
+    deny_count UInt64,
+    threat_hit_count UInt64,
+    avg_response_size Float64,
+    avg_duration_ms Float64,
+    gap_cv Float64,
+    max_domain_len UInt64,
+    extracted_at DateTime64(3, 'UTC')
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(window_start)
+ORDER BY (entity_type, entity_id, window_start)
+TTL window_start + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+-- Model / stub scores keyed to an entity window.
+CREATE TABLE IF NOT EXISTS bsdm.ml_scores
+(
+    scored_at DateTime64(3, 'UTC'),
+    entity_type LowCardinality(String),
+    entity_id String,
+    window_start DateTime64(3, 'UTC'),
+    model LowCardinality(String),
+    score Float64,
+    severity LowCardinality(String),
+    features_json String DEFAULT '{}'
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMMDD(scored_at)
+ORDER BY (entity_type, entity_id, scored_at)
+TTL scored_at + INTERVAL 90 DAY
+SETTINGS index_granularity = 8192;
+
+-- Example: top anomalous client IPs (last 24h)
+-- SELECT entity_id, max(score) AS max_score, argMax(severity, score) AS severity
+-- FROM bsdm.ml_scores
+-- WHERE scored_at >= now() - INTERVAL 1 DAY
+--   AND entity_type = 'client_ip'
+-- GROUP BY entity_id
+-- ORDER BY max_score DESC
+-- LIMIT 50;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Starts **M5 ML security** with scaffolding (ADR 0003): async `ml-worker` extracts entity windows from ClickHouse into a feature store and writes stub anomaly scores. Proxy hot path stays ML-free. Closes design/scaffold half of #46 (B15).

Epic: #165 · Follow-ups: #166 (anomaly), #167 (phishing), #168 (C&C ML), #169 (write-back).

## What's included

| Piece | Detail |
|-------|--------|
| **ADR 0003** | CH feature store + `ml-worker` sibling to `alert-worker` |
| **DDL** | `bsdm.entity_features`, `bsdm.ml_scores` (`scripts/clickhouse/ml_features.sql`) |
| **`ml-worker`** | Poll → aggregate → insert features → `anomaly_stub_v0` → optional webhook |
| **Compose** | profile `ml`, metrics `:8091` |
| **Packaging** | bin + systemd + env example; `build-package.sh` |
| **Docs** | `docs/ml-security.md`, roadmap/architecture/README |

## Quick try

```bash
clickhouse-client --multiquery < scripts/clickhouse/ml_features.sql
docker compose --profile ml up -d --build ml-worker
curl http://127.0.0.1:8091/health
```

## Tests

- `cargo test -p ml-worker` (6 unit tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## CI fix

- rustfmt on `ml-worker` sources (failed Format check on first push)

## Out of scope (later phases)

Trained UEBA / phishing / C&C models, inline proxy scoring.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

