### PR TITLE
M5 wrap-up: threat scores UI, Grafana panel, roadmap complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **M5.5 threat score write-back** — `ml-worker` publishes to `threat_score_cache` + `GET /api/threat-scores`; proxy optional async poll enriches `threat_sources` / block ([#169](https://github.com/onixus/bsdm-proxy/issues/169))
+- **Admin console** — Threat scores page (M5.5 snapshot + XAI); dashboard uses live write-back API
 - **M5.4 C&C beacon ML** — `cc_beacon_v0`: augments M4 `beacon_periodic` with behavioral signals (POST ratio, small payloads, off-hours); `beacon_pair_features` table; Grafana panel; `scripts/ml/eval_cc_beacon.py` ([#168](https://github.com/onixus/bsdm-proxy/issues/168))
 - **M5.3 lexical phishing** — `phishing_lexical_v0`: domain lexical heuristics + weak labels from PhishTank / UT1 / `phishing` category; `domain_phishing_features` table; Grafana panel; `scripts/ml/eval_phishing_lexical.py` ([#167](https://github.com/onixus/bsdm-proxy/issues/167))
 - **Admin console (UI/UX)** — React + Tailwind SPA in `admin-console/`: unified dashboard, logs with explainable ML (XAI), policies, settings; migrates `web-config` export logic

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -4,6 +4,7 @@ import { DashboardPage } from './pages/Dashboard'
 import { LogsPage } from './pages/Logs'
 import { PoliciesPage } from './pages/Policies'
 import { SettingsPage } from './pages/Settings'
+import { ThreatScoresPage } from './pages/ThreatScores'
 
 export function App() {
   return (
@@ -12,6 +13,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/logs" element={<LogsPage />} />
+          <Route path="/threat-scores" element={<ThreatScoresPage />} />
           <Route path="/policies" element={<PoliciesPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/admin-console/src/api/metrics.ts
+++ b/admin-console/src/api/metrics.ts
@@ -50,14 +50,20 @@ export async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
 }
 
 export async function fetchTopMlScores(): Promise<MlScoreRow[]> {
-  const settings = loadApiSettings()
-  try {
-    return await apiFetch<MlScoreRow[]>('/api/ml/scores?limit=10', {
-      baseUrl: settings.mlBaseUrl,
-    })
-  } catch {
-    return mockMlScores()
-  }
+  const { fetchThreatScores } = await import('./threatScores')
+  const snap = await fetchThreatScores()
+  return snap.scores
+    .slice()
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 10)
+    .map((s) => ({
+      entity_id: s.entity_id,
+      entity_type: s.entity_type,
+      score: s.score,
+      severity: s.severity,
+      model: s.model,
+      scored_at: s.scored_at,
+    }))
 }
 
 function mockMetrics(): DashboardMetric[] {
@@ -66,13 +72,5 @@ function mockMetrics(): DashboardMetric[] {
     { id: 'hit-rate', label: 'Cache hit rate', value: '87.2', unit: '%', trend: 'up', status: 'ok' },
     { id: 'denied', label: 'Denied (24h)', value: 342, trend: 'flat', status: 'warn' },
     { id: 'ml-alerts', label: 'ML anomalies', value: 7, trend: 'down', status: 'warn' },
-  ]
-}
-
-function mockMlScores(): MlScoreRow[] {
-  return [
-    { entity_id: '10.0.1.42', entity_type: 'client_ip', score: 0.91, severity: 'critical', model: 'ueba_zscore_v0', scored_at: new Date().toISOString() },
-    { entity_id: '10.0.1.88', entity_type: 'client_ip', score: 0.72, severity: 'high', model: 'ueba_zscore_v0', scored_at: new Date().toISOString() },
-    { entity_id: 'jdoe', entity_type: 'username', score: 0.55, severity: 'medium', model: 'anomaly_stub_v0', scored_at: new Date().toISOString() },
   ]
 }

--- a/admin-console/src/api/threatScores.ts
+++ b/admin-console/src/api/threatScores.ts
@@ -1,0 +1,92 @@
+import { loadApiSettings } from './settings'
+import { apiFetch } from './client'
+import type { MlFactor } from './search'
+
+export interface ThreatScoreEntry {
+  entity_type: string
+  entity_id: string
+  score: number
+  severity: string
+  model: string
+  scored_at: string
+  expires_at: string
+}
+
+export interface ThreatScoreSnapshot {
+  generated_at?: string
+  scores: ThreatScoreEntry[]
+}
+
+export async function fetchThreatScores(): Promise<ThreatScoreSnapshot> {
+  const settings = loadApiSettings()
+  try {
+    return await apiFetch<ThreatScoreSnapshot>('/api/threat-scores', {
+      baseUrl: settings.mlBaseUrl,
+    })
+  } catch {
+    return mockThreatScores()
+  }
+}
+
+/** Heuristic XAI factors from model id + score (no features_json in write-back snapshot). */
+export function factorsForThreatScore(entry: ThreatScoreEntry): MlFactor[] {
+  const s = entry.score
+  switch (entry.model) {
+    case 'phishing_lexical_v0':
+      return [
+        { label: 'Lexical risk', weight: s >= 0.8 ? 'high' : 'medium', detail: 'Domain shape, entropy, suspicious keywords' },
+        { label: 'Weak label overlap', weight: s >= 0.7 ? 'high' : 'low', detail: 'PhishTank / UT1 / category=phishing signals' },
+      ]
+    case 'cc_beacon_v0':
+      return [
+        { label: 'Periodic gaps', weight: s >= 0.8 ? 'high' : 'medium', detail: 'Regular client→domain request intervals' },
+        { label: 'Behavioral mix', weight: s >= 0.6 ? 'medium' : 'low', detail: 'POST ratio, small payloads, off-hours traffic' },
+      ]
+    case 'ueba_zscore_v0':
+    case 'anomaly_stub_v0':
+      return [
+        { label: 'Volume anomaly', weight: s >= 0.8 ? 'high' : 'medium', detail: 'Request rate vs population baseline' },
+        { label: 'Deny / threat mix', weight: s >= 0.7 ? 'high' : 'low', detail: 'Elevated deny or threat_hit ratio in window' },
+      ]
+    default:
+      return [
+        { label: 'Model score', weight: s >= 0.8 ? 'high' : 'medium', detail: `Aggregated score from ${entry.model}` },
+      ]
+  }
+}
+
+function mockThreatScores(): ThreatScoreSnapshot {
+  const now = new Date().toISOString()
+  return {
+    generated_at: now,
+    scores: [
+      {
+        entity_type: 'domain',
+        entity_id: 'login-verify.example',
+        score: 0.88,
+        severity: 'high',
+        model: 'phishing_lexical_v0',
+        scored_at: now,
+        expires_at: now,
+      },
+      {
+        entity_type: 'client_domain',
+        entity_id: '10.0.1.42|c2.beacon.test',
+        score: 0.93,
+        severity: 'critical',
+        model: 'cc_beacon_v0',
+        scored_at: now,
+        expires_at: now,
+      },
+      {
+        entity_type: 'client_ip',
+        entity_id: '10.0.1.42',
+        score: 0.76,
+        severity: 'high',
+        model: 'ueba_zscore_v0',
+        scored_at: now,
+        expires_at: now,
+      },
+    ],
+  }
+}

--- a/admin-console/src/components/layout/Sidebar.tsx
+++ b/admin-console/src/components/layout/Sidebar.tsx
@@ -6,11 +6,13 @@ import {
   Settings,
   X,
   Activity,
+  Brain,
 } from 'lucide-react'
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard, end: true },
   { to: '/logs', label: 'Logs', icon: ScrollText },
+  { to: '/threat-scores', label: 'Threat scores', icon: Brain },
   { to: '/policies', label: 'Policies', icon: Shield },
   { to: '/settings', label: 'Settings', icon: Settings },
 ] as const

--- a/admin-console/src/pages/ThreatScores.tsx
+++ b/admin-console/src/pages/ThreatScores.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { RefreshCw } from 'lucide-react'
+import {
+  factorsForThreatScore,
+  fetchThreatScores,
+  type ThreatScoreEntry,
+} from '../api/threatScores'
+import { Button } from '../components/ui/Button'
+import { Panel } from '../components/dashboard/MetricWidget'
+import { InsightPanel, ThreatIndicator } from '../components/xai/ThreatIndicator'
+import { Modal } from '../components/ui/Modal'
+import { severityBadge } from '../theme/tokens'
+
+export function ThreatScoresPage() {
+  const [snapshot, setSnapshot] = useState<{ generated_at?: string; scores: ThreatScoreEntry[] }>({
+    scores: [],
+  })
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<ThreatScoreEntry | null>(null)
+  const [modelFilter, setModelFilter] = useState<string>('all')
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    const data = await fetchThreatScores()
+    setSnapshot(data)
+    setLoading(false)
+  }, [])
+
+  useEffect(() => {
+    load()
+    const id = window.setInterval(load, 60_000)
+    return () => window.clearInterval(id)
+  }, [load])
+
+  const models = useMemo(() => {
+    const set = new Set(snapshot.scores.map((s) => s.model))
+    return ['all', ...Array.from(set).sort()]
+  }, [snapshot.scores])
+
+  const rows = useMemo(() => {
+    const filtered =
+      modelFilter === 'all'
+        ? snapshot.scores
+        : snapshot.scores.filter((s) => s.model === modelFilter)
+    return [...filtered].sort((a, b) => b.score - a.score)
+  }, [snapshot.scores, modelFilter])
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-text-primary">Threat scores</h1>
+          <p className="text-sm text-text-secondary">
+            M5.5 write-back snapshot from ml-worker — proxy polls this async (O(1) hot path)
+          </p>
+          {snapshot.generated_at && (
+            <p className="mt-1 font-mono text-xs text-text-secondary">
+              Generated {new Date(snapshot.generated_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+        <Button variant="secondary" onClick={load} disabled={loading}>
+          <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {models.map((m) => (
+          <button
+            key={m}
+            type="button"
+            onClick={() => setModelFilter(m)}
+            className={`touch-target rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              modelFilter === m
+                ? 'border-accent bg-accent/15 text-accent'
+                : 'border-border text-text-secondary hover:bg-surface-2'
+            }`}
+          >
+            {m === 'all' ? 'All models' : m}
+          </button>
+        ))}
+      </div>
+
+      <Panel title={`Active scores (${rows.length})`}>
+        {rows.length === 0 ? (
+          <p className="text-sm text-text-secondary">
+            No scores in snapshot. Configure ml-worker with write-back enabled and ensure scoring cycles run.
+          </p>
+        ) : (
+          <>
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full min-w-[720px] text-left text-sm">
+                <thead className="border-b border-border text-xs uppercase text-text-secondary">
+                  <tr>
+                    <th className="px-3 py-2">Entity</th>
+                    <th className="px-3 py-2">Type</th>
+                    <th className="px-3 py-2">Score</th>
+                    <th className="px-3 py-2">Severity</th>
+                    <th className="px-3 py-2">Model</th>
+                    <th className="px-3 py-2">Expires</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row) => (
+                    <tr
+                      key={`${row.entity_type}:${row.entity_id}:${row.model}`}
+                      className="cursor-pointer border-b border-border/50 hover:bg-surface-2/50"
+                      onClick={() => setSelected(row)}
+                    >
+                      <td className="max-w-[240px] truncate px-3 py-3 font-mono text-xs">{row.entity_id}</td>
+                      <td className="px-3 py-3 text-xs text-text-secondary">{row.entity_type}</td>
+                      <td className="px-3 py-3">
+                        <ThreatIndicator score={row.score} size="sm" label="" />
+                      </td>
+                      <td className="px-3 py-3">
+                        <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${severityBadge(row.severity)}`}>
+                          {row.severity}
+                        </span>
+                      </td>
+                      <td className="px-3 py-3 font-mono text-xs">{row.model}</td>
+                      <td className="px-3 py-3 font-mono text-xs text-text-secondary">{row.expires_at}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="space-y-3 md:hidden">
+              {rows.map((row) => (
+                <button
+                  key={`${row.entity_type}:${row.entity_id}:${row.model}`}
+                  type="button"
+                  className="w-full rounded-lg border border-border bg-surface-1 p-4 text-left"
+                  onClick={() => setSelected(row)}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-mono text-sm">{row.entity_id}</span>
+                    <span className={`rounded-full border px-2 py-0.5 text-xs ${severityBadge(row.severity)}`}>
+                      {row.severity}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-text-secondary">
+                    {row.entity_type} · {row.model}
+                  </p>
+                  <div className="mt-2">
+                    <ThreatIndicator score={row.score} size="sm" />
+                  </div>
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </Panel>
+
+      <ScoreDetailModal entry={selected} onClose={() => setSelected(null)} />
+    </div>
+  )
+}
+
+function ScoreDetailModal({
+  entry,
+  onClose,
+}: {
+  entry: ThreatScoreEntry | null
+  onClose: () => void
+}) {
+  if (!entry) return null
+  const factors = factorsForThreatScore(entry)
+
+  return (
+    <Modal open onClose={onClose} title="Threat score explainability" wide>
+      <div className="space-y-4">
+        <div className="grid gap-2 text-sm sm:grid-cols-2">
+          <div>
+            <span className="text-text-secondary">Entity</span>
+            <p className="font-mono font-medium text-text-primary">{entry.entity_id}</p>
+          </div>
+          <div>
+            <span className="text-text-secondary">Type</span>
+            <p className="font-medium text-text-primary">{entry.entity_type}</p>
+          </div>
+        </div>
+        <ThreatIndicator score={entry.score} size="lg" />
+        <InsightPanel factors={factors} model={entry.model} />
+        <p className="text-xs text-text-secondary">
+          Scored {entry.scored_at} · expires {entry.expires_at}. Proxy enriches{' '}
+          <code className="rounded bg-surface-0 px-1 font-mono">threat_sources</code> when{' '}
+          <code className="rounded bg-surface-0 px-1 font-mono">THREAT_SCORE_ENABLED=true</code>.
+        </p>
+      </div>
+    </Modal>
+  )
+}

--- a/admin-console/vite.config.ts
+++ b/admin-console/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       '/api/search': { target: 'http://127.0.0.1:8080', changeOrigin: true },
       '/api/events': { target: 'http://127.0.0.1:8080', changeOrigin: true },
       '/api/acl': { target: 'http://127.0.0.1:9090', changeOrigin: true },
-      '/api/ml': { target: 'http://127.0.0.1:8091', changeOrigin: true },
+      '/api/threat-scores': { target: 'http://127.0.0.1:8091', changeOrigin: true },
       '/metrics': { target: 'http://127.0.0.1:9090', changeOrigin: true },
     },
   },

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -39,7 +39,7 @@
 
 | ID | Issue | Блокер | Статус |
 |----|-------|--------|--------|
-| B15 | [#46](https://github.com/onixus/bsdm-proxy/issues/46) | Design analytics/ML worker service | ❌ |
+| B15 | [#46](https://github.com/onixus/bsdm-proxy/issues/46) | Design analytics/ML worker service | ✅ ml-worker M5 |
 | B16 | [#47](https://github.com/onixus/bsdm-proxy/issues/47) | Extend event schema for threat analytics | ✅ |
 | B17 | [#48](https://github.com/onixus/bsdm-proxy/issues/48) | Analytics UI (Grafana + ClickHouse; was OS Dashboards) | ✅ |
 | B18 | [#49](https://github.com/onixus/bsdm-proxy/issues/49) | Behavioral threat signals (beyond blocklists) | ✅ beacon_periodic |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,7 +218,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 
 | ID | Блокер | Описание | Milestone |
 |----|--------|----------|-----------|
-| **B15** | Analytics/ML worker | ✅ M5.1 scaffold (`ml-worker` + CH feature store); models → M5.2+ | M5 |
+| **B15** | Analytics/ML worker | ✅ M5.1–M5.5 (`ml-worker` + CH feature store + write-back) | M5 |
 | **B16** | Event schema for analytics | ✅ Done (`session_id`, `acl_action`, `threat_sources`) | M3–M4 |
 | **B17** | Analytics UI in compose | ✅ Done (Grafana + ClickHouse; OS Dashboards removed) | M3 |
 | **B18** | Behavioral / beacon signals | ✅ Done (`beacon_periodic` in alert-worker) | M4 |

--- a/docs/ml-security.md
+++ b/docs/ml-security.md
@@ -195,6 +195,7 @@ python3 scripts/ml/eval_cc_beacon.py
 Panel **Top anomalous entities (UEBA z-score / ml-worker)** on [BSDM HTTP Traffic (ClickHouse)](../grafana/dashboards/bsdm-http-traffic-ch.json).  
 Panel **Top phishing-scored domains (lexical / ml-worker M5.3)** on the same dashboard.  
 Panel **Top C&C beacon pairs (cc_beacon_v0 / ml-worker M5.4)** on the same dashboard.  
+Panel **Active threat score cache (M5.5 write-back)** on the same dashboard.  
 Ad-hoc SQL: [`scripts/clickhouse/m5_ueba_queries.sql`](../scripts/clickhouse/m5_ueba_queries.sql), [`scripts/clickhouse/m5_phishing_queries.sql`](../scripts/clickhouse/m5_phishing_queries.sql), [`scripts/clickhouse/m5_beacon_queries.sql`](../scripts/clickhouse/m5_beacon_queries.sql), [`scripts/clickhouse/m5_writeback_queries.sql`](../scripts/clickhouse/m5_writeback_queries.sql).
 
 ## Verify

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@
 | [M2.5 — Data plane](#m25--data-plane-throughput-v03x) | v0.3.x–0.3.2 | Tiered L1, streaming, P1 hot path | ✅ Done |
 | [M3 — Retro-search](#m3--retro-search) | v0.3.1+ | ClickHouse, Search API, Grafana, k8s CHI | ✅ Done (~95%) |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C / Shannon | ✅ Done |
-| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | Feature store, anomaly / phishing / C&C ML | ~55% (M5.4 C&C beacon) |
+| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | Feature store, anomaly / phishing / C&C ML | ✅ Done |
 
 ```mermaid
 gantt
@@ -39,7 +39,7 @@ gantt
   M3 Retro-search         :done, m3, 2026-05, 2026-07
   M4 Threat analytics     :done, m4, 2026-07, 2026-07
   section ML
-  M5 ML security          :active, m5, 2026-10, 2027-03
+  M5 ML security          :done, m5, 2026-10, 2027-03
 ```
 
 ---
@@ -167,12 +167,12 @@ Async scoring off the proxy hot path. Design: [ADR 0003](adr/0003-ml-worker-feat
 
 ## Матрица зрелости
 
-| Столп | Сейчас (0.5.0 + M5.1) | После M5 |
-|-------|----------------------|----------|
+| Столп | Сейчас (0.5.0 + M5) | Целевое |
+|-------|---------------------|---------|
 | Squid parity | **~92%** | ~93% |
 | Ретропоиск | **~90%** | ~95% |
-| ML / C&C / phishing | **~70%** | ~85% |
-| **Итого** | **~78%** | ~88% |
+| ML / C&C / phishing | **~85%** | ~90% |
+| **Итого** | **~88%** | ~92% |
 
 ---
 

--- a/grafana/dashboards/bsdm-http-traffic-ch.json
+++ b/grafana/dashboards/bsdm-http-traffic-ch.json
@@ -491,6 +491,36 @@
       ],
       "title": "Top C&C beacon pairs (cc_beacon_v0 / ml-worker M5.4)",
       "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 90 },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "grafana-clickhouse-datasource", "uid": "clickhouse" },
+          "editorType": "sql",
+          "format": 0,
+          "queryType": "sql",
+          "rawSql": "SELECT\n  entity_type,\n  entity_id,\n  max(score) AS max_score,\n  argMax(severity, score) AS severity,\n  argMax(model, score) AS model,\n  max(scored_at) AS last_scored,\n  max(expires_at) AS expires_at\nFROM bsdm.threat_score_cache\nWHERE expires_at > now()\nGROUP BY entity_type, entity_id\nORDER BY max_score DESC\nLIMIT 50",
+          "refId": "A"
+        }
+      ],
+      "title": "Active threat score cache (M5.5 write-back / proxy poll)",
+      "type": "table"
     }
   ],
   "refresh": "30s",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

M5 epic wrap-up after #175 merge: visibility and docs polish.

- **Admin console** — new `/threat-scores` page polling ml-worker `GET /api/threat-scores` with XAI modal per model
- **Dashboard fix** — top ML widget now uses write-back snapshot (was calling non-existent `/api/ml/scores`)
- **Grafana** — panel "Active threat score cache (M5.5 write-back / proxy poll)"
- **Docs** — roadmap M5 ✅, maturity matrix, B15 closed, architecture B15 note

## Test plan

- [x] `npm run build` in `admin-console/`
- [x] Vite proxy `/api/threat-scores` → ml-worker :8091

## Next suggested track

Strategic Phase 1 **Lite B21** — optional Cargo feature to drop `rdkafka` from proxy binary ([#52](https://github.com/onixus/bsdm-proxy/issues/52)).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

