### PR TITLE
Lite B21: optional kafka Cargo feature (no rdkafka in Lite builds) (#52)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Build workspace
         run: cargo build --workspace --all-targets
 
+      - name: Build lite profile (no rdkafka)
+        run: |
+          cargo build -p bsdm-proxy --no-default-features --features auth-basic --all-targets
+          cargo build -p cache-indexer --no-default-features --all-targets
+
       - name: Run tests
         run: cargo test --workspace --all-targets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Lite B21 — optional Kafka feature** — `kafka` Cargo feature (default on) for `bsdm-proxy` and `cache-indexer`; Lite Docker build uses `--no-default-features` (no `rdkafka` link) ([#52](https://github.com/onixus/bsdm-proxy/issues/52))
 - **M5.5 threat score write-back** — `ml-worker` publishes to `threat_score_cache` + `GET /api/threat-scores`; proxy optional async poll enriches `threat_sources` / block ([#169](https://github.com/onixus/bsdm-proxy/issues/169))
 - **M5.4 C&C beacon ML** — `cc_beacon_v0`: augments M4 `beacon_periodic` with behavioral signals (POST ratio, small payloads, off-hours); `beacon_pair_features` table; Grafana panel; `scripts/ml/eval_cc_beacon.py` ([#168](https://github.com/onixus/bsdm-proxy/issues/168))
 - **M5.3 lexical phishing** — `phishing_lexical_v0`: domain lexical heuristics + weak labels from PhishTank / UT1 / `phishing` category; `domain_phishing_features` table; Grafana panel; `scripts/ml/eval_phishing_lexical.py` ([#167](https://github.com/onixus/bsdm-proxy/issues/167))

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,15 @@ ENV OPENSSL_STATIC=1 \
     RUSTFLAGS="-C target-feature=+crt-static"
 
 # Собираем бинарники workspace в release режиме
-RUN cargo build --release --target x86_64-unknown-linux-musl \
-    -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker
+RUN if [ "$LITE_BUILD" = "1" ]; then \
+      cargo build --release --target x86_64-unknown-linux-musl \
+        --no-default-features --features auth-basic -p bsdm-proxy && \
+      cargo build --release --target x86_64-unknown-linux-musl \
+        --no-default-features -p cache-indexer; \
+    else \
+      cargo build --release --target x86_64-unknown-linux-musl \
+        -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker; \
+    fi
 
 # ============================================================
 # Proxy runtime

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -13,10 +13,14 @@ categories = ["database", "network-programming"]
 name = "cache-indexer"
 path = "src/main.rs"
 
+[features]
+default = ["kafka"]
+kafka = ["dep:rdkafka"]
+
 [dependencies]
 bsdm-events = { workspace = true }
 tokio = { workspace = true }
-rdkafka = { workspace = true }
+rdkafka = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }

--- a/cache-indexer/src/main.rs
+++ b/cache-indexer/src/main.rs
@@ -1,6 +1,8 @@
 mod admin_server;
 mod clickhouse;
+#[cfg(feature = "kafka")]
 mod kafka;
+#[cfg(feature = "kafka")]
 mod kafka_ingest;
 mod metrics;
 mod search_api;
@@ -8,6 +10,7 @@ mod store;
 
 use admin_server::run_admin_server;
 use clickhouse::{load_config_from_env, ClickHouseWriter};
+#[cfg(feature = "kafka")]
 use kafka_ingest::KafkaStoreIndexer;
 use metrics::IndexerMetrics;
 use search_api::{SearchApi, SearchApiConfig};
@@ -46,6 +49,12 @@ async fn bootstrap_store() -> Result<Arc<EventStore>, Box<dyn std::error::Error>
     }
 }
 
+async fn run_http_ingest_only() -> Result<(), Box<dyn std::error::Error>> {
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
@@ -58,7 +67,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let kafka_brokers = std::env::var("KAFKA_BROKERS")
         .ok()
         .filter(|s| !s.is_empty());
+    #[cfg(feature = "kafka")]
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
+    #[cfg(feature = "kafka")]
     let kafka_group =
         std::env::var("KAFKA_GROUP_ID").unwrap_or_else(|_| "cache-indexer-group".to_string());
     let metrics = Arc::new(IndexerMetrics::new()?);
@@ -91,17 +102,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("Search API on :{port}/api/search · ingest POST :{port}/api/events");
     }
 
-    let result = if let Some(brokers) = kafka_brokers {
-        info!("Kafka brokers: {brokers}");
-        info!("Kafka topic: {kafka_topic}");
-        info!("Kafka group: {kafka_group}");
-        let indexer =
-            KafkaStoreIndexer::new(&brokers, &kafka_topic, &kafka_group, store, metrics).await?;
-        indexer.run().await
-    } else {
-        info!("KAFKA_BROKERS unset — HTTP ingest only (POST /api/events)");
-        loop {
-            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+    let result = {
+        #[cfg(feature = "kafka")]
+        {
+            if let Some(brokers) = kafka_brokers {
+                info!("Kafka brokers: {brokers}");
+                info!("Kafka topic: {kafka_topic}");
+                info!("Kafka group: {kafka_group}");
+                let indexer =
+                    KafkaStoreIndexer::new(&brokers, &kafka_topic, &kafka_group, store, metrics)
+                        .await?;
+                indexer.run().await
+            } else {
+                info!("KAFKA_BROKERS unset — HTTP ingest only (POST /api/events)");
+                run_http_ingest_only().await
+            }
+        }
+        #[cfg(not(feature = "kafka"))]
+        {
+            if kafka_brokers.is_some() {
+                tracing::warn!(
+                    "KAFKA_BROKERS is set but cache-indexer was built without the `kafka` feature — HTTP ingest only"
+                );
+            } else {
+                info!("Kafka disabled at compile time — HTTP ingest only (POST /api/events)");
+            }
+            run_http_ingest_only().await
         }
     };
 

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -15,6 +15,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: cache-indexer
+      args:
+        LITE_BUILD: "1"
     ports:
       - "8080:8080"
     environment:
@@ -42,6 +44,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: proxy
+      args:
+        LITE_BUILD: "1"
     ports:
       - "1488:1488"
       - "9090:9090"

--- a/docs/BLOCKERS.md
+++ b/docs/BLOCKERS.md
@@ -50,7 +50,7 @@
 
 | ID | Issue | Блокер | Статус |
 |----|-------|--------|--------|
-| B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ❌ |
+| B21 | [#52](https://github.com/onixus/bsdm-proxy/issues/52) | Use Cargo feature flags in main | ✅ `kafka` feature (default on) |
 | B22 | [#53](https://github.com/onixus/bsdm-proxy/issues/53) | Cache refresh + negative caching | ✅ |
 | B23 | [#54](https://github.com/onixus/bsdm-proxy/issues/54) | HTTP/2 upstream client | ✅ |
 | B24 | [#55](https://github.com/onixus/bsdm-proxy/issues/55) | Fix healthcheck curl vs wget | ✅ |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,7 +229,7 @@ Local L1 miss → ICP query siblings → select parent → fetch_via_peer → or
 
 | ID | Блокер | Файлы |
 |----|--------|-------|
-| **B21** | Feature flags не в main | `Cargo.toml` features |
+| **B21** | Feature flags | ✅ `kafka` feature (Lite: `--no-default-features`) | `Cargo.toml` |
 | **B22** | Negative caching + `Cache-Control` revalidate | `cache_freshness.rs`, `proxy_service.rs` | ✅ |
 | **B23** | HTTP/2 upstream — `UPSTREAM_HTTP2_ENABLED` | `upstream.rs` | ✅ |
 | **B24** | Healthcheck curl vs wget — исправлено (`wget` в compose) | `docker-compose.yml`, `Dockerfile` |

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@
 |-----------|--------|
 | Rust | **1.88+** (рекомендуется latest stable) |
 | Cargo | stable |
-| librdkafka | dev-пакет (`librdkafka-dev`) |
+| librdkafka | dev-пакет (`librdkafka-dev`) — только при сборке с feature `kafka` (default) |
 | OpenSSL | dev-пакет (`libssl-dev`) |
 
 **Debian/Ubuntu:**
@@ -45,8 +45,12 @@ bsdm-proxy/
 ## Сборка
 
 ```bash
-# Debug
+# Debug (default: auth-basic + kafka)
 cargo build -p bsdm-proxy --bin proxy
+
+# Lite — без rdkafka (HTTP EVENT_SINK only)
+cargo build -p bsdm-proxy --no-default-features --features auth-basic --bin proxy
+cargo build -p cache-indexer --no-default-features --bin cache-indexer
 
 # Release (оба бинарника)
 cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-indexer

--- a/docs/lite.md
+++ b/docs/lite.md
@@ -52,4 +52,4 @@ Root [`docker-compose.yml`](../docker-compose.yml): Kafka → ClickHouse → Gra
 
 - [x] `cache-indexer` without mandatory Kafka/ClickHouse (`INDEX_STORE` + HTTP ingest)
 - [x] SQLite / in-memory metadata store
-- [ ] Cargo features to drop `rdkafka` from Lite binary (B21 / #52)
+- [x] Cargo features to drop `rdkafka` from Lite binary (B21 / #52) — `cargo build --no-default-features --features auth-basic -p bsdm-proxy`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -197,7 +197,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
-| **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; next: Cargo features без rdkafka (B21) |
+| **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
 | **2. DX** | Control plane | REST/gRPC API, hot reload ACL/upstream, cache purge по tags/regex, lite metrics |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
 | **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -17,7 +17,7 @@
 
 - **Отвязка от тяжелых зависимостей:** ✅ `INDEX_STORE=sqlite|memory` + optional Kafka; HTTP `POST /api/events` (см. [lite.md](lite.md)).
 - **Встроенное хранилище:** ✅ SQLite / in-memory event store на cache-indexer.
-- **Standalone-архитектура:** независимый бинарник / lightweight container — proxy уже работает без `KAFKA_BROKERS`; Lite compose + SQLite. *(partial — rdkafka still linked, B21)*
+- **Standalone-архитектура:** независимый бинарник / lightweight container — proxy уже работает без `KAFKA_BROKERS`; Lite compose + SQLite. ✅ `kafka` Cargo feature (B21) drops `rdkafka` from Lite builds.
 - **Zero-Config профили:** ✅ [`docker-compose.lite.yml`](../docker-compose.lite.yml) + [`scripts/gen-ca.sh`](../scripts/gen-ca.sh).
 
 ---

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -21,7 +21,7 @@ quick_cache = "0.7"
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 rand = "0.9"
 rcgen = { version = "0.14", features = ["x509-parser"] }
-rdkafka = "0.39"
+rdkafka = { version = "0.39", optional = true }
 prometheus = { version = "0.14", features = ["process"] }
 tokio-rustls = { version = "0.26", features = ["ring"] }
 rustls = { version = "0.23", features = ["ring"] }
@@ -53,7 +53,8 @@ sspi = { version = "0.21.1", optional = true, features = ["network_client"] }
 kerberos_keytab = { version = "0.0.3", optional = true }
 
 [features]
-default = ["auth-basic"]
+default = ["auth-basic", "kafka"]
+kafka = ["dep:rdkafka"]
 auth-basic = []
 auth-ldap = ["ldap3"]
 auth-ntlm = ["sspi"]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -66,7 +66,9 @@ pub use peer_discovery::{run_peer_discovery, PeerDiscoveryConfig};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
 pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
 pub use perf::{bind_http_listeners, PerfConfig};
-pub use pipeline::{HttpEventPipeline, KafkaEventPipeline};
+pub use pipeline::{dispatch_cache_event, new_event_id, HttpEventPipeline};
+#[cfg(feature = "kafka")]
+pub use pipeline::{flush_kafka, KafkaEventPipeline};
 pub use policy_cache::{PolicyCacheConfig, PolicyDecisionCache};
 pub use proxy_service::{ProxyPolicy, ProxyService};
 pub use rate_limit::{RateLimitConfig, RateLimitViolation, RateLimiter};

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -2,15 +2,16 @@ mod auth_config;
 mod policy_config;
 
 use auth_config::load_auth_config;
+#[cfg(feature = "kafka")]
+use bsdm_proxy::KafkaEventPipeline;
 use bsdm_proxy::{
     bind_http_listeners, build_hierarchy_manager, ensure_private_spill_dir, handle_connection,
     htcp_peer_port, htcp_server_bind_addr, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, metrics_server, run_peer_discovery, should_start_htcp_server,
     should_start_icp_server, wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache,
-    HtcpServer, HttpEventPipeline, IcpServer, KafkaEventPipeline, L2CacheConfig, Metrics,
-    PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy,
-    ProxyService, RateLimitConfig, RedisL2Cache, ThreatScoreCache, ThreatScoreConfig,
-    UpstreamTlsConfig,
+    HtcpServer, HttpEventPipeline, IcpServer, L2CacheConfig, Metrics, PeerDiscoveryConfig,
+    PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig,
+    RedisL2Cache, ThreatScoreCache, ThreatScoreConfig, UpstreamTlsConfig,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -20,6 +21,18 @@ use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
+
+fn spawn_http_event_pipeline(metrics: &Arc<Metrics>) -> Option<Arc<HttpEventPipeline>> {
+    std::env::var("EVENT_SINK_URL")
+        .ok()
+        .filter(|u| !u.is_empty())
+        .and_then(|url| {
+            let token = std::env::var("EVENT_SINK_TOKEN")
+                .ok()
+                .filter(|t| !t.is_empty());
+            HttpEventPipeline::spawn(url, token, metrics.clone())
+        })
+}
 
 async fn run_accept_loop(
     listener: Arc<TcpListener>,
@@ -134,24 +147,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(true);
 
     let cert_cache = CertCache::load_for_startup(mitm_enabled).await?;
+    #[cfg(feature = "kafka")]
     let kafka_brokers = std::env::var("KAFKA_BROKERS").ok();
+    #[cfg(not(feature = "kafka"))]
+    {
+        if std::env::var("KAFKA_BROKERS")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .is_some()
+        {
+            warn!(
+                "KAFKA_BROKERS is set but proxy was built without the `kafka` feature — use EVENT_SINK_URL or rebuild with default features"
+            );
+        }
+    }
+    #[cfg(feature = "kafka")]
     let kafka_topic = std::env::var("KAFKA_TOPIC").unwrap_or_else(|_| "cache-events".to_string());
+    #[cfg(feature = "kafka")]
     let kafka_pipeline = kafka_brokers
         .as_deref()
         .and_then(|brokers| KafkaEventPipeline::spawn(brokers, kafka_topic, metrics.clone()));
-    let http_pipeline = if kafka_pipeline.is_none() {
-        std::env::var("EVENT_SINK_URL")
-            .ok()
-            .filter(|u| !u.is_empty())
-            .and_then(|url| {
-                let token = std::env::var("EVENT_SINK_TOKEN")
-                    .ok()
-                    .filter(|t| !t.is_empty());
-                HttpEventPipeline::spawn(url, token, metrics.clone())
-            })
-    } else {
+    #[cfg(feature = "kafka")]
+    let http_pipeline = if kafka_pipeline.is_some() {
         None
+    } else {
+        spawn_http_event_pipeline(&metrics)
     };
+    #[cfg(not(feature = "kafka"))]
+    let http_pipeline = spawn_http_event_pipeline(&metrics);
     let cache_config = CacheConfig::from_env();
     if cache_config.spill_threshold_bytes > 0 {
         if let Err(e) = ensure_private_spill_dir(&cache_config.spill_dir) {
@@ -221,6 +244,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cert_cache,
         cache_config.clone(),
         l2_cache,
+        #[cfg(feature = "kafka")]
         kafka_pipeline,
         http_pipeline,
         metrics.clone(),

--- a/proxy/src/pipeline.rs
+++ b/proxy/src/pipeline.rs
@@ -1,7 +1,5 @@
 //! HTTP and Kafka cache-event pipelines with bounded in-memory queue (#106).
 
-use rdkafka::config::ClientConfig;
-use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -15,27 +13,6 @@ pub fn new_event_id() -> String {
     hex::encode(rand::random::<u128>().to_be_bytes())
 }
 
-pub fn create_kafka_producer(brokers: &str) -> Option<Arc<FutureProducer>> {
-    let acks = std::env::var("KAFKA_ACKS").unwrap_or_else(|_| "1".to_string());
-    let queue_buffering_max_ms =
-        std::env::var("KAFKA_QUEUE_BUFFERING_MAX_MS").unwrap_or_else(|_| "5".to_string());
-    let batch_size = std::env::var("KAFKA_BATCH_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(32_768)
-        .to_string();
-    ClientConfig::new()
-        .set("bootstrap.servers", brokers)
-        .set("message.timeout.ms", "5000")
-        .set("compression.type", "snappy")
-        .set("batch.size", &batch_size)
-        .set("linger.ms", &queue_buffering_max_ms)
-        .set("acks", &acks)
-        .create()
-        .ok()
-        .map(Arc::new)
-}
-
 fn queue_capacity_from_env() -> usize {
     std::env::var("KAFKA_QUEUE_CAPACITY")
         .ok()
@@ -44,68 +21,125 @@ fn queue_capacity_from_env() -> usize {
         .unwrap_or(8_192)
 }
 
-/// Non-blocking Kafka enqueue: bounded channel + background sender (no await on hot path).
-pub struct KafkaEventPipeline {
-    sender: mpsc::Sender<CacheEvent>,
-    producer: Arc<FutureProducer>,
+/// Enqueue cache events to Kafka (if enabled) or HTTP sink.
+pub fn dispatch_cache_event(
+    #[cfg(feature = "kafka")] kafka: Option<&KafkaEventPipeline>,
+    http: Option<&HttpEventPipeline>,
+    event: CacheEvent,
+    metrics: &Metrics,
+) {
+    #[cfg(feature = "kafka")]
+    if let Some(pipeline) = kafka {
+        pipeline.try_enqueue(event, metrics);
+        return;
+    }
+    if let Some(pipeline) = http {
+        pipeline.try_enqueue(event, metrics);
+    }
 }
 
-impl KafkaEventPipeline {
-    pub fn spawn(brokers: &str, topic: String, metrics: Arc<Metrics>) -> Option<Arc<Self>> {
-        let producer = create_kafka_producer(brokers)?;
-        let capacity = queue_capacity_from_env();
-        let (sender, mut receiver) = mpsc::channel::<CacheEvent>(capacity);
-        let producer_worker = producer.clone();
-        let metrics_worker = metrics.clone();
+#[cfg(feature = "kafka")]
+mod kafka_pipeline {
+    use super::*;
+    use rdkafka::config::ClientConfig;
+    use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
 
-        tokio::spawn(async move {
-            while let Some(event) = receiver.recv().await {
-                match serde_json::to_string(&event) {
-                    Ok(payload) => {
-                        let record = FutureRecord::to(&topic)
-                            .payload(&payload)
-                            .key(&event.event_id);
-                        match producer_worker.send(record, Duration::ZERO).await {
-                            Ok(_) => metrics_worker.kafka_events_sent.inc(),
-                            Err((e, _)) => {
-                                warn!("Kafka send failed: {}", e);
-                                metrics_worker.kafka_send_errors.inc();
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error!("Event serialization failed: {}", e);
-                        metrics_worker.kafka_send_errors.inc();
-                    }
-                }
-            }
-        });
-
-        info!(
-            "Kafka event pipeline started (queue capacity={}, drop=policy:drop_new)",
-            capacity
-        );
-
-        Some(Arc::new(Self { sender, producer }))
+    pub fn create_kafka_producer(brokers: &str) -> Option<Arc<FutureProducer>> {
+        let acks = std::env::var("KAFKA_ACKS").unwrap_or_else(|_| "1".to_string());
+        let queue_buffering_max_ms =
+            std::env::var("KAFKA_QUEUE_BUFFERING_MAX_MS").unwrap_or_else(|_| "5".to_string());
+        let batch_size = std::env::var("KAFKA_BATCH_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(32_768)
+            .to_string();
+        ClientConfig::new()
+            .set("bootstrap.servers", brokers)
+            .set("message.timeout.ms", "5000")
+            .set("compression.type", "snappy")
+            .set("batch.size", &batch_size)
+            .set("linger.ms", &queue_buffering_max_ms)
+            .set("acks", &acks)
+            .create()
+            .ok()
+            .map(Arc::new)
     }
 
-    /// Enqueue without blocking the request hot path. Drops when queue is full (drop-new).
-    pub fn try_enqueue(&self, event: CacheEvent, metrics: &Metrics) {
-        match self.sender.try_send(event) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                metrics.kafka_queue_dropped_total.inc();
+    /// Non-blocking Kafka enqueue: bounded channel + background sender (no await on hot path).
+    pub struct KafkaEventPipeline {
+        sender: mpsc::Sender<CacheEvent>,
+        producer: Arc<FutureProducer>,
+    }
+
+    impl KafkaEventPipeline {
+        pub fn spawn(brokers: &str, topic: String, metrics: Arc<Metrics>) -> Option<Arc<Self>> {
+            let producer = create_kafka_producer(brokers)?;
+            let capacity = queue_capacity_from_env();
+            let (sender, mut receiver) = mpsc::channel::<CacheEvent>(capacity);
+            let producer_worker = producer.clone();
+            let metrics_worker = metrics.clone();
+
+            tokio::spawn(async move {
+                while let Some(event) = receiver.recv().await {
+                    match serde_json::to_string(&event) {
+                        Ok(payload) => {
+                            let record = FutureRecord::to(&topic)
+                                .payload(&payload)
+                                .key(&event.event_id);
+                            match producer_worker.send(record, Duration::ZERO).await {
+                                Ok(_) => metrics_worker.kafka_events_sent.inc(),
+                                Err((e, _)) => {
+                                    warn!("Kafka send failed: {}", e);
+                                    metrics_worker.kafka_send_errors.inc();
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("Event serialization failed: {}", e);
+                            metrics_worker.kafka_send_errors.inc();
+                        }
+                    }
+                }
+            });
+
+            info!(
+                "Kafka event pipeline started (queue capacity={}, drop=policy:drop_new)",
+                capacity
+            );
+
+            Some(Arc::new(Self { sender, producer }))
+        }
+
+        /// Enqueue without blocking the request hot path. Drops when queue is full (drop-new).
+        pub fn try_enqueue(&self, event: CacheEvent, metrics: &Metrics) {
+            match self.sender.try_send(event) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    metrics.kafka_queue_dropped_total.inc();
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    metrics.kafka_send_errors.inc();
+                }
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                metrics.kafka_send_errors.inc();
-            }
+        }
+
+        pub fn producer(&self) -> Arc<FutureProducer> {
+            self.producer.clone()
         }
     }
 
-    pub fn producer(&self) -> Arc<FutureProducer> {
-        self.producer.clone()
+    pub async fn flush_kafka(producer: Arc<FutureProducer>, timeout: Duration) {
+        info!("Flushing Kafka producer...");
+        match tokio::task::spawn_blocking(move || producer.flush(timeout)).await {
+            Ok(Ok(())) => info!("Kafka producer flushed"),
+            Ok(Err(e)) => warn!("Kafka flush error: {}", e),
+            Err(e) => error!("Kafka flush task failed: {}", e),
+        }
     }
 }
+
+#[cfg(feature = "kafka")]
+pub use kafka_pipeline::{flush_kafka, KafkaEventPipeline};
 
 /// HTTP POST sink for Lite indexer (`EVENT_SINK_URL` → POST /api/events).
 pub struct HttpEventPipeline {
@@ -174,43 +208,5 @@ impl HttpEventPipeline {
                 metrics.kafka_send_errors.inc();
             }
         }
-    }
-}
-
-/// Legacy helper — prefer `KafkaEventPipeline::try_enqueue`.
-pub fn send_to_kafka_async(
-    producer: Arc<FutureProducer>,
-    topic: String,
-    metrics: Arc<Metrics>,
-    event: CacheEvent,
-) {
-    tokio::spawn(async move {
-        match serde_json::to_string(&event) {
-            Ok(payload) => {
-                let record = FutureRecord::to(&topic)
-                    .payload(&payload)
-                    .key(&event.event_id);
-                match producer.send(record, Duration::ZERO).await {
-                    Ok(_) => metrics.kafka_events_sent.inc(),
-                    Err((e, _)) => {
-                        warn!("Kafka send failed: {}", e);
-                        metrics.kafka_send_errors.inc();
-                    }
-                }
-            }
-            Err(e) => {
-                error!("Event serialization failed: {}", e);
-                metrics.kafka_send_errors.inc();
-            }
-        }
-    });
-}
-
-pub async fn flush_kafka(producer: Arc<FutureProducer>, timeout: Duration) {
-    info!("Flushing Kafka producer...");
-    match tokio::task::spawn_blocking(move || producer.flush(timeout)).await {
-        Ok(Ok(())) => info!("Kafka producer flushed"),
-        Ok(Err(e)) => warn!("Kafka flush error: {}", e),
-        Err(e) => error!("Kafka flush task failed: {}", e),
     }
 }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -34,9 +34,9 @@ use crate::metrics::{FastRequestScope, Metrics, RequestMetricsGuard};
 use crate::peer_fetch::fetch_via_peer;
 use crate::peers::CachePeer;
 use crate::perf::PerfConfig;
-use crate::pipeline::{
-    flush_kafka, new_event_id, CacheEvent, HttpEventPipeline, KafkaEventPipeline,
-};
+use crate::pipeline::{dispatch_cache_event, new_event_id, CacheEvent, HttpEventPipeline};
+#[cfg(feature = "kafka")]
+use crate::pipeline::{flush_kafka, KafkaEventPipeline};
 use crate::policy_cache::PolicyDecisionCache;
 use crate::rate_limit::{RateLimitViolation, RateLimiter};
 use crate::session::{header_ci, resolve_location, SessionCorrelator};
@@ -59,6 +59,7 @@ struct MissCompletionHandle {
     l2_cache: Option<RedisL2Cache>,
     hierarchy: Option<Arc<HierarchyManager>>,
     metrics: Arc<Metrics>,
+    #[cfg(feature = "kafka")]
     kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
     http_pipeline: Option<Arc<HttpEventPipeline>>,
     perf: PerfConfig,
@@ -89,11 +90,13 @@ impl MissCompletionHandle {
         if !self.perf.should_emit_kafka_event() {
             return;
         }
-        if let Some(pipeline) = &self.kafka_pipeline {
-            pipeline.try_enqueue(event, &self.metrics);
-        } else if let Some(pipeline) = &self.http_pipeline {
-            pipeline.try_enqueue(event, &self.metrics);
-        }
+        dispatch_cache_event(
+            #[cfg(feature = "kafka")]
+            self.kafka_pipeline.as_deref(),
+            self.http_pipeline.as_deref(),
+            event,
+            &self.metrics,
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -237,6 +240,7 @@ pub struct ProxyService {
     http_cache: Arc<HttpL1Cache>,
     l2_cache: Option<RedisL2Cache>,
     cache_config: CacheConfig,
+    #[cfg(feature = "kafka")]
     kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
     http_pipeline: Option<Arc<HttpEventPipeline>>,
     http_client:
@@ -283,6 +287,7 @@ impl ProxyService {
             l2_cache: self.l2_cache.clone(),
             hierarchy: self.hierarchy.clone(),
             metrics: self.metrics.clone(),
+            #[cfg(feature = "kafka")]
             kafka_pipeline: self.kafka_pipeline.clone(),
             http_pipeline: self.http_pipeline.clone(),
             perf: self.perf.clone(),
@@ -296,7 +301,7 @@ impl ProxyService {
         cert_cache: CertCache,
         cache_config: CacheConfig,
         l2_cache: Option<RedisL2Cache>,
-        kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
+        #[cfg(feature = "kafka")] kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
         http_pipeline: Option<Arc<HttpEventPipeline>>,
         metrics: Arc<Metrics>,
         mitm_enabled: bool,
@@ -328,6 +333,7 @@ impl ProxyService {
             http_cache,
             l2_cache,
             cache_config,
+            #[cfg(feature = "kafka")]
             kafka_pipeline,
             http_pipeline,
             http_client,
@@ -962,19 +968,25 @@ impl ProxyService {
         if !self.perf.should_emit_kafka_event() {
             return;
         }
-        if let Some(pipeline) = &self.kafka_pipeline {
-            pipeline.try_enqueue(event, &self.metrics);
-        } else if let Some(pipeline) = &self.http_pipeline {
-            pipeline.try_enqueue(event, &self.metrics);
-        }
+        dispatch_cache_event(
+            #[cfg(feature = "kafka")]
+            self.kafka_pipeline.as_deref(),
+            self.http_pipeline.as_deref(),
+            event,
+            &self.metrics,
+        );
     }
 
     pub async fn flush_kafka(&self, timeout: Duration) {
-        let Some(pipeline) = self.kafka_pipeline.as_ref() else {
-            return;
-        };
-
-        flush_kafka(pipeline.producer(), timeout).await;
+        #[cfg(feature = "kafka")]
+        {
+            let Some(pipeline) = self.kafka_pipeline.as_ref() else {
+                return;
+            };
+            flush_kafka(pipeline.producer(), timeout).await;
+        }
+        #[cfg(not(feature = "kafka"))]
+        let _ = timeout;
     }
 
     fn finish_request_metrics(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **B21 / #52** — optional `kafka` Cargo feature for Lite builds without linking `rdkafka`.

Closes #52

### proxy (`bsdm-proxy`)
- `default = ["auth-basic", "kafka"]`
- `--no-default-features --features auth-basic` → HTTP `EVENT_SINK_URL` only
- `dispatch_cache_event()` routes to Kafka or HTTP sink

### cache-indexer
- `default = ["kafka"]`
- `--no-default-features` → HTTP ingest only (`POST /api/events`)

### Docker / CI
- `docker-compose.lite.yml` sets `LITE_BUILD=1` → builds without kafka
- Rust CI: lite build step

## Build commands

```bash
# Full stack (default)
cargo build -p bsdm-proxy -p cache-indexer

# Lite (no rdkafka)
cargo build -p bsdm-proxy --no-default-features --features auth-basic
cargo build -p cache-indexer --no-default-features
```

## Test plan

- [x] `cargo test -p bsdm-proxy -p cache-indexer`
- [x] `cargo clippy -p bsdm-proxy -p cache-indexer --all-targets -- -D warnings`
- [x] Lite profile build (no-default-features)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

