### PR TITLE
DX Phase 2: control plane — ACL CRUD, /api/stats, cache purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DX Phase 2 control plane** — ACL CRUD (`PUT`/`DELETE`/`persist`), `GET /api/stats` Lite JSON, `POST /api/cache/purge`; admin-console Policies delete/persist; [docs/control-plane.md](docs/control-plane.md)
 - **Lite B21 — optional Kafka feature** — `kafka` Cargo feature (default on) for `bsdm-proxy` and `cache-indexer`; Lite Docker build uses `--no-default-features` (no `rdkafka` link) ([#52](https://github.com/onixus/bsdm-proxy/issues/52))
 - **M5.5 threat score write-back** — `ml-worker` publishes to `threat_score_cache` + `GET /api/threat-scores`; proxy optional async poll enriches `threat_sources` / block ([#169](https://github.com/onixus/bsdm-proxy/issues/169))
 - **Admin console** — Threat scores page (M5.5 snapshot + XAI); dashboard uses live write-back API

--- a/admin-console/src/api/acl.ts
+++ b/admin-console/src/api/acl.ts
@@ -30,9 +30,33 @@ export async function addAclRule(rule: AclRule): Promise<void> {
   await apiFetch('/api/acl/rules', { baseUrl, token, method: 'POST', body: rule })
 }
 
+export async function updateAclRule(rule: AclRule): Promise<void> {
+  const { baseUrl, token } = aclClient()
+  await apiFetch(`/api/acl/rules/${encodeURIComponent(rule.id)}`, {
+    baseUrl,
+    token,
+    method: 'PUT',
+    body: rule,
+  })
+}
+
+export async function deleteAclRule(id: string): Promise<void> {
+  const { baseUrl, token } = aclClient()
+  await apiFetch(`/api/acl/rules/${encodeURIComponent(id)}`, {
+    baseUrl,
+    token,
+    method: 'DELETE',
+  })
+}
+
 export async function reloadAclRules(): Promise<void> {
   const { baseUrl, token } = aclClient()
   await apiFetch('/api/acl/reload', { baseUrl, token, method: 'POST' })
+}
+
+export async function persistAclRules(): Promise<void> {
+  const { baseUrl, token } = aclClient()
+  await apiFetch('/api/acl/persist', { baseUrl, token, method: 'POST' })
 }
 
 function mockRules(): AclRulesResponse {

--- a/admin-console/src/api/metrics.ts
+++ b/admin-console/src/api/metrics.ts
@@ -1,5 +1,6 @@
 import { loadApiSettings } from './settings'
 import { apiFetch } from './client'
+import { fetchThreatScores } from './threatScores'
 
 export interface DashboardMetric {
   id: string
@@ -20,37 +21,76 @@ export interface MlScoreRow {
   features_json?: string
 }
 
-/** Parse Prometheus text exposition for a single metric sample (best-effort). */
-function parsePrometheusValue(text: string, name: string): number | null {
-  const re = new RegExp(`^${name}(?:\\{[^}]*\\})?\\s+([\\d.eE+-]+)`, 'm')
-  const m = text.match(re)
-  return m ? parseFloat(m[1]) : null
-}
-
-export async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
-  const settings = loadApiSettings()
-  const base = settings.metricsBaseUrl
-
-  try {
-    const text = await apiFetch<string>('/metrics', { baseUrl: base })
-    if (typeof text !== 'string') throw new Error('not text')
-    const requests = parsePrometheusValue(text, 'bsdm_proxy_requests_total') ?? 0
-    const hits = parsePrometheusValue(text, 'bsdm_proxy_cache_hits_total') ?? 0
-    const misses = parsePrometheusValue(text, 'bsdm_proxy_cache_misses_total') ?? 0
-    const hitRate = requests > 0 ? ((hits / (hits + misses || 1)) * 100).toFixed(1) : '—'
-    return [
-      { id: 'requests', label: 'Total requests', value: requests, status: 'ok' },
-      { id: 'hit-rate', label: 'Cache hit rate', value: hitRate, unit: '%', status: 'ok' },
-      { id: 'hits', label: 'Cache hits', value: hits, status: 'ok' },
-      { id: 'misses', label: 'Cache misses', value: misses, status: 'ok' },
-    ]
-  } catch {
-    return mockMetrics()
+export interface ProxyStats {
+  service: string
+  uptime_secs: number
+  requests_in_flight: number
+  cache: {
+    hits: number
+    misses: number
+    bypasses: number
+    hit_ratio: number
+    entries: number
+    capacity: number
+    shards: number
   }
 }
 
+export async function fetchProxyStats(): Promise<ProxyStats | null> {
+  const settings = loadApiSettings()
+  try {
+    return await apiFetch<ProxyStats>('/api/stats', { baseUrl: settings.metricsBaseUrl })
+  } catch {
+    return null
+  }
+}
+
+export async function purgeCache(body: { all?: boolean; url?: string; method?: string }): Promise<void> {
+  const settings = loadApiSettings()
+  await apiFetch('/api/cache/purge', {
+    baseUrl: settings.metricsBaseUrl,
+    method: 'POST',
+    body,
+  })
+}
+
+export async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
+  const stats = await fetchProxyStats()
+  if (stats) {
+    return [
+      {
+        id: 'hit-rate',
+        label: 'Cache hit rate',
+        value: (stats.cache.hit_ratio * 100).toFixed(1),
+        unit: '%',
+        status: 'ok',
+      },
+      { id: 'hits', label: 'Cache hits', value: stats.cache.hits, status: 'ok' },
+      { id: 'misses', label: 'Cache misses', value: stats.cache.misses, status: 'ok' },
+      {
+        id: 'entries',
+        label: 'L1 entries',
+        value: `${stats.cache.entries}/${stats.cache.capacity}`,
+        status: 'ok',
+      },
+      {
+        id: 'inflight',
+        label: 'In flight',
+        value: stats.requests_in_flight,
+        status: 'ok',
+      },
+      {
+        id: 'uptime',
+        label: 'Uptime',
+        value: formatUptime(stats.uptime_secs),
+        status: 'ok',
+      },
+    ]
+  }
+  return mockMetrics()
+}
+
 export async function fetchTopMlScores(): Promise<MlScoreRow[]> {
-  const { fetchThreatScores } = await import('./threatScores')
   const snap = await fetchThreatScores()
   return snap.scores
     .slice()
@@ -66,11 +106,17 @@ export async function fetchTopMlScores(): Promise<MlScoreRow[]> {
     }))
 }
 
+function formatUptime(secs: number): string {
+  if (secs < 60) return `${secs}s`
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`
+  return `${(secs / 3600).toFixed(1)}h`
+}
+
 function mockMetrics(): DashboardMetric[] {
   return [
-    { id: 'requests', label: 'Total requests', value: '128.4k', trend: 'up', status: 'ok' },
     { id: 'hit-rate', label: 'Cache hit rate', value: '87.2', unit: '%', trend: 'up', status: 'ok' },
-    { id: 'denied', label: 'Denied (24h)', value: 342, trend: 'flat', status: 'warn' },
-    { id: 'ml-alerts', label: 'ML anomalies', value: 7, trend: 'down', status: 'warn' },
+    { id: 'hits', label: 'Cache hits', value: 11240, trend: 'up', status: 'ok' },
+    { id: 'misses', label: 'Cache misses', value: 1640, trend: 'flat', status: 'ok' },
+    { id: 'entries', label: 'L1 entries', value: '3200/10000', status: 'ok' },
   ]
 }

--- a/admin-console/src/pages/Policies.tsx
+++ b/admin-console/src/pages/Policies.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useState } from 'react'
-import { RefreshCw, RotateCcw } from 'lucide-react'
-import { fetchAclRules, reloadAclRules, type AclRule, type AclRulesResponse } from '../api/acl'
+import { RefreshCw, RotateCcw, Save, Trash2 } from 'lucide-react'
+import {
+  deleteAclRule,
+  fetchAclRules,
+  persistAclRules,
+  reloadAclRules,
+  type AclRule,
+  type AclRulesResponse,
+} from '../api/acl'
 import { Button } from '../components/ui/Button'
 import { Panel } from '../components/dashboard/MetricWidget'
 
 export function PoliciesPage() {
   const [data, setData] = useState<AclRulesResponse | null>(null)
   const [loading, setLoading] = useState(true)
-  const [reloading, setReloading] = useState(false)
+  const [busy, setBusy] = useState(false)
 
   const load = async () => {
     setLoading(true)
@@ -20,14 +27,37 @@ export function PoliciesPage() {
   }, [])
 
   const handleReload = async () => {
-    setReloading(true)
+    setBusy(true)
     try {
       await reloadAclRules()
       await load()
     } catch {
       alert('Reload failed — check ACL API connection in Settings')
     }
-    setReloading(false)
+    setBusy(false)
+  }
+
+  const handlePersist = async () => {
+    setBusy(true)
+    try {
+      await persistAclRules()
+      alert('Rules persisted to ACL_RULES_PATH')
+    } catch {
+      alert('Persist failed — ACL_RULES_PATH may be unset or unwritable')
+    }
+    setBusy(false)
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm(`Delete rule "${id}"?`)) return
+    setBusy(true)
+    try {
+      await deleteAclRule(id)
+      await load()
+    } catch {
+      alert('Delete failed — check ACL API token / connection')
+    }
+    setBusy(false)
   }
 
   return (
@@ -41,47 +71,56 @@ export function PoliciesPage() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <Button variant="secondary" onClick={load} disabled={loading}>
+          <Button variant="secondary" onClick={load} disabled={loading || busy}>
             <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
-          <Button variant="primary" onClick={handleReload} disabled={reloading}>
-            <RotateCcw className={`size-4 ${reloading ? 'animate-spin' : ''}`} />
-            Reload rules
+          <Button variant="secondary" onClick={handlePersist} disabled={busy}>
+            <Save className="size-4" />
+            Persist
+          </Button>
+          <Button variant="primary" onClick={handleReload} disabled={busy}>
+            <RotateCcw className={`size-4 ${busy ? 'animate-spin' : ''}`} />
+            Reload from file
           </Button>
         </div>
       </div>
 
       <Panel title={`Active rules (${data?.rules.length ?? 0})`}>
-        {/* Desktop table */}
         <div className="hidden overflow-x-auto md:block">
-          <table className="w-full min-w-[600px] text-left text-sm">
+          <table className="w-full min-w-[640px] text-left text-sm">
             <thead className="text-xs uppercase text-text-secondary">
               <tr>
                 <th className="pb-3 pr-4">Priority</th>
                 <th className="pb-3 pr-4">Name</th>
                 <th className="pb-3 pr-4">Type</th>
                 <th className="pb-3 pr-4">Action</th>
-                <th className="pb-3">Status</th>
+                <th className="pb-3 pr-4">Status</th>
+                <th className="pb-3"> </th>
               </tr>
             </thead>
             <tbody>
               {data?.rules.map((rule) => (
-                <RuleRow key={rule.id} rule={rule} />
+                <RuleRow key={rule.id} rule={rule} onDelete={handleDelete} disabled={busy} />
               ))}
             </tbody>
           </table>
         </div>
 
-        {/* Mobile cards */}
         <div className="space-y-3 md:hidden">
           {data?.rules.map((rule) => (
             <div key={rule.id} className="rounded-md border border-border bg-surface-0 p-4">
               <div className="flex items-start justify-between gap-2">
                 <span className="font-medium text-text-primary">{rule.name}</span>
-                <span className={`text-xs ${rule.enabled ? 'text-success' : 'text-text-secondary'}`}>
-                  {rule.enabled ? 'enabled' : 'disabled'}
-                </span>
+                <button
+                  type="button"
+                  className="text-danger"
+                  disabled={busy}
+                  onClick={() => handleDelete(rule.id)}
+                  aria-label={`Delete ${rule.id}`}
+                >
+                  <Trash2 className="size-4" />
+                </button>
               </div>
               <p className="mt-1 font-mono text-xs text-text-secondary">
                 P{rule.priority} · {rule.action} · {formatRuleType(rule)}
@@ -92,24 +131,45 @@ export function PoliciesPage() {
       </Panel>
 
       <div className="rounded-lg border border-border bg-surface-0 p-4 text-sm text-text-secondary">
-        Export full ACL JSON from Settings → Export ACL. Live edits via{' '}
-        <code className="rounded bg-surface-2 px-1 font-mono text-xs">POST /api/acl/rules</code>.
+        Live CRUD on metrics port:{' '}
+        <code className="rounded bg-surface-2 px-1 font-mono text-xs">PUT/DELETE /api/acl/rules/:id</code>
+        {' · '}
+        <code className="rounded bg-surface-2 px-1 font-mono text-xs">POST /api/acl/persist</code>
       </div>
     </div>
   )
 }
 
-function RuleRow({ rule }: { rule: AclRule }) {
+function RuleRow({
+  rule,
+  onDelete,
+  disabled,
+}: {
+  rule: AclRule
+  onDelete: (id: string) => void
+  disabled: boolean
+}) {
   return (
     <tr className="border-t border-border/50">
       <td className="py-3 pr-4 font-mono text-xs">{rule.priority}</td>
       <td className="py-3 pr-4">{rule.name}</td>
       <td className="py-3 pr-4 font-mono text-xs">{formatRuleType(rule)}</td>
       <td className="py-3 pr-4 capitalize">{rule.action}</td>
-      <td className="py-3">
+      <td className="py-3 pr-4">
         <span className={rule.enabled ? 'text-success' : 'text-text-secondary'}>
           {rule.enabled ? 'enabled' : 'disabled'}
         </span>
+      </td>
+      <td className="py-3">
+        <button
+          type="button"
+          className="touch-target rounded-md p-2 text-danger hover:bg-danger/10 disabled:opacity-40"
+          disabled={disabled}
+          onClick={() => onDelete(rule.id)}
+          aria-label={`Delete ${rule.id}`}
+        >
+          <Trash2 className="size-4" />
+        </button>
       </td>
     </tr>
   )

--- a/admin-console/vite.config.ts
+++ b/admin-console/vite.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
       '/api/search': { target: 'http://127.0.0.1:8080', changeOrigin: true },
       '/api/events': { target: 'http://127.0.0.1:8080', changeOrigin: true },
       '/api/acl': { target: 'http://127.0.0.1:9090', changeOrigin: true },
+      '/api/stats': { target: 'http://127.0.0.1:9090', changeOrigin: true },
+      '/api/cache': { target: 'http://127.0.0.1:9090', changeOrigin: true },
       '/api/threat-scores': { target: 'http://127.0.0.1:8091', changeOrigin: true },
       '/metrics': { target: 'http://127.0.0.1:9090', changeOrigin: true },
     },

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 | [logging.md](logging.md) | `RUST_LOG`, уровни |
 | [performance.md](performance.md) | Тюнинг RPS, bench |
 | [acl.md](acl.md) | ACL + REST API |
+| [control-plane.md](control-plane.md) | DX Phase 2: stats, cache purge, ACL CRUD |
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -2,7 +2,7 @@
 
 > См. также: [оглавление документации](README.md) · [пример правил](../config/acl-rules.example.json)
 
-> ⚠️ **Ограничения реализации:** TimeWindow rules — TODO ([B14](BLOCKERS.md)); group-based rules частично игнорируются; REST API для управления ACL **не реализован** ([B25](BLOCKERS.md)) — только JSON-файл.
+> ⚠️ **Ограничения реализации:** REST ACL CRUD + persist — ✅ (см. [control-plane.md](control-plane.md)); upstream hot reload и Cache-Tags purge — ещё в roadmap Phase 2.
 
 Flexible access control system for BSDM-Proxy with multiple rule types and priority-based matching.
 
@@ -431,24 +431,30 @@ curl -X POST http://localhost:9090/api/acl/rules \
 curl http://localhost:9090/api/acl/rules
 ```
 
-### Reload Rules
+### Reload / Persist
 
 ```bash
 curl -X POST http://localhost:9090/api/acl/reload
+curl -X POST http://localhost:9090/api/acl/persist
 ```
 
 Responses:
 - `GET /api/acl/rules` → `{ "count", "default_action", "rules": [...] }`
 - `POST /api/acl/rules` → `201 Created` with rule JSON (or `409` if `id` exists)
+- `PUT /api/acl/rules/{id}` → replace rule (`404` if missing)
+- `DELETE /api/acl/rules/{id}` → delete rule
 - `POST /api/acl/reload` → `{ "status": "reloaded", "count": N }` (requires `ACL_RULES_PATH`)
+- `POST /api/acl/persist` → write memory → `ACL_RULES_PATH`
 
 When `ACL_API_TOKEN` is set, pass `Authorization: Bearer <token>` on all `/api/acl/*` requests.
 
 The API is available when `ACL_ENABLED=true` on the metrics port (`METRICS_PORT`, default `9090`).
 
-**Security:** in production set `ACL_API_TOKEN` or restrict network access to `METRICS_PORT` (the API listens on `0.0.0.0`).
+**Security:** in production set `ACL_API_TOKEN` / `CONTROL_API_TOKEN` or restrict network access to `METRICS_PORT` (the API listens on `0.0.0.0`).
 
-**Persistence:** `POST /api/acl/rules` updates the in-memory engine only; rules are not written to `ACL_RULES_PATH`. A subsequent `POST /api/acl/reload` (or `ACL_AUTO_RELOAD`) replaces in-memory rules from the file and drops API-added rules. To make changes permanent, edit the JSON file and call reload.
+**Persistence:** mutations update the in-memory engine; call `POST /api/acl/persist` to write `ACL_RULES_PATH`. A subsequent `POST /api/acl/reload` (or `ACL_AUTO_RELOAD`) replaces in-memory rules from the file.
+
+Full control plane (stats + purge): [control-plane.md](control-plane.md).
 
 ### Policy decision cache
 
@@ -459,10 +465,11 @@ POLICY_DECISION_CACHE_TTL_SECONDS=120   # 0 = disabled
 POLICY_DECISION_CACHE_MAX_KEYS=10000
 ```
 
-ACL reload (`POST /api/acl/reload`, `ACL_AUTO_RELOAD`) flushes the cache. Metric: `bsdm_proxy_policy_cache_hit_total`.
+ACL mutations and reload flush the cache. Metric: `bsdm_proxy_policy_cache_hit_total`.
 
 ---
 
 **See also:**
+- [Control plane](control-plane.md)
 - [Categorization](categorization.md)
 - [Authentication](authentication.md)

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -1,0 +1,75 @@
+# Control plane API (DX Phase 2)
+
+REST endpoints on the proxy metrics port (`METRICS_PORT`, default `9090`). No Grafana required for Lite ops.
+
+See also: [strategic-roadmap.md](strategic-roadmap.md) Phase 2 · [acl.md](acl.md).
+
+## Auth
+
+| Variable | Role |
+|----------|------|
+| `CONTROL_API_TOKEN` | Preferred Bearer token for mutating control APIs |
+| `ACL_API_TOKEN` | Fallback token (also used for `/api/acl/*`) |
+
+`GET /api/stats` is intentionally unauthenticated (local Lite monitoring).  
+`POST /api/cache/purge` and all `/api/acl/*` require Bearer when a token is configured.
+
+```bash
+curl -H "Authorization: Bearer $CONTROL_API_TOKEN" ...
+```
+
+## Stats (Lite JSON)
+
+```bash
+curl http://127.0.0.1:9090/api/stats
+```
+
+```json
+{
+  "service": "bsdm-proxy",
+  "uptime_secs": 3600,
+  "requests_in_flight": 2,
+  "cache": {
+    "hits": 1000,
+    "misses": 120,
+    "bypasses": 10,
+    "hit_ratio": 0.892,
+    "entries": 842,
+    "capacity": 10000,
+    "shards": 16
+  }
+}
+```
+
+## Cache purge
+
+```bash
+# Exact URL (method defaults to GET)
+curl -X POST http://127.0.0.1:9090/api/cache/purge \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com/asset.js"}'
+
+# Entire L1 (+ Redis L2 prefix when enabled)
+curl -X POST http://127.0.0.1:9090/api/cache/purge \
+  -H 'Content-Type: application/json' \
+  -d '{"all":true}'
+```
+
+## ACL CRUD
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `GET` | `/api/acl/rules` | List |
+| `POST` | `/api/acl/rules` | Add (in-memory); invalidates policy cache |
+| `PUT` | `/api/acl/rules/{id}` | Replace |
+| `DELETE` | `/api/acl/rules/{id}` | Remove |
+| `POST` | `/api/acl/reload` | File → memory (`ACL_RULES_PATH`) |
+| `POST` | `/api/acl/persist` | Memory → file |
+
+Requires `ACL_ENABLED=true`.
+
+## Roadmap leftovers
+
+- [ ] Upstream / hierarchy hot reload
+- [ ] Cache-Tags based purge
+- [ ] gRPC control plane

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
-| **2. DX** | Control plane | REST/gRPC API, hot reload ACL/upstream, cache purge по tags/regex, lite metrics |
+| **2. DX** | Control plane | ✅ REST ACL CRUD + `/api/stats` + cache purge; next: upstream hot reload / Cache-Tags |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
 | **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |
 

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -26,10 +26,10 @@
 
 *Фокус: удобство администрирования и эксплуатация в Cloud-Native среде.*
 
-- **Control Plane API:** REST/gRPC API для внешнего управления состоянием прокси.
-- **Горячая перезагрузка (Hot Reload):** upstream, ACL и политики без рестарта и сброса активных соединений.
-- **Умная инвалидация кэша:** API для сброса по Cache-Tags или regex URL.
-- **Встроенный мониторинг:** эндпоинт с Hit/Miss ratio, latency, throughput для Lite-режима без Grafana.
+- **Control Plane API:** ✅ REST на metrics port — ACL CRUD, `/api/stats`, `/api/cache/purge` ([control-plane.md](control-plane.md)). gRPC — later.
+- **Горячая перезагрузка (Hot Reload):** ✅ ACL (file auto-reload + API mutate/persist). Upstream/hierarchy — TBD.
+- **Умная инвалидация кэша:** ✅ URL / all purge (`POST /api/cache/purge`). Cache-Tags — TBD.
+- **Встроенный мониторинг:** ✅ `GET /api/stats` JSON (Lite, без Grafana).
 
 ---
 

--- a/proxy/src/acl.rs
+++ b/proxy/src/acl.rs
@@ -288,6 +288,33 @@ impl AclEngine {
         self.rebuild_regex_cache();
     }
 
+    /// Replace an existing rule by id. Returns false if the id was not found.
+    pub fn update_rule(&mut self, rule: AclRule) -> bool {
+        let Some(idx) = self.rules.iter().position(|r| r.id == rule.id) else {
+            return false;
+        };
+        info!(
+            "Updating ACL rule: {} (priority: {})",
+            rule.name, rule.priority
+        );
+        self.rules[idx] = rule;
+        self.rules.sort_by_key(|b| std::cmp::Reverse(b.priority));
+        self.rebuild_regex_cache();
+        true
+    }
+
+    /// Remove a rule by id. Returns false if the id was not found.
+    pub fn remove_rule(&mut self, id: &str) -> bool {
+        let before = self.rules.len();
+        self.rules.retain(|r| r.id != id);
+        if self.rules.len() == before {
+            return false;
+        }
+        info!("Removed ACL rule: {id}");
+        self.rebuild_regex_cache();
+        true
+    }
+
     /// Load rules from configuration
     pub fn load_rules(&mut self, rules: Vec<AclRule>) {
         info!("Loading {} ACL rules", rules.len());

--- a/proxy/src/acl_api.rs
+++ b/proxy/src/acl_api.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use crate::acl::{AclAction, AclEngineHandle, AclRule};
-use crate::acl_config::{load_acl_engine_from_file, parse_acl_action};
+use crate::acl_config::{load_acl_engine_from_file, parse_acl_action, save_acl_engine_to_file};
 use crate::http_types::{full, Body};
 use crate::policy_cache::PolicyDecisionCache;
 
@@ -81,10 +81,23 @@ impl AclApiState {
             return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
         }
 
+        if let Some(id) = path.strip_prefix("/api/acl/rules/") {
+            let id = percent_decode(id);
+            return match *method {
+                Method::PUT => self.update_rule_body(&id, body).await,
+                Method::DELETE => self.delete_rule(&id).await,
+                _ => json_response(
+                    StatusCode::METHOD_NOT_ALLOWED,
+                    r#"{"error":"method not allowed"}"#,
+                ),
+            };
+        }
+
         match (method, path) {
             (&Method::GET, "/api/acl/rules") => self.list_rules().await,
             (&Method::POST, "/api/acl/rules") => self.add_rule_body(body).await,
             (&Method::POST, "/api/acl/reload") => self.reload_rules().await,
+            (&Method::POST, "/api/acl/persist") => self.persist_rules().await,
             _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),
         }
     }
@@ -98,6 +111,12 @@ impl AclApiState {
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.strip_prefix("Bearer "))
             .is_some_and(|token| token == expected)
+    }
+
+    fn invalidate_policy_cache(&self) {
+        if let Some(cache) = &self.policy_cache {
+            cache.invalidate();
+        }
     }
 
     async fn list_rules(&self) -> Response<Body> {
@@ -153,10 +172,64 @@ impl AclApiState {
 
         info!("ACL API: adding rule {} ({})", rule.id, rule.name);
         self.engine.mutate(|engine| engine.add_rule(rule.clone()));
+        self.invalidate_policy_cache();
         match serde_json::to_string(&rule) {
             Ok(body) => json_response(StatusCode::CREATED, &body),
             Err(_) => json_response(StatusCode::CREATED, r#"{"status":"created"}"#),
         }
+    }
+
+    async fn update_rule_body(&self, id: &str, body: Bytes) -> Response<Body> {
+        let mut rule: AclRule = match serde_json::from_slice(&body) {
+            Ok(rule) => rule,
+            Err(e) => {
+                return json_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!(
+                        r#"{{"error":"invalid json: {}"}}"#,
+                        escape_json(&e.to_string())
+                    ),
+                );
+            }
+        };
+        if rule.id.trim().is_empty() {
+            rule.id = id.to_string();
+        } else if rule.id != id {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"path id must match rule.id"}"#,
+            );
+        }
+
+        let mut updated = false;
+        self.engine.mutate(|engine| {
+            updated = engine.update_rule(rule.clone());
+        });
+        if !updated {
+            return json_response(StatusCode::NOT_FOUND, r#"{"error":"rule not found"}"#);
+        }
+        self.invalidate_policy_cache();
+        info!("ACL API: updated rule {id}");
+        match serde_json::to_string(&rule) {
+            Ok(body) => json_response(StatusCode::OK, &body),
+            Err(_) => json_response(StatusCode::OK, r#"{"status":"updated"}"#),
+        }
+    }
+
+    async fn delete_rule(&self, id: &str) -> Response<Body> {
+        let mut removed = false;
+        self.engine.mutate(|engine| {
+            removed = engine.remove_rule(id);
+        });
+        if !removed {
+            return json_response(StatusCode::NOT_FOUND, r#"{"error":"rule not found"}"#);
+        }
+        self.invalidate_policy_cache();
+        info!("ACL API: deleted rule {id}");
+        json_response(
+            StatusCode::OK,
+            &format!(r#"{{"status":"deleted","id":"{}"}}"#, escape_json(id)),
+        )
     }
 
     async fn reload_rules(&self) -> Response<Body> {
@@ -171,9 +244,7 @@ impl AclApiState {
             Ok(loaded) => {
                 let count = loaded.rule_count();
                 self.engine.replace(loaded);
-                if let Some(cache) = &self.policy_cache {
-                    cache.invalidate();
-                }
+                self.invalidate_policy_cache();
                 info!("ACL API: reloaded {} rules from {}", count, path);
                 json_response(
                     StatusCode::OK,
@@ -187,6 +258,30 @@ impl AclApiState {
                     &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
                 )
             }
+        }
+    }
+
+    async fn persist_rules(&self) -> Response<Body> {
+        let Some(path) = &self.config.rules_path else {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"ACL_RULES_PATH is not configured"}"#,
+            );
+        };
+        let engine = self.engine.load();
+        match save_acl_engine_to_file(path, &engine) {
+            Ok(()) => json_response(
+                StatusCode::OK,
+                &format!(
+                    r#"{{"status":"persisted","count":{},"path":"{}"}}"#,
+                    engine.rule_count(),
+                    escape_json(path)
+                ),
+            ),
+            Err(e) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
+            ),
         }
     }
 }
@@ -212,6 +307,33 @@ fn escape_json(value: &str) -> String {
         .replace('"', "\\\"")
         .replace('\n', "\\n")
         .replace('\r', "\\r")
+}
+
+fn percent_decode(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let bytes = raw.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2])) {
+                out.push((h << 4 | l) as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn from_hex(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -248,6 +370,17 @@ mod tests {
         )
     }
 
+    const SAMPLE_RULE: &[u8] = br#"{
+            "id": "api-rule",
+            "name": "API rule",
+            "enabled": true,
+            "priority": 50,
+            "action": "deny",
+            "rule_type": { "Domain": "blocked.test" },
+            "redirect_url": null,
+            "comment": null
+        }"#;
+
     #[tokio::test]
     async fn list_rules_empty() {
         let state = test_state();
@@ -268,21 +401,11 @@ mod tests {
     #[tokio::test]
     async fn add_rule_via_api() {
         let state = test_state();
-        let rule_json = br#"{
-            "id": "api-rule",
-            "name": "API rule",
-            "enabled": true,
-            "priority": 50,
-            "action": "deny",
-            "rule_type": { "Domain": "blocked.test" },
-            "redirect_url": null,
-            "comment": null
-        }"#;
         let resp = state
             .dispatch(
                 &Method::POST,
                 "/api/acl/rules",
-                Bytes::from_static(rule_json),
+                Bytes::from_static(SAMPLE_RULE),
                 &HeaderMap::new(),
             )
             .await;
@@ -302,6 +425,64 @@ mod tests {
             .to_bytes();
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(parsed["count"], 1);
+    }
+
+    #[tokio::test]
+    async fn update_and_delete_rule() {
+        let state = test_state();
+        state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/rules",
+                Bytes::from_static(SAMPLE_RULE),
+                &HeaderMap::new(),
+            )
+            .await;
+
+        let updated = br#"{
+            "id": "api-rule",
+            "name": "Updated",
+            "enabled": false,
+            "priority": 10,
+            "action": "allow",
+            "rule_type": { "Domain": "blocked.test" },
+            "redirect_url": null,
+            "comment": null
+        }"#;
+        let resp = state
+            .dispatch(
+                &Method::PUT,
+                "/api/acl/rules/api-rule",
+                Bytes::from_static(updated),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = state
+            .dispatch(
+                &Method::DELETE,
+                "/api/acl/rules/api-rule",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let list_resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/acl/rules",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        let body = BodyExt::collect(list_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed["count"], 0);
     }
 
     #[tokio::test]
@@ -345,6 +526,20 @@ mod tests {
             .dispatch(
                 &Method::POST,
                 "/api/acl/reload",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn persist_without_path_returns_bad_request() {
+        let state = test_state();
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/acl/persist",
                 Bytes::new(),
                 &HeaderMap::new(),
             )

--- a/proxy/src/acl_config.rs
+++ b/proxy/src/acl_config.rs
@@ -1,7 +1,7 @@
-//! Load ACL rules from JSON configuration files.
+//! Load / persist ACL rules from JSON configuration files.
 
 use crate::acl::{AclAction, AclEngine, AclRule};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::info;
 
 pub fn parse_acl_action(value: &str) -> AclAction {
@@ -12,7 +12,15 @@ pub fn parse_acl_action(value: &str) -> AclAction {
     }
 }
 
-#[derive(Debug, Deserialize)]
+fn action_to_str(action: AclAction) -> &'static str {
+    match action {
+        AclAction::Allow => "allow",
+        AclAction::Deny => "deny",
+        AclAction::Redirect => "redirect",
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 struct AclRulesFile {
     #[serde(default)]
     default_action: Option<String>,
@@ -40,6 +48,22 @@ pub fn load_acl_engine_from_file(
     engine.load_rules(file.rules);
     info!("Loaded {} ACL rules from {}", engine.rule_count(), path);
     Ok(engine)
+}
+
+/// Persist current engine state to `ACL_RULES_PATH` JSON.
+pub fn save_acl_engine_to_file(path: &str, engine: &AclEngine) -> Result<(), String> {
+    let file = AclRulesFile {
+        default_action: Some(action_to_str(engine.default_action()).to_string()),
+        rules: engine.rules().to_vec(),
+    };
+    let content = serde_json::to_string_pretty(&file)
+        .map_err(|e| format!("failed to serialize ACL rules: {e}"))?;
+    let tmp = format!("{path}.tmp");
+    std::fs::write(&tmp, format!("{content}\n"))
+        .map_err(|e| format!("failed to write ACL temp file: {e}"))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("failed to replace ACL rules file: {e}"))?;
+    info!("Persisted {} ACL rules to {path}", engine.rule_count());
+    Ok(())
 }
 
 #[cfg(test)]
@@ -85,5 +109,27 @@ mod tests {
         assert_eq!(parse_acl_action("deny"), AclAction::Deny);
         assert_eq!(parse_acl_action("ALLOW"), AclAction::Allow);
         assert_eq!(parse_acl_action("redirect"), AclAction::Redirect);
+    }
+
+    #[test]
+    fn persist_roundtrip() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, r#"{{"default_action":"allow","rules":[]}}"#).unwrap();
+        let path = file.path().to_str().unwrap();
+        let mut engine = AclEngine::new(AclAction::Allow);
+        engine.add_rule(AclRule {
+            id: "r1".into(),
+            name: "n".into(),
+            enabled: true,
+            priority: 1,
+            action: AclAction::Deny,
+            rule_type: crate::acl::AclRuleType::Domain("evil.test".into()),
+            redirect_url: None,
+            comment: None,
+        });
+        save_acl_engine_to_file(path, &engine).unwrap();
+        let loaded = load_acl_engine_from_file(path, AclAction::Allow).unwrap();
+        assert_eq!(loaded.rule_count(), 1);
+        assert!(loaded.has_rule("r1"));
     }
 }

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -1,0 +1,284 @@
+//! Control-plane REST helpers: Lite JSON stats + L1 cache purge (DX Phase 2).
+
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use hyper::header::AUTHORIZATION;
+use hyper::{HeaderMap, Method, Request, Response, StatusCode};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time::Instant;
+use tracing::{info, warn};
+
+use crate::cache_key::http_cache_key;
+use crate::http_types::{full, Body};
+use crate::l2_cache::RedisL2Cache;
+use crate::metrics::Metrics;
+use crate::sharded_cache::HttpL1Cache;
+
+#[derive(Clone)]
+pub struct ControlApiState {
+    metrics: Arc<Metrics>,
+    http_cache: Arc<HttpL1Cache>,
+    l2_cache: Option<RedisL2Cache>,
+    api_token: Option<String>,
+    started_at: Instant,
+}
+
+impl ControlApiState {
+    pub fn new(
+        metrics: Arc<Metrics>,
+        http_cache: Arc<HttpL1Cache>,
+        l2_cache: Option<RedisL2Cache>,
+        api_token: Option<String>,
+    ) -> Self {
+        Self {
+            metrics,
+            http_cache,
+            l2_cache,
+            api_token,
+            started_at: Instant::now(),
+        }
+    }
+
+    pub fn from_env(
+        metrics: Arc<Metrics>,
+        http_cache: Arc<HttpL1Cache>,
+        l2_cache: Option<RedisL2Cache>,
+    ) -> Self {
+        let api_token = std::env::var("CONTROL_API_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .or_else(|| {
+                std::env::var("ACL_API_TOKEN")
+                    .ok()
+                    .filter(|t| !t.is_empty())
+            });
+        Self::new(metrics, http_cache, l2_cache, api_token)
+    }
+
+    pub async fn handle_request(&self, req: Request<Incoming>) -> Response<Body> {
+        let (parts, body) = req.into_parts();
+        let body = match BodyExt::collect(body).await {
+            Ok(collected) => collected.to_bytes(),
+            Err(e) => {
+                warn!("Failed to read control API body: {e}");
+                Bytes::new()
+            }
+        };
+        self.dispatch(&parts.method, parts.uri.path(), body, &parts.headers)
+            .await
+    }
+
+    async fn dispatch(
+        &self,
+        method: &Method,
+        path: &str,
+        body: Bytes,
+        headers: &HeaderMap,
+    ) -> Response<Body> {
+        // Stats are public (Lite monitoring); mutations require token when configured.
+        let needs_auth = path != "/api/stats";
+        if needs_auth && !self.is_authorized(headers) {
+            return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
+        }
+
+        match (method, path) {
+            (&Method::GET, "/api/stats") => self.stats(),
+            (&Method::POST, "/api/cache/purge") => self.purge(body).await,
+            _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),
+        }
+    }
+
+    fn is_authorized(&self, headers: &HeaderMap) -> bool {
+        let Some(expected) = &self.api_token else {
+            return true;
+        };
+        headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .is_some_and(|token| token == expected)
+    }
+
+    fn stats(&self) -> Response<Body> {
+        let hits = self.metrics.cache_hits_total.get();
+        let misses = self.metrics.cache_misses_total.get();
+        let bypasses = self.metrics.cache_bypasses_total.get();
+        let payload = StatsResponse {
+            service: "bsdm-proxy",
+            uptime_secs: self.started_at.elapsed().as_secs(),
+            requests_in_flight: self.metrics.requests_in_flight.get() as u64,
+            cache: CacheStats {
+                hits: hits as u64,
+                misses: misses as u64,
+                bypasses: bypasses as u64,
+                hit_ratio: self.metrics.cache_hit_rate(),
+                entries: self.http_cache.len(),
+                capacity: self.http_cache.capacity(),
+                shards: self.http_cache.shard_count(),
+            },
+        };
+        match serde_json::to_string(&payload) {
+            Ok(body) => json_response(StatusCode::OK, &body),
+            Err(_) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"error":"serialization failed"}"#,
+            ),
+        }
+    }
+
+    async fn purge(&self, body: Bytes) -> Response<Body> {
+        let req: PurgeRequest = if body.is_empty() {
+            PurgeRequest::default()
+        } else {
+            match serde_json::from_slice(&body) {
+                Ok(r) => r,
+                Err(e) => {
+                    return json_response(
+                        StatusCode::BAD_REQUEST,
+                        &format!(
+                            r#"{{"error":"invalid json: {}}}"#,
+                            escape_json(&e.to_string())
+                        ),
+                    );
+                }
+            }
+        };
+
+        if req.all {
+            let removed = self.http_cache.clear();
+            if let Some(l2) = &self.l2_cache {
+                l2.flush_prefix().await;
+            }
+            info!("Control API: purged entire L1 cache ({removed} entries)");
+            return json_response(
+                StatusCode::OK,
+                &format!(r#"{{"status":"purged","scope":"all","removed":{removed}}}"#),
+            );
+        }
+
+        let Some(url) = req.url.as_deref().filter(|u| !u.is_empty()) else {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"provide {\"url\":\"...\"} or {\"all\":true}"}"#,
+            );
+        };
+
+        let method = req.method.as_deref().unwrap_or("GET");
+        let key = http_cache_key(method, url);
+        let removed_l1 = self.http_cache.remove(&key).is_some();
+        if let Some(l2) = &self.l2_cache {
+            l2.delete(key.as_ref()).await;
+        }
+        info!("Control API: purge url={url} method={method} l1={removed_l1}");
+        json_response(
+            StatusCode::OK,
+            &format!(
+                r#"{{"status":"purged","scope":"url","url":"{}","removed":{}}}"#,
+                escape_json(url),
+                if removed_l1 { 1 } else { 0 }
+            ),
+        )
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct StatsResponse {
+    service: &'static str,
+    uptime_secs: u64,
+    requests_in_flight: u64,
+    cache: CacheStats,
+}
+
+#[derive(Debug, Serialize)]
+struct CacheStats {
+    hits: u64,
+    misses: u64,
+    bypasses: u64,
+    hit_ratio: f64,
+    entries: usize,
+    capacity: usize,
+    shards: usize,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PurgeRequest {
+    #[serde(default)]
+    all: bool,
+    url: Option<String>,
+    method: Option<String>,
+}
+
+fn json_response(status: StatusCode, body: &str) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .body(full(Bytes::from(body.to_string())))
+        .unwrap_or_else(|_| Response::new(full(Bytes::from_static(b"500 Internal Server Error"))))
+}
+
+fn escape_json(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Metrics;
+
+    #[tokio::test]
+    async fn stats_returns_json() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = ControlApiState::new(metrics, cache, None, None);
+        let resp = state
+            .dispatch(&Method::GET, "/api/stats", Bytes::new(), &HeaderMap::new())
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["service"], "bsdm-proxy");
+        assert!(v["cache"]["capacity"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn purge_all_clears_cache() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let key = http_cache_key("GET", "http://example.com/");
+        cache.insert(
+            key.clone(),
+            crate::cache::CachedResponse {
+                status: 200,
+                headers: Arc::from([]),
+                body: crate::cache_body::CachedBody::inline(Bytes::from_static(b"x")),
+                body_encoding: crate::cache_compress::BodyEncoding::Raw,
+                uncompressed_len: 1,
+                cached_at: std::time::SystemTime::now(),
+                ttl: std::time::Duration::from_secs(60),
+                etag: None,
+                last_modified: None,
+                is_negative: false,
+                must_revalidate: false,
+            },
+        );
+        assert_eq!(cache.len(), 1);
+
+        let state = ControlApiState::new(metrics, cache.clone(), None, None);
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/cache/purge",
+                Bytes::from_static(br#"{"all":true}"#),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(cache.len(), 0);
+    }
+}

--- a/proxy/src/l2_cache.rs
+++ b/proxy/src/l2_cache.rs
@@ -210,6 +210,51 @@ impl RedisL2Cache {
             self.metrics.cache_l2_errors_total.inc();
         }
     }
+
+    pub async fn delete(&self, cache_key: &str) {
+        let key = self.redis_key(cache_key);
+        let mut conn = self.conn.clone();
+        if let Err(e) = conn.del::<_, ()>(&key).await {
+            warn!("Redis L2 delete failed for {key}: {e}");
+            self.metrics.cache_l2_errors_total.inc();
+        }
+    }
+
+    /// Best-effort delete of all keys with this cache's prefix (SCAN + DEL).
+    pub async fn flush_prefix(&self) {
+        let pattern = format!("{}*", self.key_prefix);
+        let mut conn = self.conn.clone();
+        let mut cursor: u64 = 0;
+        loop {
+            let result: Result<(u64, Vec<String>), _> = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg(&pattern)
+                .arg("COUNT")
+                .arg(200)
+                .query_async(&mut conn)
+                .await;
+            match result {
+                Ok((next, keys)) => {
+                    if !keys.is_empty() {
+                        if let Err(e) = conn.del::<_, ()>(&keys).await {
+                            warn!("Redis L2 flush_prefix DEL failed: {e}");
+                            self.metrics.cache_l2_errors_total.inc();
+                        }
+                    }
+                    cursor = next;
+                    if cursor == 0 {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    warn!("Redis L2 flush_prefix SCAN failed: {e}");
+                    self.metrics.cache_l2_errors_total.inc();
+                    break;
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cache_digest;
 pub mod cache_freshness;
 pub mod cache_key;
 pub mod categorization;
+pub mod control_api;
 pub mod hierarchy;
 pub mod hierarchy_config;
 pub mod htcp;
@@ -40,7 +41,7 @@ pub mod upstream;
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclEngineHandle, AclRule};
 pub use acl_api::{AclApiConfig, AclApiState};
-pub use acl_config::{load_acl_engine_from_file, parse_acl_action};
+pub use acl_config::{load_acl_engine_from_file, parse_acl_action, save_acl_engine_to_file};
 #[cfg(feature = "auth-kerberos")]
 pub use auth::KerberosConfig;
 #[cfg(feature = "auth-ntlm")]
@@ -53,6 +54,7 @@ pub use cache_compress::{BodyEncoding, CompressionConfig};
 pub use cache_digest::DigestRegistry;
 pub use cache_key::http_cache_key;
 pub use categorization::{CategorizationConfig, CategorizationEngine, Category};
+pub use control_api::ControlApiState;
 pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};
 pub use hierarchy_config::{
     build_hierarchy_manager, htcp_peer_port, htcp_server_bind_addr, icp_server_bind_addr,

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,9 +9,10 @@ use bsdm_proxy::{
     htcp_peer_port, htcp_server_bind_addr, http_cache_key, icp_server_bind_addr,
     load_hierarchy_config, metrics_server, run_peer_discovery, should_start_htcp_server,
     should_start_icp_server, wait_shutdown_signal, AclAction, AuthManager, CacheConfig, CertCache,
-    HtcpServer, HttpEventPipeline, IcpServer, L2CacheConfig, Metrics, PeerDiscoveryConfig,
-    PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig,
-    RedisL2Cache, ThreatScoreCache, ThreatScoreConfig, UpstreamTlsConfig,
+    ControlApiState, HtcpServer, HttpEventPipeline, IcpServer, L2CacheConfig, Metrics,
+    PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy,
+    ProxyService, RateLimitConfig, RedisL2Cache, ThreatScoreCache, ThreatScoreConfig,
+    UpstreamTlsConfig,
 };
 use policy_config::{load_policy_config, reload_acl_engine};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -134,14 +135,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    tokio::spawn(metrics_server(
-        metrics.clone(),
-        draining.clone(),
-        shutdown_rx.clone(),
-        metrics_port,
-        acl_api,
-    ));
-
     let mitm_enabled = std::env::var("MITM_ENABLED")
         .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no"))
         .unwrap_or(true);
@@ -243,7 +236,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service = Arc::new(ProxyService::new(
         cert_cache,
         cache_config.clone(),
-        l2_cache,
+        l2_cache.clone(),
         #[cfg(feature = "kafka")]
         kafka_pipeline,
         http_pipeline,
@@ -258,6 +251,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         perf.clone(),
         policy_cache.clone(),
         threat_score_cache,
+    ));
+
+    let control_api = Arc::new(ControlApiState::from_env(
+        metrics.clone(),
+        service.http_cache(),
+        l2_cache.clone(),
+    ));
+    info!(
+        "Control plane API on :{}/api/stats · :{}/api/cache/purge",
+        metrics_port, metrics_port
+    );
+    tokio::spawn(metrics_server(
+        metrics.clone(),
+        draining.clone(),
+        shutdown_rx.clone(),
+        metrics_port,
+        acl_api,
+        Some(control_api),
     ));
 
     if should_start_icp_server(&hierarchy_config) {

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -529,7 +529,6 @@ impl Metrics {
     }
 
     /// Get cache hit rate (0.0 to 1.0)
-    #[allow(dead_code)]
     pub fn cache_hit_rate(&self) -> f64 {
         let hits = self.cache_hits_total.get();
         let misses = self.cache_misses_total.get();

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -25,6 +25,7 @@ use tracing::{debug, error, info, warn};
 use crate::acl_api::AclApiState;
 use crate::auth::ConnAuthCache;
 use crate::auth::UserInfo;
+use crate::control_api::ControlApiState;
 use crate::http_types::{empty, full};
 use crate::metrics::Metrics;
 use crate::pipeline::{new_event_id, CacheEvent};
@@ -64,6 +65,7 @@ pub async fn metrics_server(
     mut shutdown_rx: watch::Receiver<bool>,
     metrics_port: u16,
     acl_api: Option<Arc<AclApiState>>,
+    control_api: Option<Arc<ControlApiState>>,
 ) {
     let bind_addr = format!("0.0.0.0:{}", metrics_port);
     let listener = match TcpListener::bind(&bind_addr).await {
@@ -90,18 +92,26 @@ pub async fn metrics_server(
                 let metrics = metrics.clone();
                 let draining = draining.clone();
                 let acl_api = acl_api.clone();
+                let control_api = control_api.clone();
                 tokio::spawn(async move {
                     let io = TokioIo::new(stream);
                     let service = service_fn(move |req: Request<Incoming>| {
                         let metrics = metrics.clone();
                         let draining = draining.clone();
                         let acl_api = acl_api.clone();
+                        let control_api = control_api.clone();
                         async move {
                             let path = req.uri().path();
                             debug!("Metrics request from {}: {}", addr, path);
 
                             if let Some(api) = &acl_api {
                                 if path.starts_with("/api/acl/") {
+                                    return Ok::<_, Infallible>(api.handle_request(req).await);
+                                }
+                            }
+
+                            if let Some(api) = &control_api {
+                                if path == "/api/stats" || path.starts_with("/api/cache/") {
                                     return Ok::<_, Infallible>(api.handle_request(req).await);
                                 }
                             }

--- a/proxy/src/sharded_cache.rs
+++ b/proxy/src/sharded_cache.rs
@@ -45,6 +45,19 @@ impl HttpL1Cache {
         self.shard(&key).insert(key, value);
     }
 
+    pub fn remove(&self, key: &Arc<str>) -> Option<CachedResponse> {
+        self.shard(key).remove(key).map(|(_, v)| v)
+    }
+
+    /// Drop every L1 entry. Returns the number of entries before clear.
+    pub fn clear(&self) -> usize {
+        let before = self.len();
+        for shard in &self.shards {
+            shard.clear();
+        }
+        before
+    }
+
     pub fn len(&self) -> usize {
         self.shards.iter().map(|s| s.len()).sum()
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice of **Strategic Phase 2 (DX)** — REST control plane on the metrics port.

Docs: [`docs/control-plane.md`](docs/control-plane.md)

### ACL (extends B25)
| Method | Path |
|--------|------|
| `PUT` | `/api/acl/rules/{id}` |
| `DELETE` | `/api/acl/rules/{id}` |
| `POST` | `/api/acl/persist` (memory → `ACL_RULES_PATH`) |

All mutations (including existing `POST` add) now invalidate the policy decision cache.

### Lite monitoring
```bash
curl http://127.0.0.1:9090/api/stats
```
JSON: hit ratio, hits/misses, L1 entries/capacity, uptime, in-flight.

### Cache purge
```bash
curl -X POST http://127.0.0.1:9090/api/cache/purge \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://example.com/a.js"}'
# or {"all":true}
```
L1 + Redis L2 (prefix SCAN/DEL when L2 enabled). Auth: `CONTROL_API_TOKEN` or `ACL_API_TOKEN`.

### Admin console
- Policies: delete rule + persist to file
- Dashboard metrics prefer `/api/stats`

## Not in this PR (follow-ups)
- Upstream / hierarchy hot reload
- Cache-Tags purge
- gRPC

## Test plan
- [x] `cargo test -p bsdm-proxy`
- [x] `cargo clippy -p bsdm-proxy --all-targets -- -D warnings`
- [x] `npm run build` in `admin-console/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

