### PR TITLE
feat(dx): hierarchy peer hot reload via control API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DX hierarchy peer hot reload** — `GET /api/hierarchy/peers`, `POST /api/hierarchy/reload`; optional `CACHE_PEERS_PATH` / `HIERARCHY_PEERS_PATH` JSON; discovery siblings preserved
 - **DX Cache-Tag purge** — L1 secondary index for `Cache-Tag` / `Surrogate-Key`; `POST /api/cache/purge` accepts `tag` / `tags` (+ L2 key delete)
 - **DX Phase 2 control plane** — ACL CRUD (`PUT`/`DELETE`/`persist`), `GET /api/stats` Lite JSON, `POST /api/cache/purge`; admin-console Policies delete/persist; [docs/control-plane.md](docs/control-plane.md)
 - **Lite B21 — optional Kafka feature** — `kafka` Cargo feature (default on) for `bsdm-proxy` and `cache-indexer`; Lite Docker build uses `--no-default-features` (no `rdkafka` link) ([#52](https://github.com/onixus/bsdm-proxy/issues/52))

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -2,7 +2,7 @@
 
 > См. также: [оглавление документации](README.md) · [пример правил](../config/acl-rules.example.json)
 
-> ⚠️ **Ограничения реализации:** REST ACL CRUD + persist — ✅ (см. [control-plane.md](control-plane.md)); upstream hot reload и Cache-Tags purge — ещё в roadmap Phase 2.
+> ⚠️ **Ограничения реализации:** REST ACL CRUD + persist, Cache-Tag purge, hierarchy peer reload — ✅ (см. [control-plane.md](control-plane.md)); upstream TLS hot reload — ещё в roadmap Phase 2.
 
 Flexible access control system for BSDM-Proxy with multiple rule types and priority-based matching.
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -11,8 +11,8 @@ See also: [strategic-roadmap.md](strategic-roadmap.md) Phase 2 · [acl.md](acl.m
 | `CONTROL_API_TOKEN` | Preferred Bearer token for mutating control APIs |
 | `ACL_API_TOKEN` | Fallback token (also used for `/api/acl/*`) |
 
-`GET /api/stats` is intentionally unauthenticated (local Lite monitoring).  
-`POST /api/cache/purge` and all `/api/acl/*` require Bearer when a token is configured.
+`GET /api/stats` and `GET /api/hierarchy/peers` are intentionally unauthenticated (local Lite monitoring).  
+`POST /api/cache/purge`, `POST /api/hierarchy/reload`, and all `/api/acl/*` require Bearer when a token is configured.
 
 ```bash
 curl -H "Authorization: Bearer $CONTROL_API_TOKEN" ...
@@ -80,8 +80,38 @@ Tags are parsed from upstream response headers `Cache-Tag` (comma-separated) and
 
 Requires `ACL_ENABLED=true`.
 
+## Hierarchy peers (hot reload)
+
+Requires `HIERARCHY_ENABLED=true`. Reloads **static** parents/siblings only; multicast discovery peers are preserved. Does **not** rebind ICP/HTCP listeners or reload TLS.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `GET` | `/api/hierarchy/peers` | List peers (`is_static` distinguishes config vs discovery) |
+| `POST` | `/api/hierarchy/reload` | Re-read peers file or env |
+
+**Source (in order):**
+
+1. JSON file at `CACHE_PEERS_PATH` or `HIERARCHY_PEERS_PATH`
+2. Else `CACHE_PARENTS` / `CACHE_SIBLINGS` env (same format as startup)
+
+```json
+{"parents":["parent.example.com:1488:1.0"],"siblings":["sib.example.com:1488:1.0:3130"]}
+```
+
+```bash
+curl http://127.0.0.1:9090/api/hierarchy/peers
+
+curl -X POST http://127.0.0.1:9090/api/hierarchy/reload \
+  -H "Authorization: Bearer $CONTROL_API_TOKEN"
+```
+
+```json
+{"status":"reloaded","source":"file","added":2,"removed":1,"preserved_discovery":3}
+```
+
 ## Roadmap leftovers
 
 - [x] Cache-Tags / Surrogate-Key purge (`{"tag":"..."}`)
-- [ ] Upstream / hierarchy hot reload
+- [x] Hierarchy peer hot reload (`/api/hierarchy/*`)
+- [ ] Upstream TLS hot reload
 - [ ] gRPC control plane

--- a/docs/hierarchical-caching.md
+++ b/docs/hierarchical-caching.md
@@ -117,6 +117,12 @@ CACHE_PARENTS=parent1.example.com:1488:1.0,parent2.example.com:1488:0.5
 # Sibling caches (host:port[:weight][:icp_port])
 CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488:1.0:3130
 
+# Optional peers JSON file (overrides CACHE_PARENTS / CACHE_SIBLINGS when set)
+# CACHE_PEERS_PATH=/etc/bsdm/peers.json
+# HIERARCHY_PEERS_PATH=/etc/bsdm/peers.json   # alias
+# {"parents":["parent:1488:1.0"],"siblings":["sib:1488:1.0:3130"]}
+# Hot reload: POST /api/hierarchy/reload  (see control-plane.md)
+
 # ICP server bind (UDP, default 0.0.0.0:3130)
 ICP_BIND=0.0.0.0:3130
 
@@ -163,9 +169,13 @@ PEER_DISCOVERY_DIGEST_EVERY=5
 HIERARCHY_DIRECT_DOMAINS=localhost,127.0.0.1
 ```
 
+### Peers JSON file
+
+When `CACHE_PEERS_PATH` (or `HIERARCHY_PEERS_PATH`) is set, static peers load from that file instead of `CACHE_PARENTS` / `CACHE_SIBLINGS`. Call `POST /api/hierarchy/reload` on the metrics port after editing the file (discovery siblings are preserved). See [control-plane.md](control-plane.md).
+
 ### Configuration File (TOML)
 
-TOML config is **planned** for M2. Currently only environment variables are supported via `hierarchy_config.rs`.
+Full TOML config is still planned. Env vars + optional peers JSON cover runtime hierarchy peer changes.
 
 ## Implementation Status
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
-| **2. DX** | Control plane | ✅ REST ACL CRUD + `/api/stats` + cache purge; next: upstream hot reload / Cache-Tags |
+| **2. DX** | Control plane | ✅ REST ACL CRUD + `/api/stats` + URL/tag/all purge + hierarchy reload; next: upstream TLS hot reload |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
 | **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |
 

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -26,8 +26,8 @@
 
 *Фокус: удобство администрирования и эксплуатация в Cloud-Native среде.*
 
-- **Control Plane API:** ✅ REST на metrics port — ACL CRUD, `/api/stats`, `/api/cache/purge` ([control-plane.md](control-plane.md)). gRPC — later.
-- **Горячая перезагрузка (Hot Reload):** ✅ ACL (file auto-reload + API mutate/persist). Upstream/hierarchy — TBD.
+- **Control Plane API:** ✅ REST на metrics port — ACL CRUD, `/api/stats`, `/api/cache/purge`, `/api/hierarchy/*` ([control-plane.md](control-plane.md)). gRPC — later.
+- **Горячая перезагрузка (Hot Reload):** ✅ ACL (file auto-reload + API mutate/persist). ✅ Hierarchy static peers (`POST /api/hierarchy/reload`). Upstream TLS — TBD.
 - **Умная инвалидация кэша:** ✅ URL / tag / all purge (`POST /api/cache/purge`). Cache-Tag + Surrogate-Key index on L1.
 - **Встроенный мониторинг:** ✅ `GET /api/stats` JSON (Lite, без Grafana).
 

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -508,8 +508,7 @@ mod tests {
                 max_connections: 100,
             })
             .await;
-        let state =
-            ControlApiState::new(metrics, cache, None, None, Some(registry), false);
+        let state = ControlApiState::new(metrics, cache, None, None, Some(registry), false);
         let resp = state
             .dispatch(
                 &Method::GET,

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -1,4 +1,4 @@
-//! Control-plane REST helpers: Lite JSON stats + L1 cache purge (DX Phase 2).
+//! Control-plane REST helpers: Lite JSON stats, L1 cache purge, hierarchy peer reload (DX Phase 2).
 
 use bytes::Bytes;
 use http_body_util::BodyExt;
@@ -11,9 +11,11 @@ use std::time::Instant;
 use tracing::{info, warn};
 
 use crate::cache_key::http_cache_key;
+use crate::hierarchy_config::reload_static_peers;
 use crate::http_types::{full, Body};
 use crate::l2_cache::RedisL2Cache;
 use crate::metrics::Metrics;
+use crate::peers::PeerRegistry;
 use crate::sharded_cache::HttpL1Cache;
 
 #[derive(Clone)]
@@ -23,6 +25,8 @@ pub struct ControlApiState {
     l2_cache: Option<RedisL2Cache>,
     api_token: Option<String>,
     started_at: Instant,
+    peer_registry: Option<PeerRegistry>,
+    hierarchy_use_htcp: bool,
 }
 
 impl ControlApiState {
@@ -31,6 +35,8 @@ impl ControlApiState {
         http_cache: Arc<HttpL1Cache>,
         l2_cache: Option<RedisL2Cache>,
         api_token: Option<String>,
+        peer_registry: Option<PeerRegistry>,
+        hierarchy_use_htcp: bool,
     ) -> Self {
         Self {
             metrics,
@@ -38,6 +44,8 @@ impl ControlApiState {
             l2_cache,
             api_token,
             started_at: Instant::now(),
+            peer_registry,
+            hierarchy_use_htcp,
         }
     }
 
@@ -45,6 +53,8 @@ impl ControlApiState {
         metrics: Arc<Metrics>,
         http_cache: Arc<HttpL1Cache>,
         l2_cache: Option<RedisL2Cache>,
+        peer_registry: Option<PeerRegistry>,
+        hierarchy_use_htcp: bool,
     ) -> Self {
         let api_token = std::env::var("CONTROL_API_TOKEN")
             .ok()
@@ -54,7 +64,14 @@ impl ControlApiState {
                     .ok()
                     .filter(|t| !t.is_empty())
             });
-        Self::new(metrics, http_cache, l2_cache, api_token)
+        Self::new(
+            metrics,
+            http_cache,
+            l2_cache,
+            api_token,
+            peer_registry,
+            hierarchy_use_htcp,
+        )
     }
 
     pub async fn handle_request(&self, req: Request<Incoming>) -> Response<Body> {
@@ -77,8 +94,11 @@ impl ControlApiState {
         body: Bytes,
         headers: &HeaderMap,
     ) -> Response<Body> {
-        // Stats are public (Lite monitoring); mutations require token when configured.
-        let needs_auth = path != "/api/stats";
+        // Public monitoring GETs; mutations require token when configured.
+        let needs_auth = !matches!(
+            (method, path),
+            (&Method::GET, "/api/stats") | (&Method::GET, "/api/hierarchy/peers")
+        );
         if needs_auth && !self.is_authorized(headers) {
             return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
         }
@@ -86,6 +106,8 @@ impl ControlApiState {
         match (method, path) {
             (&Method::GET, "/api/stats") => self.stats(),
             (&Method::POST, "/api/cache/purge") => self.purge(body).await,
+            (&Method::GET, "/api/hierarchy/peers") => self.hierarchy_peers().await,
+            (&Method::POST, "/api/hierarchy/reload") => self.hierarchy_reload().await,
             _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),
         }
     }
@@ -125,6 +147,67 @@ impl ControlApiState {
             Err(_) => json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 r#"{"error":"serialization failed"}"#,
+            ),
+        }
+    }
+
+    async fn hierarchy_peers(&self) -> Response<Body> {
+        let Some(registry) = &self.peer_registry else {
+            return json_response(
+                StatusCode::OK,
+                r#"{"enabled":false,"peers":[],"source_hint":"set HIERARCHY_ENABLED=true"}"#,
+            );
+        };
+        let peers = registry.all_peers().await;
+        let mut items = Vec::with_capacity(peers.len());
+        for peer in peers {
+            let is_static = registry.is_static(&peer.id).await;
+            items.push(PeerListItem {
+                id: peer.id.clone(),
+                host: peer.config.host.clone(),
+                port: peer.config.port,
+                peer_type: peer.config.peer_type.to_string(),
+                weight: peer.config.weight,
+                icp_port: peer.config.icp_port,
+                healthy: peer.is_healthy(),
+                is_static,
+            });
+        }
+        items.sort_by(|a, b| a.id.cmp(&b.id));
+        let payload = PeersListResponse {
+            enabled: true,
+            peers: items,
+        };
+        match serde_json::to_string(&payload) {
+            Ok(body) => json_response(StatusCode::OK, &body),
+            Err(_) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"error":"serialization failed"}"#,
+            ),
+        }
+    }
+
+    async fn hierarchy_reload(&self) -> Response<Body> {
+        let Some(registry) = &self.peer_registry else {
+            return json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                r#"{"error":"hierarchy disabled (HIERARCHY_ENABLED=false)"}"#,
+            );
+        };
+        match reload_static_peers(registry, self.hierarchy_use_htcp).await {
+            Ok(report) => {
+                let body = format!(
+                    r#"{{"status":"reloaded","source":"{}","added":{},"removed":{},"preserved_discovery":{}}}"#,
+                    report.source.as_str(),
+                    report.stats.added,
+                    report.stats.removed,
+                    report.stats.preserved_discovery
+                );
+                json_response(StatusCode::OK, &body)
+            }
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
             ),
         }
     }
@@ -232,6 +315,24 @@ struct CacheStats {
     tags: usize,
 }
 
+#[derive(Debug, Serialize)]
+struct PeersListResponse {
+    enabled: bool,
+    peers: Vec<PeerListItem>,
+}
+
+#[derive(Debug, Serialize)]
+struct PeerListItem {
+    id: String,
+    host: String,
+    port: u16,
+    peer_type: String,
+    weight: f64,
+    icp_port: Option<u16>,
+    healthy: bool,
+    is_static: bool,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct PurgeRequest {
     #[serde(default)]
@@ -277,12 +378,17 @@ fn escape_json(value: &str) -> String {
 mod tests {
     use super::*;
     use crate::metrics::Metrics;
+    use crate::peers::{PeerConfig, PeerType};
+
+    fn state_plain(metrics: Arc<Metrics>, cache: Arc<HttpL1Cache>) -> ControlApiState {
+        ControlApiState::new(metrics, cache, None, None, None, false)
+    }
 
     #[tokio::test]
     async fn stats_returns_json() {
         let metrics = Arc::new(Metrics::new().unwrap());
         let cache = Arc::new(HttpL1Cache::new(100, 4));
-        let state = ControlApiState::new(metrics, cache, None, None);
+        let state = state_plain(metrics, cache);
         let resp = state
             .dispatch(&Method::GET, "/api/stats", Bytes::new(), &HeaderMap::new())
             .await;
@@ -316,7 +422,7 @@ mod tests {
         );
         assert_eq!(cache.len(), 1);
 
-        let state = ControlApiState::new(metrics, cache.clone(), None, None);
+        let state = state_plain(metrics, cache.clone());
         let resp = state
             .dispatch(
                 &Method::POST,
@@ -351,7 +457,7 @@ mod tests {
             },
         );
         assert_eq!(cache.len(), 1);
-        let state = ControlApiState::new(metrics, cache.clone(), None, None);
+        let state = state_plain(metrics, cache.clone());
         let resp = state
             .dispatch(
                 &Method::POST,
@@ -366,5 +472,73 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["scope"], "tag");
         assert_eq!(v["removed"], 1);
+    }
+
+    #[tokio::test]
+    async fn hierarchy_peers_when_disabled() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = state_plain(metrics, cache);
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/hierarchy/peers",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["enabled"], false);
+    }
+
+    #[tokio::test]
+    async fn hierarchy_peers_lists_registry() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let registry = PeerRegistry::new();
+        registry
+            .add_peer(PeerConfig {
+                host: "10.0.0.1".into(),
+                port: 1488,
+                peer_type: PeerType::Parent,
+                weight: 1.0,
+                icp_port: None,
+                max_connections: 100,
+            })
+            .await;
+        let state =
+            ControlApiState::new(metrics, cache, None, None, Some(registry), false);
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/hierarchy/peers",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["enabled"], true);
+        assert_eq!(v["peers"].as_array().unwrap().len(), 1);
+        assert_eq!(v["peers"][0]["is_static"], true);
+    }
+
+    #[tokio::test]
+    async fn hierarchy_reload_unavailable_when_disabled() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = state_plain(metrics, cache);
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/hierarchy/reload",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -300,7 +300,8 @@ pub fn should_start_htcp_server(config: &HierarchyConfig) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex;
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -318,7 +319,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_and_reload_static_peers_from_json_file() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("peers.json");
         std::fs::write(

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -357,11 +357,7 @@ mod tests {
             })
             .await;
 
-        std::fs::write(
-            &path,
-            r#"{"parents":["10.0.0.2:1488:2.0"],"siblings":[]}"#,
-        )
-        .unwrap();
+        std::fs::write(&path, r#"{"parents":["10.0.0.2:1488:2.0"],"siblings":[]}"#).unwrap();
         let report = reload_static_peers(&registry, false).await.unwrap();
         std::env::remove_var("CACHE_PEERS_PATH");
         assert_eq!(report.source, PeerConfigSource::File);

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -3,8 +3,9 @@
 use crate::cache_digest::DigestRegistry;
 use crate::hierarchy::{HierarchyConfig, HierarchyManager};
 use crate::metrics::Metrics;
-use crate::peers::{PeerConfig, PeerRegistry, PeerType};
+use crate::peers::{PeerConfig, PeerRegistry, PeerType, ReplaceStaticStats};
 use crate::selection::parse_strategy;
+use serde::Deserialize;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -45,6 +46,113 @@ fn parse_peer_list(
             },
         )
         .collect()
+}
+
+fn sibling_default_query_port(use_htcp: bool) -> u16 {
+    if use_htcp {
+        htcp_peer_port()
+    } else {
+        std::env::var("ICP_PEER_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3130)
+    }
+}
+
+fn peers_file_path() -> Option<String> {
+    std::env::var("CACHE_PEERS_PATH")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            std::env::var("HIERARCHY_PEERS_PATH")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+}
+
+#[derive(Debug, Deserialize)]
+struct PeersFile {
+    #[serde(default)]
+    parents: Vec<String>,
+    #[serde(default)]
+    siblings: Vec<String>,
+}
+
+/// Where static peers were loaded from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerConfigSource {
+    File,
+    Env,
+}
+
+impl PeerConfigSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Env => "env",
+        }
+    }
+}
+
+/// Load static parent/sibling configs from peers JSON file or env vars.
+pub fn load_static_peer_configs(
+    use_htcp: bool,
+) -> Result<(Vec<PeerConfig>, PeerConfigSource), String> {
+    let sibling_port = sibling_default_query_port(use_htcp);
+    if let Some(path) = peers_file_path() {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read peers file {path}: {e}"))?;
+        let file: PeersFile = serde_json::from_str(&content)
+            .map_err(|e| format!("failed to parse peers JSON {path}: {e}"))?;
+        let mut configs = Vec::new();
+        for entry in file.parents {
+            configs.extend(parse_peer_list(&entry, PeerType::Parent, None));
+        }
+        for entry in file.siblings {
+            configs.extend(parse_peer_list(
+                &entry,
+                PeerType::Sibling,
+                Some(sibling_port),
+            ));
+        }
+        return Ok((configs, PeerConfigSource::File));
+    }
+
+    let mut configs = Vec::new();
+    if let Ok(parents) = std::env::var("CACHE_PARENTS") {
+        configs.extend(parse_peer_list(&parents, PeerType::Parent, None));
+    }
+    if let Ok(siblings) = std::env::var("CACHE_SIBLINGS") {
+        configs.extend(parse_peer_list(
+            &siblings,
+            PeerType::Sibling,
+            Some(sibling_port),
+        ));
+    }
+    Ok((configs, PeerConfigSource::Env))
+}
+
+#[derive(Debug, Clone)]
+pub struct HierarchyReloadReport {
+    pub stats: ReplaceStaticStats,
+    pub source: PeerConfigSource,
+}
+
+/// Hot-reload static peers into an existing registry (preserves discovery siblings).
+pub async fn reload_static_peers(
+    registry: &PeerRegistry,
+    use_htcp: bool,
+) -> Result<HierarchyReloadReport, String> {
+    let (configs, source) = load_static_peer_configs(use_htcp)?;
+    let stats = registry.replace_static_peers(configs).await;
+    info!(
+        "Hierarchy peers reloaded from {} (added={}, removed={}, preserved_discovery={})",
+        source.as_str(),
+        stats.added,
+        stats.removed,
+        stats.preserved_discovery
+    );
+    Ok(HierarchyReloadReport { stats, source })
 }
 
 pub fn load_hierarchy_config() -> HierarchyConfig {
@@ -106,26 +214,15 @@ pub async fn build_hierarchy_manager(
     ));
 
     let registry = PeerRegistry::new();
-    let sibling_query_port = if config.use_htcp {
-        htcp_peer_port()
-    } else {
-        std::env::var("ICP_PEER_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(3130)
-    };
-
-    if let Ok(parents) = std::env::var("CACHE_PARENTS") {
-        for peer_config in parse_peer_list(&parents, PeerType::Parent, None) {
-            registry.add_peer(peer_config).await;
-        }
+    let (configs, source) = load_static_peer_configs(config.use_htcp)?;
+    for peer_config in configs {
+        registry.add_peer(peer_config).await;
     }
-
-    if let Ok(siblings) = std::env::var("CACHE_SIBLINGS") {
-        for peer_config in parse_peer_list(&siblings, PeerType::Sibling, Some(sibling_query_port)) {
-            registry.add_peer(peer_config).await;
-        }
-    }
+    info!(
+        "Loaded {} static hierarchy peers from {}",
+        registry.all_peers().await.len(),
+        source.as_str()
+    );
 
     let strategy_name =
         std::env::var("CACHE_SELECTION_STRATEGY").unwrap_or_else(|_| "round-robin".to_string());
@@ -203,6 +300,12 @@ pub fn should_start_htcp_server(config: &HierarchyConfig) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn parse_parents_list() {
@@ -211,6 +314,62 @@ mod tests {
         assert_eq!(peers[0].host, "127.0.0.1");
         assert_eq!(peers[0].port, 1488);
         assert!((peers[0].weight - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn load_and_reload_static_peers_from_json_file() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("peers.json");
+        std::fs::write(
+            &path,
+            r#"{"parents":["127.0.0.1:1488:1.5"],"siblings":["10.0.0.2:1488"]}"#,
+        )
+        .unwrap();
+        std::env::set_var("CACHE_PEERS_PATH", path.to_str().unwrap());
+        let (configs, source) = load_static_peer_configs(false).unwrap();
+        assert_eq!(source, PeerConfigSource::File);
+        assert_eq!(configs.len(), 2);
+        assert_eq!(configs[0].peer_type, PeerType::Parent);
+        assert_eq!(configs[1].peer_type, PeerType::Sibling);
+        assert_eq!(configs[1].icp_port, Some(3130));
+
+        let registry = PeerRegistry::new();
+        registry
+            .add_peer(PeerConfig {
+                host: "10.0.0.1".into(),
+                port: 1488,
+                peer_type: PeerType::Parent,
+                weight: 1.0,
+                icp_port: None,
+                max_connections: 100,
+            })
+            .await;
+        registry
+            .upsert_sibling(PeerConfig {
+                host: "10.0.0.9".into(),
+                port: 1488,
+                peer_type: PeerType::Sibling,
+                weight: 1.0,
+                icp_port: Some(3130),
+                max_connections: 100,
+            })
+            .await;
+
+        std::fs::write(
+            &path,
+            r#"{"parents":["10.0.0.2:1488:2.0"],"siblings":[]}"#,
+        )
+        .unwrap();
+        let report = reload_static_peers(&registry, false).await.unwrap();
+        std::env::remove_var("CACHE_PEERS_PATH");
+        assert_eq!(report.source, PeerConfigSource::File);
+        assert_eq!(report.stats.preserved_discovery, 1);
+        let peers = registry.all_peers().await;
+        assert_eq!(peers.len(), 2);
+        assert!(peers.iter().any(|p| p.config.host == "10.0.0.2"));
+        assert!(peers.iter().any(|p| p.config.host == "10.0.0.9"));
+        assert!(!peers.iter().any(|p| p.config.host == "10.0.0.1"));
     }
 
     #[test]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -59,7 +59,8 @@ pub use control_api::ControlApiState;
 pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};
 pub use hierarchy_config::{
     build_hierarchy_manager, htcp_peer_port, htcp_server_bind_addr, icp_server_bind_addr,
-    load_hierarchy_config, should_start_htcp_server, should_start_icp_server, HierarchySetup,
+    load_hierarchy_config, reload_static_peers, should_start_htcp_server, should_start_icp_server,
+    HierarchyReloadReport, HierarchySetup, PeerConfigSource,
 };
 pub use htcp::{HtcpClient, HtcpOpcode, HtcpServer};
 pub use icp::{IcpClient, IcpMessage, IcpOpcode, IcpServer};
@@ -67,7 +68,7 @@ pub use l2_cache::{L2CacheConfig, RedisL2Cache};
 pub use metrics::{FastRequestScope, Metrics, RequestMetricsGuard};
 pub use peer_discovery::{run_peer_discovery, PeerDiscoveryConfig};
 pub use peer_fetch::{fetch_via_peer, PeerFetchError};
-pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType};
+pub use peers::{CachePeer, PeerConfig, PeerRegistry, PeerType, ReplaceStaticStats};
 pub use perf::{bind_http_listeners, PerfConfig};
 pub use pipeline::{dispatch_cache_event, new_event_id, HttpEventPipeline};
 #[cfg(feature = "kafka")]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -253,14 +253,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         threat_score_cache,
     ));
 
+    let hierarchy_peers = hierarchy.as_ref().map(|m| m.peer_registry());
     let control_api = Arc::new(ControlApiState::from_env(
         metrics.clone(),
         service.http_cache(),
         l2_cache.clone(),
+        hierarchy_peers,
+        hierarchy_config.use_htcp,
     ));
     info!(
-        "Control plane API on :{}/api/stats · :{}/api/cache/purge",
-        metrics_port, metrics_port
+        "Control plane API on :{}/api/stats · :{}/api/cache/purge · :{}/api/hierarchy/*",
+        metrics_port, metrics_port, metrics_port
     );
     tokio::spawn(metrics_server(
         metrics.clone(),

--- a/proxy/src/peers.rs
+++ b/proxy/src/peers.rs
@@ -4,7 +4,7 @@
 //! Tracks peer health, RTT, statistics, and connection pools.
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -209,24 +209,38 @@ impl CachePeer {
     }
 }
 
+/// Result of replacing statically configured peers (discovery peers preserved).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ReplaceStaticStats {
+    pub added: usize,
+    pub removed: usize,
+    pub preserved_discovery: usize,
+}
+
 /// Manages all cache peers
 #[derive(Clone)]
 pub struct PeerRegistry {
     peers: Arc<RwLock<HashMap<String, Arc<CachePeer>>>>,
+    /// IDs loaded from CACHE_PARENTS / CACHE_SIBLINGS / peers file (not multicast discovery).
+    static_ids: Arc<RwLock<HashSet<String>>>,
 }
 
 impl PeerRegistry {
     pub fn new() -> Self {
         Self {
             peers: Arc::new(RwLock::new(HashMap::new())),
+            static_ids: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
-    /// Add a peer to the registry
+    /// Add a statically configured peer to the registry.
     pub async fn add_peer(&self, config: PeerConfig) -> Arc<CachePeer> {
         let peer = Arc::new(CachePeer::new(config));
         let id = peer.id.clone();
-        self.peers.write().await.insert(id, peer.clone());
+        let mut peers = self.peers.write().await;
+        let mut static_ids = self.static_ids.write().await;
+        peers.insert(id.clone(), peer.clone());
+        static_ids.insert(id);
         peer
     }
 
@@ -245,7 +259,38 @@ impl PeerRegistry {
 
     /// Remove a peer from the registry
     pub async fn remove_peer(&self, id: &str) -> bool {
-        self.peers.write().await.remove(id).is_some()
+        let mut peers = self.peers.write().await;
+        let mut static_ids = self.static_ids.write().await;
+        static_ids.remove(id);
+        peers.remove(id).is_some()
+    }
+
+    pub async fn is_static(&self, id: &str) -> bool {
+        self.static_ids.read().await.contains(id)
+    }
+
+    /// Replace all statically configured peers; preserve discovery-added siblings.
+    pub async fn replace_static_peers(&self, configs: Vec<PeerConfig>) -> ReplaceStaticStats {
+        let mut peers = self.peers.write().await;
+        let mut static_ids = self.static_ids.write().await;
+        let preserved_discovery = peers.len().saturating_sub(static_ids.len());
+        let removed = static_ids.len();
+        for id in static_ids.drain() {
+            peers.remove(&id);
+        }
+        let mut added = 0;
+        for config in configs {
+            let peer = Arc::new(CachePeer::new(config));
+            let id = peer.id.clone();
+            peers.insert(id.clone(), peer);
+            static_ids.insert(id);
+            added += 1;
+        }
+        ReplaceStaticStats {
+            added,
+            removed,
+            preserved_discovery,
+        }
     }
 
     /// Get a peer by ID
@@ -431,6 +476,49 @@ mod tests {
 
         let siblings = registry.sibling_caches().await;
         assert_eq!(siblings.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn replace_static_preserves_discovery() {
+        let registry = PeerRegistry::new();
+        registry
+            .add_peer(PeerConfig {
+                host: "parent.example.com".into(),
+                port: 1488,
+                peer_type: PeerType::Parent,
+                weight: 1.0,
+                icp_port: None,
+                max_connections: 100,
+            })
+            .await;
+        registry
+            .upsert_sibling(PeerConfig {
+                host: "discovered.example.com".into(),
+                port: 1488,
+                peer_type: PeerType::Sibling,
+                weight: 1.0,
+                icp_port: Some(3130),
+                max_connections: 50,
+            })
+            .await;
+        assert_eq!(registry.all_peers().await.len(), 2);
+
+        let stats = registry
+            .replace_static_peers(vec![PeerConfig {
+                host: "parent2.example.com".into(),
+                port: 1488,
+                peer_type: PeerType::Parent,
+                weight: 1.0,
+                icp_port: None,
+                max_connections: 100,
+            }])
+            .await;
+        assert_eq!(stats.removed, 1);
+        assert_eq!(stats.added, 1);
+        assert_eq!(stats.preserved_discovery, 1);
+        assert_eq!(registry.all_peers().await.len(), 2);
+        assert!(registry.is_static("parent:parent2.example.com:1488").await);
+        assert!(!registry.is_static("sibling:discovered.example.com:1488").await);
     }
 
     #[test]

--- a/proxy/src/peers.rs
+++ b/proxy/src/peers.rs
@@ -518,7 +518,11 @@ mod tests {
         assert_eq!(stats.preserved_discovery, 1);
         assert_eq!(registry.all_peers().await.len(), 2);
         assert!(registry.is_static("parent:parent2.example.com:1488").await);
-        assert!(!registry.is_static("sibling:discovered.example.com:1488").await);
+        assert!(
+            !registry
+                .is_static("sibling:discovered.example.com:1488")
+                .await
+        );
     }
 
     #[test]

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -111,7 +111,10 @@ pub async fn metrics_server(
                             }
 
                             if let Some(api) = &control_api {
-                                if path == "/api/stats" || path.starts_with("/api/cache/") {
+                                if path == "/api/stats"
+                                    || path.starts_with("/api/cache/")
+                                    || path.starts_with("/api/hierarchy/")
+                                {
                                     return Ok::<_, Infallible>(api.handle_request(req).await);
                                 }
                             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hot-reload static hierarchy peers without restarting the proxy (DX Phase 2).

- `GET /api/hierarchy/peers` — list parents/siblings (`is_static` vs discovery)
- `POST /api/hierarchy/reload` — re-read peers from `CACHE_PEERS_PATH` / `HIERARCHY_PEERS_PATH` JSON, else `CACHE_PARENTS` / `CACHE_SIBLINGS`
- Multicast discovery siblings are preserved across reload
- Does **not** rebind ICP/HTCP or reload TLS

Docs: `docs/control-plane.md`, `docs/hierarchical-caching.md`, roadmap Phase 2.

## Связанные issue

- Milestone / блокер: DX Phase 2 (no blocker issue)

## Testing

```bash
cargo test -p bsdm-proxy --lib hierarchy_
cargo test -p bsdm-proxy --lib control_api
cargo test -p bsdm-proxy --lib replace_static
cargo clippy -p bsdm-proxy --all-targets -- -D warnings
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена
- [x] `docs/roadmap.md` / strategic-roadmap updated
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

