### PR TITLE
feat(dx): upstream TLS hot reload via control API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DX upstream TLS hot reload** — `GET /api/upstream/tls`, `POST /api/upstream/tls/reload`; rebuilds Hyper client pool from `UPSTREAM_CA_CERT` / `UPSTREAM_HTTP2_ENABLED` (`ArcSwap`)
 - **DX hierarchy peer hot reload** — `GET /api/hierarchy/peers`, `POST /api/hierarchy/reload`; optional `CACHE_PEERS_PATH` / `HIERARCHY_PEERS_PATH` JSON; discovery siblings preserved
 - **DX Cache-Tag purge** — L1 secondary index for `Cache-Tag` / `Surrogate-Key`; `POST /api/cache/purge` accepts `tag` / `tags` (+ L2 key delete)
 - **DX Phase 2 control plane** — ACL CRUD (`PUT`/`DELETE`/`persist`), `GET /api/stats` Lite JSON, `POST /api/cache/purge`; admin-console Policies delete/persist; [docs/control-plane.md](docs/control-plane.md)

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `NEGATIVE_CACHE_TTL_SECONDS` | `120` | TTL negative cache (сек) |
 | `CACHE_HONOR_CACHE_CONTROL` | `true` | Учитывать `Cache-Control`, ETag, revalidate |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Таймаут graceful shutdown |
-| `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab) |
-| `UPSTREAM_HTTP2_ENABLED` | `false` | HTTP/2 ALPN для upstream HTTPS |
+| `UPSTREAM_CA_CERT` | — | PEM самоподписанного CA для upstream TLS (тесты/lab); hot reload: `POST /api/upstream/tls/reload` |
+| `UPSTREAM_HTTP2_ENABLED` | `false` | HTTP/2 ALPN для upstream HTTPS (перечитывается при TLS reload) |
 | `CACHE_COMPRESSION` | `off` | At-rest сжатие кеша: `zstd`, `brotli`, `off` |
 | `CACHE_COMPRESS_MIN_BYTES` | `1024` | Мин. размер body для сжатия в кеше |
 | `CACHE_COMPRESS_ZSTD_LEVEL` | `3` | Уровень Zstd (1–22) |

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -2,7 +2,7 @@
 
 > См. также: [оглавление документации](README.md) · [пример правил](../config/acl-rules.example.json)
 
-> ⚠️ **Ограничения реализации:** REST ACL CRUD + persist, Cache-Tag purge, hierarchy peer reload — ✅ (см. [control-plane.md](control-plane.md)); upstream TLS hot reload — ещё в roadmap Phase 2.
+> ⚠️ **Ограничения реализации:** REST ACL CRUD + persist, Cache-Tag purge, hierarchy peer reload, upstream TLS reload — ✅ (см. [control-plane.md](control-plane.md)); gRPC control plane — ещё в roadmap Phase 2.
 
 Flexible access control system for BSDM-Proxy with multiple rule types and priority-based matching.
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -11,8 +11,8 @@ See also: [strategic-roadmap.md](strategic-roadmap.md) Phase 2 · [acl.md](acl.m
 | `CONTROL_API_TOKEN` | Preferred Bearer token for mutating control APIs |
 | `ACL_API_TOKEN` | Fallback token (also used for `/api/acl/*`) |
 
-`GET /api/stats` and `GET /api/hierarchy/peers` are intentionally unauthenticated (local Lite monitoring).  
-`POST /api/cache/purge`, `POST /api/hierarchy/reload`, and all `/api/acl/*` require Bearer when a token is configured.
+`GET /api/stats`, `GET /api/hierarchy/peers`, and `GET /api/upstream/tls` are intentionally unauthenticated (local Lite monitoring).  
+`POST /api/cache/purge`, `POST /api/hierarchy/reload`, `POST /api/upstream/tls/reload`, and all `/api/acl/*` require Bearer when a token is configured.
 
 ```bash
 curl -H "Authorization: Bearer $CONTROL_API_TOKEN" ...
@@ -109,9 +109,41 @@ curl -X POST http://127.0.0.1:9090/api/hierarchy/reload \
 {"status":"reloaded","source":"file","added":2,"removed":1,"preserved_discovery":3}
 ```
 
+## Upstream TLS (hot reload)
+
+Rebuilds the shared Hyper upstream client pool after re-reading env / CA file. In-flight requests keep the previous pool until idle drain.
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `GET` | `/api/upstream/tls` | Current snapshot (`http2_enabled`, `ca_cert_path`, `custom_ca`, `reloaded_at_unix`) |
+| `POST` | `/api/upstream/tls/reload` | Re-read `UPSTREAM_CA_CERT` + `UPSTREAM_HTTP2_ENABLED` |
+
+Typical flow: replace the PEM at `UPSTREAM_CA_CERT` (or flip `UPSTREAM_HTTP2_ENABLED` in the process env), then reload.
+
+```bash
+curl http://127.0.0.1:9090/api/upstream/tls
+
+curl -X POST http://127.0.0.1:9090/api/upstream/tls/reload \
+  -H "Authorization: Bearer $CONTROL_API_TOKEN"
+```
+
+```json
+{
+  "status": "reloaded",
+  "tls": {
+    "http2_enabled": false,
+    "ca_cert_path": "/etc/bsdm-proxy/upstream-ca.crt",
+    "custom_ca": true,
+    "reloaded_at_unix": 1720000000
+  }
+}
+```
+
+On failure (missing/invalid CA file) the previous client is kept and the API returns `400`.
+
 ## Roadmap leftovers
 
 - [x] Cache-Tags / Surrogate-Key purge (`{"tag":"..."}`)
 - [x] Hierarchy peer hot reload (`/api/hierarchy/*`)
-- [ ] Upstream TLS hot reload
+- [x] Upstream TLS hot reload (`/api/upstream/tls*`)
 - [ ] gRPC control plane

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
-| **2. DX** | Control plane | ✅ REST ACL CRUD + `/api/stats` + URL/tag/all purge + hierarchy reload; next: upstream TLS hot reload |
+| **2. DX** | Control plane | ✅ REST ACL/stats/purge/hierarchy/upstream-TLS reload; next: gRPC control plane |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
 | **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |
 

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -26,8 +26,8 @@
 
 *Фокус: удобство администрирования и эксплуатация в Cloud-Native среде.*
 
-- **Control Plane API:** ✅ REST на metrics port — ACL CRUD, `/api/stats`, `/api/cache/purge`, `/api/hierarchy/*` ([control-plane.md](control-plane.md)). gRPC — later.
-- **Горячая перезагрузка (Hot Reload):** ✅ ACL (file auto-reload + API mutate/persist). ✅ Hierarchy static peers (`POST /api/hierarchy/reload`). Upstream TLS — TBD.
+- **Control Plane API:** ✅ REST на metrics port — ACL CRUD, `/api/stats`, `/api/cache/purge`, `/api/hierarchy/*`, `/api/upstream/tls*` ([control-plane.md](control-plane.md)). gRPC — later.
+- **Горячая перезагрузка (Hot Reload):** ✅ ACL (file auto-reload + API mutate/persist). ✅ Hierarchy static peers (`POST /api/hierarchy/reload`). ✅ Upstream TLS client pool (`POST /api/upstream/tls/reload`).
 - **Умная инвалидация кэша:** ✅ URL / tag / all purge (`POST /api/cache/purge`). Cache-Tag + Surrogate-Key index on L1.
 - **Встроенный мониторинг:** ✅ `GET /api/stats` JSON (Lite, без Grafana).
 

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -17,6 +17,7 @@ use crate::l2_cache::RedisL2Cache;
 use crate::metrics::Metrics;
 use crate::peers::PeerRegistry;
 use crate::sharded_cache::HttpL1Cache;
+use crate::upstream::UpstreamClientHandle;
 
 #[derive(Clone)]
 pub struct ControlApiState {
@@ -27,6 +28,7 @@ pub struct ControlApiState {
     started_at: Instant,
     peer_registry: Option<PeerRegistry>,
     hierarchy_use_htcp: bool,
+    upstream_client: UpstreamClientHandle,
 }
 
 impl ControlApiState {
@@ -37,6 +39,7 @@ impl ControlApiState {
         api_token: Option<String>,
         peer_registry: Option<PeerRegistry>,
         hierarchy_use_htcp: bool,
+        upstream_client: UpstreamClientHandle,
     ) -> Self {
         Self {
             metrics,
@@ -46,6 +49,7 @@ impl ControlApiState {
             started_at: Instant::now(),
             peer_registry,
             hierarchy_use_htcp,
+            upstream_client,
         }
     }
 
@@ -55,6 +59,7 @@ impl ControlApiState {
         l2_cache: Option<RedisL2Cache>,
         peer_registry: Option<PeerRegistry>,
         hierarchy_use_htcp: bool,
+        upstream_client: UpstreamClientHandle,
     ) -> Self {
         let api_token = std::env::var("CONTROL_API_TOKEN")
             .ok()
@@ -71,6 +76,7 @@ impl ControlApiState {
             api_token,
             peer_registry,
             hierarchy_use_htcp,
+            upstream_client,
         )
     }
 
@@ -97,7 +103,9 @@ impl ControlApiState {
         // Public monitoring GETs; mutations require token when configured.
         let needs_auth = !matches!(
             (method, path),
-            (&Method::GET, "/api/stats") | (&Method::GET, "/api/hierarchy/peers")
+            (&Method::GET, "/api/stats")
+                | (&Method::GET, "/api/hierarchy/peers")
+                | (&Method::GET, "/api/upstream/tls")
         );
         if needs_auth && !self.is_authorized(headers) {
             return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
@@ -108,6 +116,8 @@ impl ControlApiState {
             (&Method::POST, "/api/cache/purge") => self.purge(body).await,
             (&Method::GET, "/api/hierarchy/peers") => self.hierarchy_peers().await,
             (&Method::POST, "/api/hierarchy/reload") => self.hierarchy_reload().await,
+            (&Method::GET, "/api/upstream/tls") => self.upstream_tls_status(),
+            (&Method::POST, "/api/upstream/tls/reload") => self.upstream_tls_reload(),
             _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),
         }
     }
@@ -205,6 +215,35 @@ impl ControlApiState {
                 );
                 json_response(StatusCode::OK, &body)
             }
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
+            ),
+        }
+    }
+
+    fn upstream_tls_status(&self) -> Response<Body> {
+        match serde_json::to_string(self.upstream_client.snapshot().as_ref()) {
+            Ok(body) => json_response(StatusCode::OK, &body),
+            Err(_) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                r#"{"error":"serialization failed"}"#,
+            ),
+        }
+    }
+
+    fn upstream_tls_reload(&self) -> Response<Body> {
+        match self.upstream_client.reload_from_env() {
+            Ok(snap) => match serde_json::to_string(&UpstreamTlsReloadResponse {
+                status: "reloaded",
+                tls: snap,
+            }) {
+                Ok(body) => json_response(StatusCode::OK, &body),
+                Err(_) => json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    r#"{"error":"serialization failed"}"#,
+                ),
+            },
             Err(e) => json_response(
                 StatusCode::BAD_REQUEST,
                 &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
@@ -316,6 +355,12 @@ struct CacheStats {
 }
 
 #[derive(Debug, Serialize)]
+struct UpstreamTlsReloadResponse {
+    status: &'static str,
+    tls: crate::upstream::UpstreamTlsSnapshot,
+}
+
+#[derive(Debug, Serialize)]
 struct PeersListResponse {
     enabled: bool,
     peers: Vec<PeerListItem>,
@@ -379,9 +424,15 @@ mod tests {
     use super::*;
     use crate::metrics::Metrics;
     use crate::peers::{PeerConfig, PeerType};
+    use crate::upstream::UpstreamTlsConfig;
+
+    fn test_upstream() -> UpstreamClientHandle {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        UpstreamClientHandle::new(UpstreamTlsConfig::default()).unwrap()
+    }
 
     fn state_plain(metrics: Arc<Metrics>, cache: Arc<HttpL1Cache>) -> ControlApiState {
-        ControlApiState::new(metrics, cache, None, None, None, false)
+        ControlApiState::new(metrics, cache, None, None, None, false, test_upstream())
     }
 
     #[tokio::test]
@@ -508,7 +559,15 @@ mod tests {
                 max_connections: 100,
             })
             .await;
-        let state = ControlApiState::new(metrics, cache, None, None, Some(registry), false);
+        let state = ControlApiState::new(
+            metrics,
+            cache,
+            None,
+            None,
+            Some(registry),
+            false,
+            test_upstream(),
+        );
         let resp = state
             .dispatch(
                 &Method::GET,
@@ -523,6 +582,39 @@ mod tests {
         assert_eq!(v["enabled"], true);
         assert_eq!(v["peers"].as_array().unwrap().len(), 1);
         assert_eq!(v["peers"][0]["is_static"], true);
+    }
+
+    #[tokio::test]
+    async fn upstream_tls_status_and_reload() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = state_plain(metrics, cache);
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/upstream/tls",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["custom_ca"], false);
+
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/upstream/tls/reload",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "reloaded");
+        assert!(v["tls"]["reloaded_at_unix"].as_u64().unwrap() > 0);
     }
 
     #[tokio::test]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -83,7 +83,9 @@ pub use sharded_cache::HttpL1Cache;
 pub use tag_index::{parse_cache_tags, TagIndex};
 pub use threat_score_cache::{ThreatScoreCache, ThreatScoreConfig, ThreatScoreHit};
 pub use tls::CertCache;
-pub use upstream::{build_upstream_https_connector, UpstreamTlsConfig};
+pub use upstream::{
+    build_upstream_https_connector, UpstreamClientHandle, UpstreamTlsConfig, UpstreamTlsSnapshot,
+};
 
 // Conditional re-exports based on features
 #[cfg(feature = "auth-ldap")]

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -260,10 +260,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         l2_cache.clone(),
         hierarchy_peers,
         hierarchy_config.use_htcp,
+        service.upstream_client(),
     ));
     info!(
-        "Control plane API on :{}/api/stats · :{}/api/cache/purge · :{}/api/hierarchy/*",
-        metrics_port, metrics_port, metrics_port
+        "Control plane API on :{}/api/stats · :{}/api/cache/purge · :{}/api/hierarchy/* · :{}/api/upstream/tls",
+        metrics_port, metrics_port, metrics_port, metrics_port
     );
     tokio::spawn(metrics_server(
         metrics.clone(),

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -9,8 +9,6 @@ use hyper::header::{
     HeaderName, HeaderValue, AUTHORIZATION, IF_MODIFIED_SINCE, IF_NONE_MATCH, LOCATION,
 };
 use hyper::{Request, Response, StatusCode};
-use hyper_util::client::legacy::connect::HttpConnector;
-use hyper_util::rt::TokioExecutor;
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::Arc;
@@ -44,7 +42,7 @@ use crate::sharded_cache::HttpL1Cache;
 use crate::streaming_miss::TeeMissBody;
 use crate::threat_score_cache::ThreatScoreCache;
 use crate::tls::CertCache;
-use crate::upstream::{build_upstream_https_connector, UpstreamTlsConfig};
+use crate::upstream::{UpstreamClientHandle, UpstreamTlsConfig};
 
 pub struct ProxyPolicy {
     pub acl_engine: Option<Arc<AclEngineHandle>>,
@@ -243,8 +241,7 @@ pub struct ProxyService {
     #[cfg(feature = "kafka")]
     kafka_pipeline: Option<Arc<KafkaEventPipeline>>,
     http_pipeline: Option<Arc<HttpEventPipeline>>,
-    http_client:
-        hyper_util::client::legacy::Client<hyper_rustls::HttpsConnector<HttpConnector>, Body>,
+    http_client: UpstreamClientHandle,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) mitm_enabled: bool,
     auth: Option<Arc<AuthManager>>,
@@ -278,6 +275,10 @@ impl ProxyService {
 
     pub fn policy_cache(&self) -> Arc<PolicyDecisionCache> {
         self.policy_cache.clone()
+    }
+
+    pub fn upstream_client(&self) -> UpstreamClientHandle {
+        self.http_client.clone()
     }
 
     fn miss_completion_handle(&self) -> MissCompletionHandle {
@@ -320,13 +321,8 @@ impl ProxyService {
             cache_config.shard_count,
         ));
 
-        let https = build_upstream_https_connector(&upstream_tls)
-            .expect("failed to build upstream HTTPS connector");
-
-        let http_client = hyper_util::client::legacy::Client::builder(TokioExecutor::new())
-            .pool_idle_timeout(Duration::from_secs(90))
-            .pool_max_idle_per_host(32)
-            .build(https);
+        let http_client =
+            UpstreamClientHandle::new(upstream_tls).expect("failed to build upstream HTTPS client");
 
         Self {
             cert_cache,
@@ -736,7 +732,7 @@ impl ProxyService {
         let domain = Self::extract_domain(url);
         let upstream_start = Instant::now();
 
-        let response = match self.http_client.request(cond_req).await {
+        let response = match self.http_client.load().request(cond_req).await {
             Ok(resp) => resp,
             Err(e) => {
                 warn!("Revalidation upstream error for {}: {}", url, e);
@@ -1444,7 +1440,7 @@ impl ProxyService {
         let fetch_result = if let Some((_, response)) = peer_fetch {
             Ok(response)
         } else {
-            self.http_client.request(req).await
+            self.http_client.load().request(req).await
         };
 
         match fetch_result {

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -114,6 +114,7 @@ pub async fn metrics_server(
                                 if path == "/api/stats"
                                     || path.starts_with("/api/cache/")
                                     || path.starts_with("/api/hierarchy/")
+                                    || path.starts_with("/api/upstream/")
                                 {
                                     return Ok::<_, Infallible>(api.handle_request(req).await);
                                 }

--- a/proxy/src/upstream.rs
+++ b/proxy/src/upstream.rs
@@ -1,14 +1,26 @@
-//! Upstream HTTP(S) client TLS configuration.
+//! Upstream HTTP(S) client TLS configuration and hot-reloadable client pool.
 
+use arc_swap::ArcSwap;
 use hyper_rustls::ConfigBuilderExt;
 use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::TokioExecutor;
+use serde::Serialize;
 use std::io::Cursor;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tracing::info;
+
+use crate::http_types::Body;
+
+pub type UpstreamHttpClient =
+    hyper_util::client::legacy::Client<hyper_rustls::HttpsConnector<HttpConnector>, Body>;
 
 #[derive(Clone, Debug, Default)]
 pub struct UpstreamTlsConfig {
     /// Negotiate HTTP/2 via ALPN on TLS upstream connections.
     pub http2_enabled: bool,
+    /// Optional PEM CA bundle path (`UPSTREAM_CA_CERT`).
+    pub ca_cert_path: Option<String>,
 }
 
 impl UpstreamTlsConfig {
@@ -16,15 +28,49 @@ impl UpstreamTlsConfig {
         let http2_enabled = std::env::var("UPSTREAM_HTTP2_ENABLED")
             .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
             .unwrap_or(false);
-        Self { http2_enabled }
+        let ca_cert_path = std::env::var("UPSTREAM_CA_CERT")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        Self {
+            http2_enabled,
+            ca_cert_path,
+        }
     }
+}
+
+/// Observable snapshot for control-plane GET / reload responses.
+#[derive(Clone, Debug, Serialize)]
+pub struct UpstreamTlsSnapshot {
+    pub http2_enabled: bool,
+    pub ca_cert_path: Option<String>,
+    pub custom_ca: bool,
+    pub reloaded_at_unix: u64,
+}
+
+impl UpstreamTlsSnapshot {
+    fn from_config(config: &UpstreamTlsConfig) -> Self {
+        Self {
+            http2_enabled: config.http2_enabled,
+            ca_cert_path: config.ca_cert_path.clone(),
+            custom_ca: config.ca_cert_path.is_some(),
+            reloaded_at_unix: unix_now(),
+        }
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 pub fn build_upstream_https_connector(
     config: &UpstreamTlsConfig,
-) -> Result<hyper_rustls::HttpsConnector<HttpConnector>, Box<dyn std::error::Error>> {
-    let tls_config = if let Ok(path) = std::env::var("UPSTREAM_CA_CERT") {
-        let pem = std::fs::read(&path)
+) -> Result<hyper_rustls::HttpsConnector<HttpConnector>, Box<dyn std::error::Error + Send + Sync>> {
+    let tls_config = if let Some(path) = &config.ca_cert_path {
+        let pem = std::fs::read(path)
             .map_err(|e| format!("failed to read UPSTREAM_CA_CERT {path}: {e}"))?;
         let certs: Vec<rustls::pki_types::CertificateDer<'static>> =
             rustls_pemfile::certs(&mut Cursor::new(pem))
@@ -32,9 +78,15 @@ pub fn build_upstream_https_connector(
                 .into_iter()
                 .map(|cert| cert.into_owned())
                 .collect();
+        if certs.is_empty() {
+            return Err(format!("no certificates found in UPSTREAM_CA_CERT {path}").into());
+        }
         let mut roots = rustls::RootCertStore::empty();
-        roots.add_parsable_certificates(certs);
-        info!("Upstream TLS: trusting custom CA from UPSTREAM_CA_CERT");
+        let (added, _) = roots.add_parsable_certificates(certs);
+        if added == 0 {
+            return Err(format!("failed to parse any CA certificates from {path}").into());
+        }
+        info!("Upstream TLS: trusting custom CA from {path} ({added} certs)");
         rustls::ClientConfig::builder()
             .with_root_certificates(roots)
             .with_no_client_auth()
@@ -61,19 +113,90 @@ pub fn build_upstream_https_connector(
     }
 }
 
+pub fn build_upstream_http_client(
+    config: &UpstreamTlsConfig,
+) -> Result<UpstreamHttpClient, Box<dyn std::error::Error + Send + Sync>> {
+    let https = build_upstream_https_connector(config)?;
+    Ok(
+        hyper_util::client::legacy::Client::builder(TokioExecutor::new())
+            .pool_idle_timeout(Duration::from_secs(90))
+            .pool_max_idle_per_host(32)
+            .build(https),
+    )
+}
+
+/// Shared hot-reloadable upstream Hyper client (connection pool rebuilt on reload).
+#[derive(Clone)]
+pub struct UpstreamClientHandle {
+    client: Arc<ArcSwap<UpstreamHttpClient>>,
+    snapshot: Arc<ArcSwap<UpstreamTlsSnapshot>>,
+}
+
+impl UpstreamClientHandle {
+    pub fn new(
+        config: UpstreamTlsConfig,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let client = build_upstream_http_client(&config)?;
+        let snapshot = UpstreamTlsSnapshot::from_config(&config);
+        Ok(Self {
+            client: Arc::new(ArcSwap::from_pointee(client)),
+            snapshot: Arc::new(ArcSwap::from_pointee(snapshot)),
+        })
+    }
+
+    pub fn load(&self) -> arc_swap::Guard<Arc<UpstreamHttpClient>> {
+        self.client.load()
+    }
+
+    pub fn snapshot(&self) -> Arc<UpstreamTlsSnapshot> {
+        self.snapshot.load_full()
+    }
+
+    /// Re-read `UPSTREAM_CA_CERT` / `UPSTREAM_HTTP2_ENABLED` and swap the client pool.
+    pub fn reload_from_env(&self) -> Result<UpstreamTlsSnapshot, String> {
+        let config = UpstreamTlsConfig::from_env();
+        let client = build_upstream_http_client(&config).map_err(|e| e.to_string())?;
+        let snapshot = UpstreamTlsSnapshot::from_config(&config);
+        self.client.store(Arc::new(client));
+        self.snapshot.store(Arc::new(snapshot.clone()));
+        info!(
+            "Upstream TLS reloaded (http2={}, custom_ca={})",
+            snapshot.http2_enabled, snapshot.custom_ca
+        );
+        Ok(snapshot)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, Once, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn ensure_crypto_provider() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
 
     #[test]
     fn upstream_tls_config_defaults_http2_off() {
+        let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("UPSTREAM_HTTP2_ENABLED");
+        std::env::remove_var("UPSTREAM_CA_CERT");
         let cfg = UpstreamTlsConfig::from_env();
         assert!(!cfg.http2_enabled);
+        assert!(cfg.ca_cert_path.is_none());
     }
 
     #[test]
     fn upstream_tls_config_parses_http2_flag() {
+        let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         std::env::set_var("UPSTREAM_HTTP2_ENABLED", "true");
         let cfg = UpstreamTlsConfig::from_env();
         assert!(cfg.http2_enabled);
@@ -82,10 +205,42 @@ mod tests {
 
     #[test]
     fn builds_connector_with_and_without_http2() {
+        ensure_crypto_provider();
         let _ = build_upstream_https_connector(&UpstreamTlsConfig::default()).unwrap();
         let _ = build_upstream_https_connector(&UpstreamTlsConfig {
             http2_enabled: true,
+            ca_cert_path: None,
         })
         .unwrap();
+    }
+
+    #[test]
+    fn reload_swaps_snapshot_from_env() {
+        ensure_crypto_provider();
+        let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("UPSTREAM_CA_CERT");
+        std::env::remove_var("UPSTREAM_HTTP2_ENABLED");
+        let handle = UpstreamClientHandle::new(UpstreamTlsConfig::default()).unwrap();
+        assert!(!handle.snapshot().http2_enabled);
+
+        std::env::set_var("UPSTREAM_HTTP2_ENABLED", "true");
+        let snap = handle.reload_from_env().unwrap();
+        std::env::remove_var("UPSTREAM_HTTP2_ENABLED");
+        assert!(snap.http2_enabled);
+        assert!(handle.snapshot().http2_enabled);
+        assert!(!snap.custom_ca);
+    }
+
+    #[test]
+    fn reload_rejects_missing_ca_file() {
+        ensure_crypto_provider();
+        let _g = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let handle = UpstreamClientHandle::new(UpstreamTlsConfig::default()).unwrap();
+        std::env::set_var("UPSTREAM_CA_CERT", "/nonexistent/upstream-ca.pem");
+        let err = handle.reload_from_env().unwrap_err();
+        std::env::remove_var("UPSTREAM_CA_CERT");
+        assert!(err.contains("failed to read") || err.contains("UPSTREAM_CA_CERT"));
+        // Previous client remains usable.
+        assert!(!handle.snapshot().custom_ca);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hot-reload the shared Hyper upstream HTTPS client pool without restarting the proxy (DX Phase 2 leftover).

- `GET /api/upstream/tls` — snapshot (`http2_enabled`, `ca_cert_path`, `custom_ca`, `reloaded_at_unix`)
- `POST /api/upstream/tls/reload` — re-read `UPSTREAM_CA_CERT` + `UPSTREAM_HTTP2_ENABLED`, rebuild connector/pool via `ArcSwap`
- Failed reload keeps the previous client (`400`)
- In-flight requests continue on the old pool until idle drain

Docs: `docs/control-plane.md`, roadmap Phase 2.

## Связанные issue

- Milestone / блокер: DX Phase 2 (no blocker issue)

## Testing

```bash
cargo test -p bsdm-proxy --lib upstream
cargo clippy -p bsdm-proxy --all-targets -- -D warnings
cargo fmt -p bsdm-proxy -- --check
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена
- [x] `docs/roadmap.md` / strategic-roadmap updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

