### PR TITLE
feat(ai): request coalescing for concurrent cache MISSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI request coalescing** — singleflight for concurrent GET/HEAD cache MISSes (`MISS_COALESCE_ENABLED`); waiters serve `COALESCED-HIT`; metric `bsdm_proxy_cache_coalesced_total`
 - **DX upstream TLS hot reload** — `GET /api/upstream/tls`, `POST /api/upstream/tls/reload`; rebuilds Hyper client pool from `UPSTREAM_CA_CERT` / `UPSTREAM_HTTP2_ENABLED` (`ArcSwap`)
 - **DX hierarchy peer hot reload** — `GET /api/hierarchy/peers`, `POST /api/hierarchy/reload`; optional `CACHE_PEERS_PATH` / `HIERARCHY_PEERS_PATH` JSON; discovery siblings preserved
 - **DX Cache-Tag purge** — L1 secondary index for `Cache-Tag` / `Surrogate-Key`; `POST /api/cache/purge` accepts `tag` / `tags` (+ L2 key delete)

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `CACHE_SPILL_THRESHOLD_BYTES` | `262144` | Тела ≥ порога — в mmap spill (`0` = только inline) |
 | `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог spill-файлов (dir `0o700`, files `0o600` на Unix) |
 | `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS → client при записи в L1 |
+| `MISS_COALESCE_ENABLED` | `true` | Singleflight: параллельные GET/HEAD MISS → один upstream; waiters: `COALESCED-HIT` |
 | `CACHE_TTL_SECONDS` | `3600` | Fallback TTL кеша (сек), если нет `max-age` |
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
 | `NEGATIVE_CACHE_ENABLED` | `true` | Кешировать upstream 403/404 |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -40,6 +40,7 @@ cargo install oha   # или бинарь с https://github.com/hatoo/oha
 | `KAFKA_QUEUE_CAPACITY` | `8192` | Bounded in-memory queue перед Kafka producer (#106) |
 | `METRICS_SAMPLE_RATE` | `0` | `N` → histograms для 1 из N запросов (`0` = все) |
 | `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS body to client while buffering for L1 |
+| `MISS_COALESCE_ENABLED` | `true` | Singleflight: parallel identical GET/HEAD MISSes share one upstream fill; waiters get `COALESCED-HIT` |
 
 > **Production ACL:** `PERF_FAST_CACHE_HIT=true` пропускает ACL и categorization на cache HIT. Используйте **только для bench/lab**, не в production с включённой политикой.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,7 +200,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
 | **2. DX** | Control plane | ✅ REST ACL/stats/purge/hierarchy/upstream-TLS reload; next: gRPC control plane |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
-| **4. AI-трафик** | LLM / API proxy | token-bucket RL, semantic cache (vector DB prep), request coalescing |
+| **4. AI-трафик** | LLM / API proxy | ✅ request coalescing (singleflight MISS); next: token-bucket API-key RL, semantic cache |
 
 Порядок реализации по умолчанию: **Lite → DX → Wasm / AI** (AI coalescing может частично пересекаться с perf-треком раньше Wasm).
 

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -49,7 +49,7 @@
 
 - **Умный Rate Limiting:** квоты и токены (Token Bucket / Leaky Bucket) под API-ключи.
 - **Семантическое кэширование:** подготовка к векторным БД для LLM (hit при семантическом сходстве запроса).
-- **Request Coalescing:** защита от Cache Stampede — схлопывание параллельных MISS в один upstream-запрос.
+- **Request Coalescing:** ✅ singleflight для GET/HEAD MISS (`MISS_COALESCE_ENABLED`, metric `bsdm_proxy_cache_coalesced_total`, `X-Cache-Status: COALESCED-HIT`).
 
 ---
 

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -175,3 +175,4 @@ RUST_BACKTRACE=0
 # METRICS_SAMPLE_RATE=100
 # Stream upstream MISS responses to the client while buffering for L1 (default: true)
 # STREAMING_MISS_ENABLED=true
+# MISS_COALESCE_ENABLED=true

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -21,6 +21,7 @@ pub mod http_types;
 pub mod icp;
 pub mod l2_cache;
 pub mod metrics;
+pub mod miss_coalesce;
 pub mod peer_discovery;
 pub mod peer_fetch;
 pub mod peers;

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -28,6 +28,7 @@ pub struct Metrics {
     // Cache metrics
     pub cache_hits_total: Counter,
     pub cache_misses_total: Counter,
+    pub cache_coalesced_total: Counter,
     pub cache_bypasses_total: Counter,
     pub cache_entries: Gauge,
     pub cache_size_bytes: Gauge,
@@ -148,6 +149,12 @@ impl Metrics {
             "Total number of cache misses",
         )?;
         registry.register(Box::new(cache_misses_total.clone()))?;
+
+        let cache_coalesced_total = Counter::new(
+            "bsdm_proxy_cache_coalesced_total",
+            "Cache MISSes served from a coalesced in-flight fill (singleflight waiters)",
+        )?;
+        registry.register(Box::new(cache_coalesced_total.clone()))?;
 
         let cache_bypasses_total = Counter::new(
             "bsdm_proxy_cache_bypasses_total",
@@ -412,6 +419,7 @@ impl Metrics {
             response_size_bytes,
             cache_hits_total,
             cache_misses_total,
+            cache_coalesced_total,
             cache_bypasses_total,
             cache_entries,
             cache_size_bytes,

--- a/proxy/src/miss_coalesce.rs
+++ b/proxy/src/miss_coalesce.rs
@@ -1,0 +1,197 @@
+//! Request coalescing (singleflight) for concurrent cacheable MISSes.
+//!
+//! Parallel identical GET/HEAD misses share one upstream fetch: the leader fills L1,
+//! followers wait and serve the stored response as `COALESCED-HIT`.
+
+use crate::cache::CachedResponse;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::watch;
+
+#[derive(Clone, Default)]
+pub struct MissFlightMap {
+    inner: Arc<Mutex<HashMap<Arc<str>, Arc<Flight>>>>,
+}
+
+struct Flight {
+    tx: watch::Sender<FlightState>,
+}
+
+#[derive(Clone)]
+enum FlightState {
+    Pending,
+    Done(Option<CachedResponse>),
+}
+
+pub enum CoalesceJoin {
+    /// This request should fetch upstream; call [`MissFlightPermit::complete`] when done.
+    Leader(MissFlightPermit),
+    /// Wait for the leader; [`MissFlightWait::wait`] returns a stored response or `None`.
+    Follower(MissFlightWait),
+}
+
+pub struct MissFlightPermit {
+    map: MissFlightMap,
+    key: Arc<str>,
+    disarmed: bool,
+}
+
+pub struct MissFlightWait {
+    rx: watch::Receiver<FlightState>,
+}
+
+impl MissFlightMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Join an in-flight miss for `key`, or become the leader.
+    pub fn join(&self, key: &Arc<str>) -> CoalesceJoin {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(flight) = guard.get(key) {
+            return CoalesceJoin::Follower(MissFlightWait {
+                rx: flight.tx.subscribe(),
+            });
+        }
+        let (tx, _rx) = watch::channel(FlightState::Pending);
+        let flight = Arc::new(Flight { tx });
+        guard.insert(key.clone(), flight);
+        CoalesceJoin::Leader(MissFlightPermit {
+            map: self.clone(),
+            key: key.clone(),
+            disarmed: false,
+        })
+    }
+
+    /// Publish outcome and remove the flight (idempotent).
+    pub fn complete(&self, key: &Arc<str>, result: Option<CachedResponse>) {
+        let flight = {
+            let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            guard.remove(key)
+        };
+        if let Some(flight) = flight {
+            let _ = flight.tx.send(FlightState::Done(result));
+        }
+    }
+
+    #[cfg(test)]
+    fn inflight_len(&self) -> usize {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+}
+
+impl MissFlightPermit {
+    /// Hand responsibility to miss-completion (streaming path); Drop will not finish.
+    pub fn disarm(mut self) {
+        self.disarmed = true;
+    }
+
+    pub fn complete(mut self, result: Option<CachedResponse>) {
+        self.disarmed = true;
+        self.map.complete(&self.key, result);
+    }
+
+    pub fn key(&self) -> &Arc<str> {
+        &self.key
+    }
+}
+
+impl Drop for MissFlightPermit {
+    fn drop(&mut self) {
+        if !self.disarmed {
+            self.map.complete(&self.key, None);
+        }
+    }
+}
+
+impl MissFlightWait {
+    pub async fn wait(mut self) -> Option<CachedResponse> {
+        loop {
+            let state = self.rx.borrow().clone();
+            match state {
+                FlightState::Done(result) => return result,
+                FlightState::Pending => {
+                    if self.rx.changed().await.is_err() {
+                        return None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use std::time::{Duration, SystemTime};
+
+    fn sample_cached(marker: &'static str) -> CachedResponse {
+        CachedResponse {
+            status: 200,
+            headers: Arc::from([]),
+            body: crate::cache_body::CachedBody::inline(Bytes::from_static(marker.as_bytes())),
+            body_encoding: crate::cache_compress::BodyEncoding::Raw,
+            uncompressed_len: marker.len(),
+            cached_at: SystemTime::now(),
+            ttl: Duration::from_secs(60),
+            etag: None,
+            last_modified: None,
+            is_negative: false,
+            must_revalidate: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn leader_and_follower_share_result() {
+        let map = MissFlightMap::new();
+        let key: Arc<str> = Arc::from("k1");
+        let CoalesceJoin::Leader(permit) = map.join(&key) else {
+            panic!("expected leader");
+        };
+        let CoalesceJoin::Follower(wait) = map.join(&key) else {
+            panic!("expected follower");
+        };
+        assert_eq!(map.inflight_len(), 1);
+
+        let cached = sample_cached("body");
+        let wait_task = tokio::spawn(async move { wait.wait().await });
+        permit.complete(Some(cached.clone()));
+
+        let got = wait_task.await.unwrap().unwrap();
+        assert_eq!(got.status, 200);
+        assert_eq!(got.stored_body_bytes(), Bytes::from_static(b"body"));
+        assert_eq!(map.inflight_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn empty_complete_unblocks_follower() {
+        let map = MissFlightMap::new();
+        let key: Arc<str> = Arc::from("k2");
+        let CoalesceJoin::Leader(permit) = map.join(&key) else {
+            panic!("expected leader");
+        };
+        let CoalesceJoin::Follower(wait) = map.join(&key) else {
+            panic!("expected follower");
+        };
+        let wait_task = tokio::spawn(async move { wait.wait().await });
+        permit.complete(None);
+        assert!(wait_task.await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn drop_permit_unblocks_followers() {
+        let map = MissFlightMap::new();
+        let key: Arc<str> = Arc::from("k3");
+        let CoalesceJoin::Leader(permit) = map.join(&key) else {
+            panic!("expected leader");
+        };
+        let CoalesceJoin::Follower(wait) = map.join(&key) else {
+            panic!("expected follower");
+        };
+        let wait_task = tokio::spawn(async move { wait.wait().await });
+        drop(permit);
+        assert!(wait_task.await.unwrap().is_none());
+        assert_eq!(map.inflight_len(), 0);
+    }
+}

--- a/proxy/src/perf.rs
+++ b/proxy/src/perf.rs
@@ -19,6 +19,8 @@ pub struct PerfConfig {
     pub metrics_sample_rate: u32,
     /// Stream upstream MISS bodies to the client while buffering for cache (#94).
     pub streaming_miss_enabled: bool,
+    /// Collapse concurrent identical GET/HEAD MISSes into one upstream fetch.
+    pub miss_coalesce_enabled: bool,
 }
 
 impl PerfConfig {
@@ -47,6 +49,7 @@ impl PerfConfig {
             .unwrap_or(0);
 
         let streaming_miss_enabled = env_bool("STREAMING_MISS_ENABLED", true);
+        let miss_coalesce_enabled = env_bool("MISS_COALESCE_ENABLED", true);
 
         Self {
             fast_cache_hit,
@@ -55,6 +58,7 @@ impl PerfConfig {
             kafka_sample_rate,
             metrics_sample_rate,
             streaming_miss_enabled,
+            miss_coalesce_enabled,
         }
     }
 
@@ -165,6 +169,7 @@ mod tests {
             kafka_sample_rate: 0,
             metrics_sample_rate: 0,
             streaming_miss_enabled: true,
+            miss_coalesce_enabled: true,
         };
         assert!(cfg.should_emit_kafka_event());
         assert!(cfg.record_detailed_metrics());
@@ -179,6 +184,7 @@ mod tests {
             kafka_sample_rate: 1,
             metrics_sample_rate: 0,
             streaming_miss_enabled: true,
+            miss_coalesce_enabled: true,
         };
         assert!(cfg.should_emit_kafka_event());
     }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -29,6 +29,7 @@ use crate::hierarchy::{HierarchyManager, HierarchyResult};
 use crate::http_types::{empty, full, Body};
 use crate::l2_cache::RedisL2Cache;
 use crate::metrics::{FastRequestScope, Metrics, RequestMetricsGuard};
+use crate::miss_coalesce::{CoalesceJoin, MissFlightMap, MissFlightPermit};
 use crate::peer_fetch::fetch_via_peer;
 use crate::peers::CachePeer;
 use crate::perf::PerfConfig;
@@ -63,6 +64,7 @@ struct MissCompletionHandle {
     perf: PerfConfig,
     digest_registry: Option<Arc<DigestRegistry>>,
     sessions: Arc<SessionCorrelator>,
+    miss_flights: MissFlightMap,
 }
 
 impl MissCompletionHandle {
@@ -149,7 +151,9 @@ impl MissCompletionHandle {
                 store_decision.is_negative,
                 store_decision.must_revalidate,
             );
-            self.store_in_l1_and_l2(cache_key.clone(), cached_response);
+            self.store_in_l1_and_l2(cache_key.clone(), cached_response.clone());
+            self.miss_flights
+                .complete(&cache_key, Some(cached_response));
             if let Some(g) = guard.as_mut() {
                 g.set_cache_status(if store_decision.is_negative {
                     "NEGATIVE_MISS"
@@ -158,6 +162,7 @@ impl MissCompletionHandle {
                 });
             }
         } else {
+            self.miss_flights.complete(&cache_key, None);
             self.metrics.cache_bypasses_total.inc();
             if let Some(g) = guard.as_mut() {
                 g.set_cache_status("BYPASS");
@@ -254,6 +259,7 @@ pub struct ProxyService {
     policy_cache: Arc<PolicyDecisionCache>,
     sessions: Arc<SessionCorrelator>,
     threat_score_cache: Arc<ThreatScoreCache>,
+    miss_flights: MissFlightMap,
 }
 
 impl ProxyService {
@@ -294,6 +300,7 @@ impl ProxyService {
             perf: self.perf.clone(),
             digest_registry: self.digest_registry.clone(),
             sessions: self.sessions.clone(),
+            miss_flights: self.miss_flights.clone(),
         }
     }
 
@@ -345,6 +352,7 @@ impl ProxyService {
             policy_cache,
             sessions: Arc::new(SessionCorrelator::from_env()),
             threat_score_cache,
+            miss_flights: MissFlightMap::new(),
         }
     }
 
@@ -1411,6 +1419,63 @@ impl ProxyService {
                 .observe(cache_lookup_start.elapsed().as_secs_f64());
         }
 
+        // Collapse concurrent identical GET/HEAD MISSes onto one upstream fill.
+        let mut flight_permit: Option<MissFlightPermit> = None;
+        if self.perf.miss_coalesce_enabled && CACHEABLE_METHODS.contains(&method) {
+            match self.miss_flights.join(&cache_key) {
+                CoalesceJoin::Follower(wait) => {
+                    if let Some(cached) = wait.wait().await {
+                        debug!("Cache COALESCED HIT: {} {}", method, url);
+                        self.metrics.cache_coalesced_total.inc();
+                        return self.serve_l1_hit(
+                            &cached,
+                            &cache_key,
+                            &url,
+                            method,
+                            &user_id,
+                            &username,
+                            user_agent.as_deref(),
+                            &client_ip,
+                            &categories,
+                            &threat_sources,
+                            request_start,
+                            detailed_metrics,
+                            &mut guard,
+                            &mut fast_scope,
+                            "COALESCED",
+                            "COALESCED-HIT",
+                        );
+                    }
+                    // Leader failed / bypassed — check L1 then fetch without coalescing.
+                    if let Some(cached) = self.http_cache.get(&cache_key) {
+                        if cached.can_serve_fresh() {
+                            return self.serve_l1_hit(
+                                &cached,
+                                &cache_key,
+                                &url,
+                                method,
+                                &user_id,
+                                &username,
+                                user_agent.as_deref(),
+                                &client_ip,
+                                &categories,
+                                &threat_sources,
+                                request_start,
+                                detailed_metrics,
+                                &mut guard,
+                                &mut fast_scope,
+                                "HIT",
+                                "HIT",
+                            );
+                        }
+                    }
+                }
+                CoalesceJoin::Leader(permit) => {
+                    flight_permit = Some(permit);
+                }
+            }
+        }
+
         debug!("Cache MISS: {} {}", method, url);
         self.metrics.cache_misses_total.inc();
 
@@ -1419,6 +1484,9 @@ impl ProxyService {
             Ok(collected) => collected.to_bytes(),
             Err(e) => {
                 error!("Body collection failed: {}", e);
+                if let Some(permit) = flight_permit.take() {
+                    permit.complete(None);
+                }
                 let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
                 *resp.status_mut() = StatusCode::BAD_REQUEST;
                 Self::finish_request_metrics(&mut guard, &mut fast_scope, 400, 0, 15);
@@ -1467,6 +1535,11 @@ impl ProxyService {
                     let x_cache = miss_x_cache_status_header(true, &store_precheck);
                     if let Some(g) = guard.as_mut() {
                         g.set_cache_status(&cache_status_metric_label(x_cache));
+                    }
+
+                    // Completion path finishes the flight; disarm Drop.
+                    if let Some(permit) = flight_permit.take() {
+                        permit.disarm();
                     }
 
                     let handle = self.miss_completion_handle();
@@ -1540,6 +1613,9 @@ impl ProxyService {
                     Ok(collected) => collected.to_bytes(),
                     Err(e) => {
                         error!("Response body collection failed: {}", e);
+                        if let Some(permit) = flight_permit.take() {
+                            permit.complete(None);
+                        }
                         self.metrics
                             .upstream_errors_total
                             .with_label_values(&[&domain, "body_read"])
@@ -1556,6 +1632,11 @@ impl ProxyService {
                         return resp;
                     }
                 };
+
+                // Buffered path: complete_cache_miss finishes the flight; disarm Drop.
+                if let Some(permit) = flight_permit.take() {
+                    permit.disarm();
+                }
 
                 let store_decision = evaluate_store(
                     method,
@@ -1596,6 +1677,9 @@ impl ProxyService {
             }
             Err(e) => {
                 error!("Upstream error for {}: {}", url, e);
+                if let Some(permit) = flight_permit.take() {
+                    permit.complete(None);
+                }
                 self.metrics
                     .upstream_errors_total
                     .with_label_values(&[&domain, "connection"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cache stampede protection for concurrent identical GET/HEAD MISSes (strategic Phase 4).

- New `miss_coalesce` singleflight map keyed by L1 cache key
- Leader fetches/stores as before; followers wait and serve `X-Cache-Status: COALESCED-HIT`
- Streaming MISS: waiters unblock after leader drain + L1 insert (no body fan-out)
- Failed/bypass leader → waiters fall through (L1 check, then own fetch)
- Env: `MISS_COALESCE_ENABLED` (default `true`)
- Metric: `bsdm_proxy_cache_coalesced_total`

## Связанные issue

- Milestone: strategic Phase 4 (AI-трафик / coalescing)

## Testing

```bash
cargo test -p bsdm-proxy --lib miss_coalesce
cargo clippy -p bsdm-proxy --all-targets -- -D warnings
cargo fmt -p bsdm-proxy -- --check
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена (`docs/performance.md`, roadmap)
- [x] `docs/roadmap.md` / strategic-roadmap updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

