### PR TITLE
feat(ai): LLM / semantic cache prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **AI semantic / LLM cache prep** — `SEMANTIC_CACHE_ENABLED` POST body-hash cache for chat/completions paths; optional local cosine near-hit; docs [semantic-cache.md](docs/semantic-cache.md)
 - **AI API-key rate limiting** — token bucket per API key (`RATE_LIMIT_API_KEY_*`); key from `X-API-Key` or `Authorization: Bearer`; optional `RATE_LIMIT_API_KEY_REQUIRED` → 401; metric label `api_key` / `api_key_missing`
 - **AI request coalescing** — singleflight for concurrent GET/HEAD cache MISSes (`MISS_COALESCE_ENABLED`); waiters serve `COALESCED-HIT`; metric `bsdm_proxy_cache_coalesced_total`
 - **DX upstream TLS hot reload** — `GET /api/upstream/tls`, `POST /api/upstream/tls/reload`; rebuilds Hyper client pool from `UPSTREAM_CA_CERT` / `UPSTREAM_HTTP2_ENABLED` (`ArcSwap`)

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `CACHE_SPILL_DIR` | `{tmp}/bsdm-cache-spill` | Каталог spill-файлов (dir `0o700`, files `0o600` на Unix) |
 | `STREAMING_MISS_ENABLED` | `true` | Tee upstream MISS → client при записи в L1 |
 | `MISS_COALESCE_ENABLED` | `true` | Singleflight: параллельные GET/HEAD MISS → один upstream; waiters: `COALESCED-HIT` |
+| `SEMANTIC_CACHE_ENABLED` | `false` | LLM POST cache (body-hash + optional similarity); см. [docs/semantic-cache.md](docs/semantic-cache.md) |
+| `SEMANTIC_CACHE_PATH_PREFIXES` | `/v1/chat/completions,…` | Path prefixes for LLM POST caching |
+| `SEMANTIC_CACHE_TTL_SECONDS` | `3600` | TTL for LLM cached responses |
+| `SEMANTIC_CACHE_SIMILARITY` | `1.0` | Cosine threshold; `<1` enables near-hit |
 | `CACHE_TTL_SECONDS` | `3600` | Fallback TTL кеша (сек), если нет `max-age` |
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
 | `NEGATIVE_CACHE_ENABLED` | `true` | Кешировать upstream 403/404 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
 | [authentication.md](authentication.md) | Basic, LDAP, NTLM, Kerberos |
 | [logging.md](logging.md) | `RUST_LOG`, уровни |
 | [performance.md](performance.md) | Тюнинг RPS, bench |
+| [semantic-cache.md](semantic-cache.md) | LLM / semantic cache prep |
 | [acl.md](acl.md) | ACL + REST API |
 | [control-plane.md](control-plane.md) | DX Phase 2: stats, cache purge, ACL CRUD |
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,7 +200,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
 | **2. DX** | Control plane | ✅ REST ACL/stats/purge/hierarchy/upstream-TLS reload; next: gRPC control plane |
 | **3. Wasm** | Плагины | Wasmtime в request/response pipeline, SDK (Rust/Go/AS), PoC auth-as-plugin |
-| **4. AI-трафик** | LLM / API proxy | ✅ coalescing + API-key token-bucket RL; next: semantic cache |
+| **4. AI-трафик** | LLM / API proxy | ✅ coalescing + API-key RL + LLM/semantic cache prep; next: external vector DB |
 
 Порядок реализации по умолчанию: **Lite → DX → Wasm / AI** (AI coalescing может частично пересекаться с perf-треком раньше Wasm).
 

--- a/docs/semantic-cache.md
+++ b/docs/semantic-cache.md
@@ -1,0 +1,33 @@
+# Semantic / LLM cache (Phase 4 prep)
+
+Content-addressable caching for LLM-style `POST` APIs, plus an optional local similarity index as a stand-in for a future vector DB.
+
+See [strategic-roadmap.md](strategic-roadmap.md) Phase 4.
+
+## Enable
+
+```bash
+SEMANTIC_CACHE_ENABLED=true
+# Optional:
+# SEMANTIC_CACHE_PATH_PREFIXES=/v1/chat/completions,/v1/completions,/chat/completions
+# SEMANTIC_CACHE_TTL_SECONDS=3600
+# SEMANTIC_CACHE_SIMILARITY=1.0          # <1.0 enables near-hit (cosine on local hash embed)
+# SEMANTIC_CACHE_EMBED_DIMS=64
+# SEMANTIC_CACHE_MAX_INDEX=10000
+```
+
+## Behavior
+
+1. **Exact hit** — SHA-256 of `method + URL + normalized JSON body` (`model` + `messages` / `prompt`; other fields like `temperature` ignored).  
+   Header: `X-Cache-Status: LLM-HIT` · metric `bsdm_proxy_semantic_cache_exact_hits_total`
+2. **Near hit** (only if `SEMANTIC_CACHE_SIMILARITY < 1.0`) — local feature-hash embedding + cosine vs in-memory index.  
+   Header: `X-Cache-Status: SEMANTIC-HIT` · metric `bsdm_proxy_semantic_cache_similar_hits_total`
+3. **Miss** — upstream fetch; on `200` store in L1 with configured TTL (ignores provider `Cache-Control: no-store` / `private`).  
+   Header: `X-Cache-Status: LLM-MISS` · index updated for future near-hits
+
+Applies only to `POST` URLs whose path matches a configured prefix.
+
+## Limits / next steps
+
+- Local hashing embeddings are **not** true semantic embeddings — useful for near-duplicate prompts, not paraphrase matching.
+- Next: plug in an external embedding API / vector store behind the same `SemanticIndex` shape.

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -48,7 +48,7 @@
 *Фокус: современные паттерны трафика и LLM.*
 
 - **Умный Rate Limiting:** ✅ token bucket per IP / user / API key (`RATE_LIMIT_API_KEY_*`, header или Bearer; optional required → 401).
-- **Семантическое кэширование:** подготовка к векторным БД для LLM (hit при семантическом сходстве запроса).
+- **Семантическое кэширование:** ✅ LLM POST content-hash cache + local similarity index prep ([semantic-cache.md](semantic-cache.md)); next: external embeddings / vector DB.
 - **Request Coalescing:** ✅ singleflight для GET/HEAD MISS (`MISS_COALESCE_ENABLED`, metric `bsdm_proxy_cache_coalesced_total`, `X-Cache-Status: COALESCED-HIT`).
 
 ---

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -181,3 +181,9 @@ RUST_BACKTRACE=0
 # Stream upstream MISS responses to the client while buffering for L1 (default: true)
 # STREAMING_MISS_ENABLED=true
 # MISS_COALESCE_ENABLED=true
+# SEMANTIC_CACHE_ENABLED=false
+# SEMANTIC_CACHE_PATH_PREFIXES=/v1/chat/completions,/v1/completions,/chat/completions
+# SEMANTIC_CACHE_TTL_SECONDS=3600
+# SEMANTIC_CACHE_SIMILARITY=1.0
+# SEMANTIC_CACHE_EMBED_DIMS=64
+# SEMANTIC_CACHE_MAX_INDEX=10000

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -31,6 +31,7 @@ pub mod policy_cache;
 pub mod proxy_service;
 pub mod rate_limit;
 pub mod selection;
+pub mod semantic_cache;
 pub mod server;
 pub mod session;
 pub mod sharded_cache;
@@ -78,6 +79,9 @@ pub use policy_cache::{PolicyCacheConfig, PolicyDecisionCache};
 pub use proxy_service::{ProxyPolicy, ProxyService};
 pub use rate_limit::{extract_api_key, RateLimitConfig, RateLimitViolation, RateLimiter};
 pub use selection::{parse_strategy, SelectionStrategy};
+pub use semantic_cache::{
+    content_cache_key, normalize_llm_body, SemanticCacheConfig, SemanticIndex,
+};
 pub use server::{handle_connection, metrics_server, wait_shutdown_signal};
 pub use session::{SessionCorrelation, SessionCorrelator};
 pub use sharded_cache::HttpL1Cache;

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -29,6 +29,8 @@ pub struct Metrics {
     pub cache_hits_total: Counter,
     pub cache_misses_total: Counter,
     pub cache_coalesced_total: Counter,
+    pub semantic_cache_exact_hits_total: Counter,
+    pub semantic_cache_similar_hits_total: Counter,
     pub cache_bypasses_total: Counter,
     pub cache_entries: Gauge,
     pub cache_size_bytes: Gauge,
@@ -155,6 +157,18 @@ impl Metrics {
             "Cache MISSes served from a coalesced in-flight fill (singleflight waiters)",
         )?;
         registry.register(Box::new(cache_coalesced_total.clone()))?;
+
+        let semantic_cache_exact_hits_total = Counter::new(
+            "bsdm_proxy_semantic_cache_exact_hits_total",
+            "LLM POST exact content-hash cache hits",
+        )?;
+        registry.register(Box::new(semantic_cache_exact_hits_total.clone()))?;
+
+        let semantic_cache_similar_hits_total = Counter::new(
+            "bsdm_proxy_semantic_cache_similar_hits_total",
+            "LLM POST near-neighbor semantic cache hits (local embedding cosine)",
+        )?;
+        registry.register(Box::new(semantic_cache_similar_hits_total.clone()))?;
 
         let cache_bypasses_total = Counter::new(
             "bsdm_proxy_cache_bypasses_total",
@@ -420,6 +434,8 @@ impl Metrics {
             cache_hits_total,
             cache_misses_total,
             cache_coalesced_total,
+            semantic_cache_exact_hits_total,
+            semantic_cache_similar_hits_total,
             cache_bypasses_total,
             cache_entries,
             cache_size_bytes,

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -38,6 +38,10 @@ use crate::pipeline::{dispatch_cache_event, new_event_id, CacheEvent, HttpEventP
 use crate::pipeline::{flush_kafka, KafkaEventPipeline};
 use crate::policy_cache::PolicyDecisionCache;
 use crate::rate_limit::{extract_api_key, RateLimitViolation, RateLimiter};
+use crate::semantic_cache::{
+    content_cache_key, evaluate_llm_store, extract_embed_text, hash_embed, normalize_llm_body,
+    SemanticCacheConfig, SemanticIndex,
+};
 use crate::session::{header_ci, resolve_location, SessionCorrelator};
 use crate::sharded_cache::HttpL1Cache;
 use crate::streaming_miss::TeeMissBody;
@@ -65,6 +69,11 @@ struct MissCompletionHandle {
     digest_registry: Option<Arc<DigestRegistry>>,
     sessions: Arc<SessionCorrelator>,
     miss_flights: MissFlightMap,
+    semantic_config: SemanticCacheConfig,
+    semantic_index: SemanticIndex,
+    /// When set, this completion is an LLM/semantic POST fill.
+    llm_mode: bool,
+    llm_normalized_body: Option<Bytes>,
 }
 
 impl MissCompletionHandle {
@@ -152,11 +161,20 @@ impl MissCompletionHandle {
                 store_decision.must_revalidate,
             );
             self.store_in_l1_and_l2(cache_key.clone(), cached_response.clone());
+            if self.llm_mode {
+                if let Some(norm) = &self.llm_normalized_body {
+                    let emb =
+                        hash_embed(&extract_embed_text(norm), self.semantic_config.embed_dims);
+                    self.semantic_index.insert(emb, cache_key.clone());
+                }
+            }
             self.miss_flights
                 .complete(&cache_key, Some(cached_response));
             if let Some(g) = guard.as_mut() {
                 g.set_cache_status(if store_decision.is_negative {
                     "NEGATIVE_MISS"
+                } else if self.llm_mode {
+                    "LLM_MISS"
                 } else {
                     "MISS"
                 });
@@ -172,6 +190,8 @@ impl MissCompletionHandle {
         let cache_status = if stored && store_decision.store {
             if store_decision.is_negative {
                 "NEGATIVE_MISS"
+            } else if self.llm_mode {
+                "LLM_MISS"
             } else {
                 "MISS"
             }
@@ -260,6 +280,8 @@ pub struct ProxyService {
     sessions: Arc<SessionCorrelator>,
     threat_score_cache: Arc<ThreatScoreCache>,
     miss_flights: MissFlightMap,
+    semantic_config: SemanticCacheConfig,
+    semantic_index: SemanticIndex,
 }
 
 impl ProxyService {
@@ -288,6 +310,18 @@ impl ProxyService {
     }
 
     fn miss_completion_handle(&self) -> MissCompletionHandle {
+        self.miss_completion_handle_inner(false, None)
+    }
+
+    fn miss_completion_handle_llm(&self, normalized_body: Bytes) -> MissCompletionHandle {
+        self.miss_completion_handle_inner(true, Some(normalized_body))
+    }
+
+    fn miss_completion_handle_inner(
+        &self,
+        llm_mode: bool,
+        llm_normalized_body: Option<Bytes>,
+    ) -> MissCompletionHandle {
         MissCompletionHandle {
             http_cache: self.http_cache.clone(),
             cache_config: self.cache_config.clone(),
@@ -301,6 +335,10 @@ impl ProxyService {
             digest_registry: self.digest_registry.clone(),
             sessions: self.sessions.clone(),
             miss_flights: self.miss_flights.clone(),
+            semantic_config: self.semantic_config.clone(),
+            semantic_index: self.semantic_index.clone(),
+            llm_mode,
+            llm_normalized_body,
         }
     }
 
@@ -330,6 +368,8 @@ impl ProxyService {
 
         let http_client =
             UpstreamClientHandle::new(upstream_tls).expect("failed to build upstream HTTPS client");
+        let semantic_config = SemanticCacheConfig::from_env();
+        let semantic_index = SemanticIndex::new(semantic_config.max_index_entries);
 
         Self {
             cert_cache,
@@ -353,6 +393,8 @@ impl ProxyService {
             sessions: Arc::new(SessionCorrelator::from_env()),
             threat_score_cache,
             miss_flights: MissFlightMap::new(),
+            semantic_config,
+            semantic_index,
         }
     }
 
@@ -1254,8 +1296,8 @@ impl ProxyService {
         let detailed_metrics = self.perf.record_detailed_metrics();
         let http_method = req.method().clone();
         let method = http_method.as_str();
-        let uri = req.uri();
-        let url = uri.to_string();
+        let url = req.uri().to_string();
+        let mut req = Some(req);
 
         let mut guard = if detailed_metrics {
             Some(RequestMetricsGuard::new(
@@ -1272,17 +1314,21 @@ impl ProxyService {
         };
 
         let request_start = Instant::now();
+        let llm_mode = self.semantic_config.applies(method, &url);
 
-        let cache_key = self.generate_cache_key(method, &url);
+        let mut cache_key = self.generate_cache_key(method, &url);
 
+        let req_ref = req.as_ref().expect("request present");
         let (user_id, username) = if let Some(user) = proxy_user.as_deref() {
             Self::user_fields(Some(user))
         } else {
-            Self::extract_user_info(&req)
+            Self::extract_user_info(req_ref)
         };
-        let user_agent = Self::request_header_str(&req, "user-agent");
+        let user_agent = Self::request_header_str(req_ref, "user-agent");
 
-        if let Some(resp) = self.check_rate_limit(&client_ip, username.as_deref(), req.headers()) {
+        if let Some(resp) =
+            self.check_rate_limit(&client_ip, username.as_deref(), req_ref.headers())
+        {
             let code = resp.status().as_u16();
             if let Some(g) = guard.take() {
                 g.finish(code, 0, 0);
@@ -1292,10 +1338,10 @@ impl ProxyService {
             return resp;
         }
 
-        if self.perf.skip_policy_on_cache_serve() {
+        if self.perf.skip_policy_on_cache_serve() && !llm_mode {
             if let Some(resp) = self
                 .try_serve_cache_before_policy(
-                    &req,
+                    req.as_ref().expect("request present"),
                     &cache_key,
                     &url,
                     method,
@@ -1345,7 +1391,93 @@ impl ProxyService {
         }
 
         let cache_lookup_start = Instant::now();
-        if let Some(cached) = self.http_cache.get(&cache_key) {
+        let mut early_body = None::<(hyper::http::request::Parts, Bytes)>;
+        let mut llm_normalized: Option<Bytes> = None;
+
+        if llm_mode {
+            let (parts, body) = req.take().expect("request present").into_parts();
+            let body_bytes = match http_body_util::BodyExt::collect(body).await {
+                Ok(collected) => collected.to_bytes(),
+                Err(e) => {
+                    error!("LLM body collection failed: {}", e);
+                    let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
+                    *resp.status_mut() = StatusCode::BAD_REQUEST;
+                    Self::finish_request_metrics(&mut guard, &mut fast_scope, 400, 0, 15);
+                    return resp;
+                }
+            };
+            let normalized = Bytes::from(normalize_llm_body(&body_bytes));
+            cache_key = content_cache_key(method, &url, &normalized);
+
+            if let Some(cached) = self.http_cache.get(&cache_key) {
+                if cached.can_serve_fresh() {
+                    debug!("LLM cache exact HIT: {} {}", method, url);
+                    self.metrics.semantic_cache_exact_hits_total.inc();
+                    return self.serve_l1_hit(
+                        &cached,
+                        &cache_key,
+                        &url,
+                        method,
+                        &user_id,
+                        &username,
+                        user_agent.as_deref(),
+                        &client_ip,
+                        &categories,
+                        &threat_sources,
+                        request_start,
+                        detailed_metrics,
+                        &mut guard,
+                        &mut fast_scope,
+                        "LLM_HIT",
+                        "LLM-HIT",
+                    );
+                }
+            }
+
+            if self.semantic_config.near_hit_enabled() {
+                let emb = hash_embed(
+                    &extract_embed_text(&normalized),
+                    self.semantic_config.embed_dims,
+                );
+                if let Some(near_key) = self
+                    .semantic_index
+                    .find_similar(&emb, self.semantic_config.similarity_threshold)
+                {
+                    if let Some(cached) = self.http_cache.get(&near_key) {
+                        if cached.can_serve_fresh() {
+                            debug!("LLM cache semantic HIT: {} {}", method, url);
+                            self.metrics.semantic_cache_similar_hits_total.inc();
+                            return self.serve_l1_hit(
+                                &cached,
+                                &near_key,
+                                &url,
+                                method,
+                                &user_id,
+                                &username,
+                                user_agent.as_deref(),
+                                &client_ip,
+                                &categories,
+                                &threat_sources,
+                                request_start,
+                                detailed_metrics,
+                                &mut guard,
+                                &mut fast_scope,
+                                "SEMANTIC_HIT",
+                                "SEMANTIC-HIT",
+                            );
+                        }
+                    }
+                }
+            }
+
+            llm_normalized = Some(normalized);
+            early_body = Some((parts, body_bytes));
+            if detailed_metrics {
+                self.metrics
+                    .cache_lookup_duration_seconds
+                    .observe(cache_lookup_start.elapsed().as_secs_f64());
+            }
+        } else if let Some(cached) = self.http_cache.get(&cache_key) {
             if detailed_metrics {
                 self.metrics
                     .cache_lookup_duration_seconds
@@ -1377,7 +1509,7 @@ impl ProxyService {
             if let Some(resp) = self
                 .try_revalidate_stale(
                     &cached,
-                    &req,
+                    req.as_ref().expect("request present"),
                     &cache_key,
                     &url,
                     method,
@@ -1397,60 +1529,62 @@ impl ProxyService {
             }
         }
 
-        if let Some(cached) = self.try_l2_cache_get(&cache_key).await {
-            debug!("Cache L2 HIT: {} {}", method, url);
-            self.http_cache.insert(cache_key.clone(), cached.clone());
-            let hit_label = if cached.is_negative {
-                "NEGATIVE_HIT"
-            } else {
-                "L2_HIT"
-            };
-            let x_status = if cached.is_negative {
-                "NEGATIVE-HIT"
-            } else {
-                "L2-HIT"
-            };
-            if let Some(g) = guard.as_mut() {
-                g.set_cache_status(hit_label);
-                self.metrics.cache_hits_total.inc();
+        if !llm_mode {
+            if let Some(cached) = self.try_l2_cache_get(&cache_key).await {
+                debug!("Cache L2 HIT: {} {}", method, url);
+                self.http_cache.insert(cache_key.clone(), cached.clone());
+                let hit_label = if cached.is_negative {
+                    "NEGATIVE_HIT"
+                } else {
+                    "L2_HIT"
+                };
+                let x_status = if cached.is_negative {
+                    "NEGATIVE-HIT"
+                } else {
+                    "L2-HIT"
+                };
+                if let Some(g) = guard.as_mut() {
+                    g.set_cache_status(hit_label);
+                    self.metrics.cache_hits_total.inc();
+                }
+
+                if detailed_metrics {
+                    self.emit_cache_hit_event(
+                        &url,
+                        method,
+                        &cache_key,
+                        hit_label,
+                        &cached,
+                        &user_id,
+                        &username,
+                        user_agent.as_deref(),
+                        &client_ip,
+                        &categories,
+                        &threat_sources,
+                        request_start,
+                    );
+                }
+
+                let response = cached.to_response_with_cache_status(x_status);
+                let body_size = cached.response_body_len();
+                if let Some(g) = guard.take() {
+                    g.finish(cached.status, 0, body_size);
+                } else if let Some(scope) = fast_scope.take() {
+                    scope.finish_cache_hit();
+                }
+                return response;
             }
 
             if detailed_metrics {
-                self.emit_cache_hit_event(
-                    &url,
-                    method,
-                    &cache_key,
-                    hit_label,
-                    &cached,
-                    &user_id,
-                    &username,
-                    user_agent.as_deref(),
-                    &client_ip,
-                    &categories,
-                    &threat_sources,
-                    request_start,
-                );
+                self.metrics
+                    .cache_lookup_duration_seconds
+                    .observe(cache_lookup_start.elapsed().as_secs_f64());
             }
-
-            let response = cached.to_response_with_cache_status(x_status);
-            let body_size = cached.response_body_len();
-            if let Some(g) = guard.take() {
-                g.finish(cached.status, 0, body_size);
-            } else if let Some(scope) = fast_scope.take() {
-                scope.finish_cache_hit();
-            }
-            return response;
-        }
-
-        if detailed_metrics {
-            self.metrics
-                .cache_lookup_duration_seconds
-                .observe(cache_lookup_start.elapsed().as_secs_f64());
         }
 
         // Collapse concurrent identical GET/HEAD MISSes onto one upstream fill.
         let mut flight_permit: Option<MissFlightPermit> = None;
-        if self.perf.miss_coalesce_enabled && CACHEABLE_METHODS.contains(&method) {
+        if self.perf.miss_coalesce_enabled && CACHEABLE_METHODS.contains(&method) && !llm_mode {
             match self.miss_flights.join(&cache_key) {
                 CoalesceJoin::Follower(wait) => {
                     if let Some(cached) = wait.wait().await {
@@ -1508,19 +1642,24 @@ impl ProxyService {
         debug!("Cache MISS: {} {}", method, url);
         self.metrics.cache_misses_total.inc();
 
-        let (parts, body) = req.into_parts();
-        let body_bytes = match http_body_util::BodyExt::collect(body).await {
-            Ok(collected) => collected.to_bytes(),
-            Err(e) => {
-                error!("Body collection failed: {}", e);
-                if let Some(permit) = flight_permit.take() {
-                    permit.complete(None);
+        let (parts, body_bytes) = if let Some(early) = early_body.take() {
+            early
+        } else {
+            let (parts, body) = req.take().expect("request present").into_parts();
+            let body_bytes = match http_body_util::BodyExt::collect(body).await {
+                Ok(collected) => collected.to_bytes(),
+                Err(e) => {
+                    error!("Body collection failed: {}", e);
+                    if let Some(permit) = flight_permit.take() {
+                        permit.complete(None);
+                    }
+                    let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
+                    *resp.status_mut() = StatusCode::BAD_REQUEST;
+                    Self::finish_request_metrics(&mut guard, &mut fast_scope, 400, 0, 15);
+                    return resp;
                 }
-                let mut resp = Response::new(full(Bytes::from_static(b"400 Bad Request")));
-                *resp.status_mut() = StatusCode::BAD_REQUEST;
-                Self::finish_request_metrics(&mut guard, &mut fast_scope, 400, 0, 15);
-                return resp;
-            }
+            };
+            (parts, body_bytes)
         };
         let request_body_size = body_bytes.len();
         let req_for_peer = Request::from_parts(parts.clone(), full(body_bytes.clone()));
@@ -1529,9 +1668,12 @@ impl ProxyService {
         let domain = Self::extract_domain(&url);
         let upstream_start = Instant::now();
 
-        let peer_fetch = self
-            .try_fetch_via_hierarchy(method, &url, req_for_peer)
-            .await;
+        let peer_fetch = if llm_mode {
+            None
+        } else {
+            self.try_fetch_via_hierarchy(method, &url, req_for_peer)
+                .await
+        };
         let hierarchy_peer = peer_fetch.as_ref().map(|(peer, _)| peer.clone());
 
         let fetch_result = if let Some((_, response)) = peer_fetch {
@@ -1556,12 +1698,24 @@ impl ProxyService {
                     .observe(upstream_duration);
 
                 let headers_map = Self::headers_map_from_response(&response);
-                let store_precheck =
-                    evaluate_store_precheck(method, status_code, &headers_map, &self.cache_config);
+                let store_precheck = if llm_mode {
+                    evaluate_llm_store(
+                        status_code,
+                        0,
+                        self.cache_config.max_body_size,
+                        self.semantic_config.ttl,
+                    )
+                } else {
+                    evaluate_store_precheck(method, status_code, &headers_map, &self.cache_config)
+                };
 
                 if self.perf.streaming_miss_enabled {
                     let upstream_body = response.into_body();
-                    let x_cache = miss_x_cache_status_header(true, &store_precheck);
+                    let x_cache = if llm_mode && store_precheck.store {
+                        "LLM-MISS-STREAMING"
+                    } else {
+                        miss_x_cache_status_header(true, &store_precheck)
+                    };
                     if let Some(g) = guard.as_mut() {
                         g.set_cache_status(&cache_status_metric_label(x_cache));
                     }
@@ -1571,7 +1725,11 @@ impl ProxyService {
                         permit.disarm();
                     }
 
-                    let handle = self.miss_completion_handle();
+                    let handle = if llm_mode {
+                        self.miss_completion_handle_llm(llm_normalized.clone().unwrap_or_default())
+                    } else {
+                        self.miss_completion_handle()
+                    };
                     let cache_key_cb = cache_key.clone();
                     let url_cb = url.clone();
                     let method_cb = method.to_string();
@@ -1593,7 +1751,16 @@ impl ProxyService {
                         store_precheck.store,
                         self.cache_config.max_body_size,
                         move |body_bytes, stored| {
-                            let final_decision = if stored {
+                            let final_decision = if !stored {
+                                crate::cache_freshness::CacheStoreDecision::bypass()
+                            } else if handle.llm_mode {
+                                evaluate_llm_store(
+                                    status_code,
+                                    body_bytes.len(),
+                                    handle.cache_config.max_body_size,
+                                    handle.semantic_config.ttl,
+                                )
+                            } else {
                                 evaluate_store(
                                     &method_cb,
                                     status_code,
@@ -1601,8 +1768,6 @@ impl ProxyService {
                                     body_bytes.len(),
                                     &handle.cache_config,
                                 )
-                            } else {
-                                crate::cache_freshness::CacheStoreDecision::bypass()
                             };
                             handle.complete_cache_miss(
                                 cache_key_cb,
@@ -1667,40 +1832,79 @@ impl ProxyService {
                     permit.disarm();
                 }
 
-                let store_decision = evaluate_store(
-                    method,
-                    status_code,
-                    &headers_map,
-                    body_bytes.len(),
-                    &self.cache_config,
-                );
-                let _cache_status = self.complete_cache_miss(
-                    cache_key,
-                    &url,
-                    method,
-                    &domain,
-                    status_code,
-                    &headers_map,
-                    body_bytes.clone(),
-                    &store_decision,
-                    store_decision.store,
-                    user_id,
-                    username,
-                    user_agent,
-                    &client_ip,
-                    &categories,
-                    &threat_sources,
-                    request_start,
-                    request_body_size,
-                    hierarchy_peer,
-                    guard.take(),
-                    fast_scope.take(),
-                );
+                let store_decision = if llm_mode {
+                    evaluate_llm_store(
+                        status_code,
+                        body_bytes.len(),
+                        self.cache_config.max_body_size,
+                        self.semantic_config.ttl,
+                    )
+                } else {
+                    evaluate_store(
+                        method,
+                        status_code,
+                        &headers_map,
+                        body_bytes.len(),
+                        &self.cache_config,
+                    )
+                };
+                if llm_mode {
+                    self.miss_completion_handle_llm(llm_normalized.clone().unwrap_or_default())
+                        .complete_cache_miss(
+                            cache_key,
+                            &url,
+                            method,
+                            &domain,
+                            status_code,
+                            &headers_map,
+                            body_bytes.clone(),
+                            &store_decision,
+                            store_decision.store,
+                            user_id,
+                            username,
+                            user_agent,
+                            &client_ip,
+                            &categories,
+                            &threat_sources,
+                            request_start,
+                            request_body_size,
+                            hierarchy_peer,
+                            guard.take(),
+                            fast_scope.take(),
+                        );
+                } else {
+                    let _cache_status = self.complete_cache_miss(
+                        cache_key,
+                        &url,
+                        method,
+                        &domain,
+                        status_code,
+                        &headers_map,
+                        body_bytes.clone(),
+                        &store_decision,
+                        store_decision.store,
+                        user_id,
+                        username,
+                        user_agent,
+                        &client_ip,
+                        &categories,
+                        &threat_sources,
+                        request_start,
+                        request_body_size,
+                        hierarchy_peer,
+                        guard.take(),
+                        fast_scope.take(),
+                    );
+                }
 
                 let mut resp = Response::new(full(body_bytes));
                 *resp.status_mut() = status;
                 Self::apply_response_headers(&headers_map, &mut resp);
-                let header_label = miss_x_cache_status_header(false, &store_decision);
+                let header_label = if llm_mode && store_decision.store {
+                    "LLM-MISS"
+                } else {
+                    miss_x_cache_status_header(false, &store_decision)
+                };
                 Self::attach_x_cache_status(&mut resp, header_label);
                 resp
             }

--- a/proxy/src/semantic_cache.rs
+++ b/proxy/src/semantic_cache.rs
@@ -1,0 +1,377 @@
+//! LLM / semantic cache prep: content-addressable POST keys + optional local similarity index.
+//!
+//! Exact hits use a SHA-256 of method + URL + normalized JSON body.
+//! Near-hits (opt-in) use a local hashing embedding + cosine similarity — a stand-in until
+//! an external vector DB / embedding API is wired.
+
+use sha2::{Digest, Sha256};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tracing::info;
+
+/// Runtime config for LLM / semantic caching.
+#[derive(Debug, Clone)]
+pub struct SemanticCacheConfig {
+    pub enabled: bool,
+    /// URL path prefixes (matched against path of absolute URL or path-absolute form).
+    pub path_prefixes: Vec<String>,
+    pub ttl: Duration,
+    /// Cosine similarity threshold in `(0, 1]`. `1.0` disables near-hit lookup (exact only).
+    pub similarity_threshold: f32,
+    pub embed_dims: usize,
+    pub max_index_entries: usize,
+}
+
+impl Default for SemanticCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            path_prefixes: default_prefixes(),
+            ttl: Duration::from_secs(3600),
+            similarity_threshold: 1.0,
+            embed_dims: 64,
+            max_index_entries: 10_000,
+        }
+    }
+}
+
+fn default_prefixes() -> Vec<String> {
+    vec![
+        "/v1/chat/completions".to_string(),
+        "/v1/completions".to_string(),
+        "/chat/completions".to_string(),
+    ]
+}
+
+impl SemanticCacheConfig {
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("SEMANTIC_CACHE_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        let path_prefixes = std::env::var("SEMANTIC_CACHE_PATH_PREFIXES")
+            .ok()
+            .map(|s| {
+                s.split(',')
+                    .map(str::trim)
+                    .filter(|p| !p.is_empty())
+                    .map(|p| {
+                        if p.starts_with('/') {
+                            p.to_string()
+                        } else {
+                            format!("/{p}")
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(default_prefixes);
+
+        let ttl_secs = std::env::var("SEMANTIC_CACHE_TTL_SECONDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(3600u64)
+            .max(1);
+
+        let similarity_threshold = std::env::var("SEMANTIC_CACHE_SIMILARITY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(1.0f32)
+            .clamp(0.0, 1.0);
+
+        let embed_dims = std::env::var("SEMANTIC_CACHE_EMBED_DIMS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(64usize)
+            .clamp(8, 512);
+
+        let max_index_entries = std::env::var("SEMANTIC_CACHE_MAX_INDEX")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10_000usize)
+            .max(1);
+
+        let cfg = Self {
+            enabled,
+            path_prefixes,
+            ttl: Duration::from_secs(ttl_secs),
+            similarity_threshold,
+            embed_dims,
+            max_index_entries,
+        };
+        if cfg.enabled {
+            info!(
+                "Semantic/LLM cache enabled (prefixes={:?}, ttl={}s, similarity={})",
+                cfg.path_prefixes, ttl_secs, cfg.similarity_threshold
+            );
+        }
+        cfg
+    }
+
+    pub fn applies(&self, method: &str, url: &str) -> bool {
+        self.enabled
+            && method.eq_ignore_ascii_case("POST")
+            && path_matches(url, &self.path_prefixes)
+    }
+
+    pub fn near_hit_enabled(&self) -> bool {
+        self.similarity_threshold < 1.0
+    }
+}
+
+/// Match URL path against configured prefixes.
+pub fn path_matches(url: &str, prefixes: &[String]) -> bool {
+    let path = url_path(url);
+    prefixes
+        .iter()
+        .any(|p| path == p.as_str() || path.starts_with(&format!("{p}/")))
+}
+
+fn url_path(url: &str) -> &str {
+    if let Some(rest) = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+    {
+        let path = rest.find('/').map(|i| &rest[i..]).unwrap_or("/");
+        path.split('?').next().unwrap_or(path)
+    } else {
+        url.split('?').next().unwrap_or(url)
+    }
+}
+
+/// Normalize LLM JSON body for stable exact-match keys (model + messages/prompt).
+pub fn normalize_llm_body(body: &[u8]) -> Vec<u8> {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return body.to_vec();
+    };
+    let Some(obj) = value.as_object() else {
+        return body.to_vec();
+    };
+
+    let mut out = serde_json::Map::new();
+    if let Some(model) = obj.get("model") {
+        out.insert("model".into(), model.clone());
+    }
+    if let Some(messages) = obj.get("messages") {
+        out.insert("messages".into(), messages.clone());
+    } else if let Some(prompt) = obj.get("prompt") {
+        out.insert("prompt".into(), prompt.clone());
+    } else {
+        // Unknown shape — hash full body as-is.
+        return body.to_vec();
+    }
+    // Intentionally omit temperature/stream/user for higher hit rate on identical prompts.
+    serde_json::to_vec(&serde_json::Value::Object(out)).unwrap_or_else(|_| body.to_vec())
+}
+
+/// Content-addressable cache key for LLM POST.
+pub fn content_cache_key(method: &str, url: &str, normalized_body: &[u8]) -> Arc<str> {
+    let mut hasher = Sha256::new();
+    hasher.update(method.as_bytes());
+    hasher.update(b":");
+    hasher.update(url.as_bytes());
+    hasher.update(b":");
+    hasher.update(normalized_body);
+    hex::encode(hasher.finalize()).into()
+}
+
+/// Flatten message / prompt text for local embedding.
+pub fn extract_embed_text(body: &[u8]) -> String {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return String::from_utf8_lossy(body).into_owned();
+    };
+    let mut parts = Vec::new();
+    if let Some(model) = value.get("model").and_then(|v| v.as_str()) {
+        parts.push(model.to_string());
+    }
+    if let Some(messages) = value.get("messages").and_then(|v| v.as_array()) {
+        for msg in messages {
+            if let Some(content) = msg.get("content") {
+                match content {
+                    serde_json::Value::String(s) => parts.push(s.clone()),
+                    other => parts.push(other.to_string()),
+                }
+            }
+        }
+    } else if let Some(prompt) = value.get("prompt") {
+        match prompt {
+            serde_json::Value::String(s) => parts.push(s.clone()),
+            other => parts.push(other.to_string()),
+        }
+    }
+    if parts.is_empty() {
+        String::from_utf8_lossy(body).into_owned()
+    } else {
+        parts.join("\n")
+    }
+}
+
+/// Feature-hashing embedding (local PoC; replace with real embeddings later).
+pub fn hash_embed(text: &str, dims: usize) -> Vec<f32> {
+    let dims = dims.max(1);
+    let mut vec = vec![0.0f32; dims];
+    for token in text
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+    {
+        let mut hasher = Sha256::new();
+        hasher.update(token.to_ascii_lowercase().as_bytes());
+        let digest = hasher.finalize();
+        let idx = u32::from_le_bytes([digest[0], digest[1], digest[2], digest[3]]) as usize % dims;
+        let sign = if digest[4] & 1 == 0 { 1.0 } else { -1.0 };
+        vec[idx] += sign;
+    }
+    let norm = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut vec {
+            *x /= norm;
+        }
+    }
+    vec
+}
+
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+    }
+    dot.clamp(-1.0, 1.0)
+}
+
+struct IndexEntry {
+    embedding: Vec<f32>,
+    cache_key: Arc<str>,
+}
+
+/// In-memory similarity index (prep for external vector DB).
+#[derive(Clone, Default)]
+pub struct SemanticIndex {
+    inner: Arc<Mutex<VecDeque<IndexEntry>>>,
+    max_entries: usize,
+}
+
+impl SemanticIndex {
+    pub fn new(max_entries: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+            max_entries: max_entries.max(1),
+        }
+    }
+
+    pub fn insert(&self, embedding: Vec<f32>, cache_key: Arc<str>) {
+        let mut guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        guard.retain(|e| e.cache_key != cache_key);
+        guard.push_back(IndexEntry {
+            embedding,
+            cache_key,
+        });
+        while guard.len() > self.max_entries {
+            guard.pop_front();
+        }
+    }
+
+    pub fn find_similar(&self, embedding: &[f32], threshold: f32) -> Option<Arc<str>> {
+        let guard = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut best: Option<(f32, Arc<str>)> = None;
+        for entry in guard.iter() {
+            let score = cosine_similarity(embedding, &entry.embedding);
+            if score >= threshold && best.as_ref().map(|(s, _)| score > *s).unwrap_or(true) {
+                best = Some((score, entry.cache_key.clone()));
+            }
+        }
+        best.map(|(_, k)| k)
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+}
+
+/// Store decision for LLM responses (ignores typical no-store/private from API providers).
+pub fn evaluate_llm_store(
+    status: u16,
+    body_size: usize,
+    max_body_size: usize,
+    ttl: Duration,
+) -> crate::cache_freshness::CacheStoreDecision {
+    use crate::cache_freshness::CacheStoreDecision;
+    if status != 200 || body_size == 0 || body_size > max_body_size {
+        return CacheStoreDecision::bypass();
+    }
+    CacheStoreDecision {
+        store: true,
+        ttl,
+        is_negative: false,
+        must_revalidate: false,
+        etag: None,
+        last_modified: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_prefix_matching() {
+        let prefixes = default_prefixes();
+        assert!(path_matches(
+            "https://api.openai.com/v1/chat/completions",
+            &prefixes
+        ));
+        assert!(path_matches("/v1/completions", &prefixes));
+        assert!(!path_matches("https://api.openai.com/v1/models", &prefixes));
+    }
+
+    #[test]
+    fn normalize_keeps_model_and_messages() {
+        let body =
+            br#"{"model":"gpt","messages":[{"role":"user","content":"hi"}],"temperature":0.9}"#;
+        let norm = normalize_llm_body(body);
+        let v: serde_json::Value = serde_json::from_slice(&norm).unwrap();
+        assert_eq!(v["model"], "gpt");
+        assert!(v.get("temperature").is_none());
+        assert_eq!(v["messages"][0]["content"], "hi");
+    }
+
+    #[test]
+    fn content_key_stable() {
+        let body = br#"{"model":"m","messages":[{"role":"user","content":"x"}]}"#;
+        let n = normalize_llm_body(body);
+        let a = content_cache_key("POST", "https://x/v1/chat/completions", &n);
+        let b = content_cache_key("POST", "https://x/v1/chat/completions", &n);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn similar_texts_score_high() {
+        let a = hash_embed("hello world from the llm cache", 64);
+        let b = hash_embed("hello world from the llm cache!", 64);
+        assert!(cosine_similarity(&a, &b) > 0.5);
+    }
+
+    #[test]
+    fn index_finds_near_neighbor() {
+        let idx = SemanticIndex::new(10);
+        let emb = hash_embed("the quick brown fox", 32);
+        idx.insert(emb.clone(), Arc::from("key-1"));
+        let hit = idx.find_similar(&emb, 0.99);
+        assert_eq!(hit.as_deref(), Some("key-1"));
+        assert_eq!(idx.len(), 1);
+    }
+
+    #[test]
+    fn applies_only_to_post_prefixes() {
+        let cfg = SemanticCacheConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        assert!(cfg.applies("POST", "https://h/v1/chat/completions"));
+        assert!(!cfg.applies("GET", "https://h/v1/chat/completions"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 semantic cache preparation for LLM API proxy traffic.

- `SEMANTIC_CACHE_ENABLED` — cache `POST` to chat/completions path prefixes
- Exact hit: SHA-256 of method + URL + normalized JSON (`model` + `messages`/`prompt`)
- Optional near-hit: local feature-hash embedding + cosine (`SEMANTIC_CACHE_SIMILARITY < 1`)
- Store ignores typical provider `Cache-Control: no-store` / `private` for LLM `200`s
- Headers: `LLM-HIT` / `SEMANTIC-HIT` / `LLM-MISS`
- Metrics: `bsdm_proxy_semantic_cache_exact_hits_total`, `…_similar_hits_total`
- Docs: [docs/semantic-cache.md](docs/semantic-cache.md)

## Связанные issue

- Milestone: strategic Phase 4 (semantic cache prep)

## Testing

```bash
cargo test -p bsdm-proxy --lib semantic_cache
cargo clippy -p bsdm-proxy --all-targets -- -D warnings
cargo fmt -p bsdm-proxy -- --check
```

## Checklist

- [x] CI зелёный
- [x] Документация обновлена
- [x] `docs/roadmap.md` / strategic-roadmap updated

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

