### PR TITLE
docs: refresh project documentation for M1–M5 and DX/AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Running and testing:
   `./certs/ca.key` and `./certs/ca.crt`. These are git-ignored and NOT in the repo, so
   generate them first (`./scripts/gen-ca.sh` or "Быстрый старт" in `README.md`), otherwise MITM startup fails.
   For plain forward-proxy testing you can set `MITM_ENABLED=false` and skip the certs.
-  Standalone caching node (no Kafka/CH): `./scripts/gen-ca.sh && docker compose -f docker-compose.lite.yml up -d --build` (see `docs/lite.md`).
+  Lite node (proxy + SQLite indexer, no Kafka/CH): `./scripts/gen-ca.sh && docker compose -f docker-compose.lite.yml up -d --build` (see `docs/lite.md`).
 - Run locally: `HTTP_PORT=1488 METRICS_PORT=9090 cargo run -p bsdm-proxy --bin proxy`
   (or the built `./target/debug/proxy`). Verify with `curl http://127.0.0.1:9090/health`
   and `curl -x http://127.0.0.1:1488 http://httpbin.org/get`. HTTPS through MITM:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Project docs refresh** — README / architecture / development / structure / docker / deployment / wiki index / env.example aligned with M1–M5 done and DX/AI Unreleased (Lite = proxy+SQLite, control plane, event sink, hierarchy peers paths, threat-score vars)
+
 ### Added
 
 - **AI semantic / LLM cache prep** — `SEMANTIC_CACHE_ENABLED` POST body-hash cache for chat/completions paths; optional local cosine near-hit; docs [semantic-cache.md](docs/semantic-cache.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
 [![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org)
 
-> **Текущая версия:** `0.5.0` · M2.5/M3/M4 done · M5 ML next — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
+> **Текущая версия:** `0.5.0` · M1–M5 done · DX/AI prep in Unreleased — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
 
 ⚠️ **MITM-прокси для HTTPS.** Используйте только в корпоративной среде с согласия пользователей и в рамках законодательства.
 
@@ -18,12 +18,12 @@
 
 | Область | Возможности |
 |---------|-------------|
-| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (443/8443), HTTP CONNECT, **tiered L1** (inline + mmap spill, шарды), **streaming MISS**, Redis L2, **иерархический кеш** (ICP/HTCP), HTTP/2 upstream (опц.) |
-| **Безопасность** | Proxy-auth (Basic / LDAP / NTLM / Kerberos), **connection-level auth cache**, ACL + REST API, **policy decision cache**, категоризация URL, rate limiting |
-| **Производительность** | Multi-worker accept (`WORKER_COUNT`), perf fast path (`PERF_FAST_CACHE_HIT`), HTTP Archive bench profiles (`BENCH_PROFILE=warm\|cold`) |
-| **Наблюдаемость** | Prometheus (proxy + cache-indexer), Grafana (Prometheus + ClickHouse), `/health`, `/ready`, `/metrics` |
-| **Аналитика** | Kafka → cache-indexer → **ClickHouse** (`bsdm.http_cache`); Grafana **HTTP Traffic**; REST **Search API** (`/api/search`); optional **ml-worker** features/scores (M5) |
-| **Эксплуатация** | Graceful shutdown, Helm chart `charts/bsdm/`, release-пакет + systemd |
+| **Прокси** | HTTP/HTTPS forward proxy, MITM TLS (443/8443), HTTP CONNECT, **tiered L1** (inline + mmap spill, шарды), **streaming MISS**, Redis L2, **иерархический кеш** (ICP/HTCP), HTTP/2 upstream (опц.), **LLM/semantic POST cache** |
+| **Безопасность** | Proxy-auth (Basic / LDAP / NTLM / Kerberos), **connection-level auth cache**, ACL + REST API, **policy decision cache**, категоризация URL, rate limiting (IP / user / **API key**), M5 threat-score write-back (опц.) |
+| **Производительность** | Multi-worker accept (`WORKER_COUNT`), perf fast path (`PERF_FAST_CACHE_HIT`), **miss coalescing** (`MISS_COALESCE_ENABLED`), HTTP Archive bench profiles (`BENCH_PROFILE=warm\|cold`) |
+| **Наблюдаемость** | Prometheus (proxy + cache-indexer), Grafana (Prometheus + ClickHouse), `/health`, `/ready`, `/metrics`, **control plane** на `:9090` |
+| **Аналитика** | Kafka → cache-indexer → **ClickHouse** (или Lite: HTTP → SQLite); Grafana **HTTP Traffic**; REST **Search API**; **ml-worker** UEBA / phishing / C&C / threat scores (M5) |
+| **Эксплуатация** | Graceful shutdown, DX hot reload (ACL / hierarchy / upstream TLS), cache purge (URL/tag/all), Helm chart `charts/bsdm/`, release-пакет + systemd, Cargo feature `kafka` (Lite: `--no-default-features`) |
 
 ## Архитектура
 
@@ -60,9 +60,10 @@
 |-----------|------|----------|
 | **proxy** | 1488 | HTTPS-прокси, MITM, кеш L1, иерархия (опционально) |
 | **ICP** | 3130 | UDP-запросы между cache peers (при `HIERARCHY_ENABLED=true`) |
-| **metrics** | 9090 | `/health`, `/ready`, `/metrics` |
-| **cache-indexer** | 8080 | Kafka → ClickHouse, `/api/search` |
-| **ml-worker** | 8091 | M5: entity features + scores (compose profile `ml`) |
+| **metrics** | 9090 | `/health`, `/ready`, `/metrics` + [control plane](docs/control-plane.md) (`/api/stats`, purge, hierarchy, TLS) |
+| **cache-indexer** | 8080 | Kafka → ClickHouse (или Lite SQLite + `POST /api/events`), `/api/search` |
+| **ml-worker** | 8091 | M5: features/scores + threat-score API (compose profile `ml`) |
+| **admin-console** | — | Unified UI (dashboard, logs, policies); см. [admin-console/](admin-console/) |
 | **Kafka** | 9092 | Очередь событий кеша |
 | **ClickHouse** | 8123 / 9000 | Аналитика HTTP-трафика |
 | **Prometheus** | 9091 | Сбор метрик |
@@ -70,14 +71,17 @@
 
 ## Быстрый старт (Docker)
 
-### Lite — только прокси (без Kafka / ClickHouse)
+### Lite — proxy + SQLite Search API (без Kafka / ClickHouse)
 
 ```bash
 ./scripts/gen-ca.sh
 docker compose -f docker-compose.lite.yml up -d --build
 curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
 curl http://127.0.0.1:9090/health
+curl 'http://127.0.0.1:8080/api/search?domain=httpbin.org&limit=5'
 ```
+
+Стек: `proxy` (:1488) + `cache-indexer` SQLite (:8080, `EVENT_SINK_URL`). Сборка без `rdkafka`: `--no-default-features` / `LITE_BUILD=1`.
 
 Подробнее: [docs/lite.md](docs/lite.md) · Strategic Phase 1: [docs/strategic-roadmap.md](docs/strategic-roadmap.md)
 
@@ -143,7 +147,7 @@ Grafana: http://localhost:3000 → **BSDM HTTP Traffic (ClickHouse)** и **BSDM 
 
 | Файл | Назначение |
 |------|------------|
-| [docker-compose.lite.yml](docker-compose.lite.yml) | **Lite:** один proxy (MITM + L1), без analytics |
+| [docker-compose.lite.yml](docker-compose.lite.yml) | **Lite:** proxy + SQLite indexer (без Kafka/CH) |
 | [docker-compose.yml](docker-compose.yml) | Полный стек: proxy, Kafka, ClickHouse, cache-indexer, Prometheus, Grafana |
 | [docker-compose.test.yml](docker-compose.test.yml) | Минимальный стек для smoke/E2E |
 | [docker-compose.redis-l2.yml](docker-compose.redis-l2.yml) | Два proxy + Redis L2 |
@@ -190,7 +194,9 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `HTTP_PORT` | `1488` | Порт прокси |
 | `METRICS_PORT` | `9090` | Порт health/metrics |
 | `MITM_ENABLED` | `true` | MITM для портов 443 и 8443 |
-| `KAFKA_BROKERS` | — | Kafka (опционально) |
+| `KAFKA_BROKERS` | — | Kafka (опционально; без брокеров — Lite HTTP sink или no-op) |
+| `EVENT_SINK_URL` | — | Lite: `POST` JSON events (напр. `http://indexer:8080/api/events`) |
+| `EVENT_SINK_TOKEN` | — | Bearer для event sink (опционально) |
 | `CACHE_CAPACITY` | `10000` | Размер L1-кеша (на шард) |
 | `CACHE_SHARDS` | `16` | Число шардов L1 (`quick_cache` на шард) |
 | `CACHE_SPILL_THRESHOLD_BYTES` | `262144` | Тела ≥ порога — в mmap spill (`0` = только inline) |
@@ -201,6 +207,8 @@ cargo build --release -p bsdm-proxy --bin proxy -p cache-indexer --bin cache-ind
 | `SEMANTIC_CACHE_PATH_PREFIXES` | `/v1/chat/completions,…` | Path prefixes for LLM POST caching |
 | `SEMANTIC_CACHE_TTL_SECONDS` | `3600` | TTL for LLM cached responses |
 | `SEMANTIC_CACHE_SIMILARITY` | `1.0` | Cosine threshold; `<1` enables near-hit |
+| `SEMANTIC_CACHE_EMBED_DIMS` | `64` | Размерность local hash embedding |
+| `SEMANTIC_CACHE_MAX_INDEX` | `10000` | Макс. записей similarity index |
 | `CACHE_TTL_SECONDS` | `3600` | Fallback TTL кеша (сек), если нет `max-age` |
 | `MAX_CACHE_BODY_SIZE` | `10485760` | Макс. размер body (байт) |
 | `NEGATIVE_CACHE_ENABLED` | `true` | Кешировать upstream 403/404 |
@@ -251,9 +259,25 @@ CA для MITM читается из `/certs/ca.key` и `/certs/ca.crt` (fallbac
 
 → [docs/acl.md](docs/acl.md) · [docs/categorization.md](docs/categorization.md)
 
+### Control plane (metrics port)
+
+REST на `:9090` (см. [docs/control-plane.md](docs/control-plane.md)):
+
+| Endpoint | Auth |
+|----------|------|
+| `GET /api/stats` | публичный |
+| `POST /api/cache/purge` | Bearer при токене |
+| `GET/POST /api/hierarchy/*` | GET публичный; reload — Bearer |
+| `GET/POST /api/upstream/tls*` | GET публичный; reload — Bearer |
+| `/api/acl/*` | при `ACL_ENABLED` |
+
+| Переменная | Описание |
+|-----------|----------|
+| `CONTROL_API_TOKEN` | Bearer для mutating control APIs (fallback: `ACL_API_TOKEN`) |
+
 ### Rate limiting (опционально)
 
-Token-bucket лимиты на IP и аутентифицированного пользователя. Метрика: `bsdm_proxy_rate_limit_rejected_total{limit_type="ip|user"}`.
+Token-bucket лимиты на IP, пользователя и **API key**. Метрика: `bsdm_proxy_rate_limit_rejected_total{limit_type="ip\|user\|api_key\|api_key_missing"}`.
 
 | Переменная | По умолчанию | Описание |
 |-----------|-------------|----------|
@@ -305,6 +329,8 @@ Token-bucket лимиты на IP и аутентифицированного п
 | `HIERARCHY_ENABLED` | `false` | Включить иерархию |
 | `CACHE_PARENTS` | — | Parent peers: `host:port[:weight]` |
 | `CACHE_SIBLINGS` | — | Sibling peers: `host:port[:weight][:icp_port]` |
+| `CACHE_PEERS_PATH` | — | JSON peers file (overrides env); hot reload: `POST /api/hierarchy/reload` |
+| `HIERARCHY_PEERS_PATH` | — | Alias for `CACHE_PEERS_PATH` |
 | `CACHE_SELECTION_STRATEGY` | `round-robin` | `round-robin`, `weighted`, `closest`, `hash` |
 | `ICP_BIND` | `0.0.0.0:3130` | Адрес ICP-сервера (UDP) |
 | `ICP_CLIENT_BIND` | `0.0.0.0:0` | Bind для ICP-клиента |
@@ -314,7 +340,20 @@ Token-bucket лимиты на IP и аутентифицированного п
 | `PARENT_TIMEOUT_SECONDS` | `5` | Таймаут HTTP-запроса к peer |
 | `ICP_MAX_SIBLING_QUERIES` | `10` | Макс. параллельных ICP-запросов |
 
-→ [docs/hierarchical-caching.md](docs/hierarchical-caching.md)
+→ [docs/hierarchical-caching.md](docs/hierarchical-caching.md) · [docs/control-plane.md](docs/control-plane.md)
+
+### Threat score write-back (M5.5, опционально)
+
+Опциональный poll snapshot’ов из `ml-worker` для O(1) enrichment / block. Подробно: [docs/ml-security.md](docs/ml-security.md).
+
+| Переменная | По умолчанию | Описание |
+|-----------|-------------|----------|
+| `THREAT_SCORE_ENABLED` | `false` | Включить poll + lookup |
+| `THREAT_SCORE_POLL_URL` | `http://127.0.0.1:8091/api/threat-scores` | Snapshot URL |
+| `THREAT_SCORE_POLL_INTERVAL_SECS` | `60` | Интервал poll |
+| `THREAT_SCORE_CACHE_TTL_SECS` | `300` | TTL локального snapshot |
+| `THREAT_SCORE_WARN_THRESHOLD` | `0.7` | Порог warn enrichment |
+| `THREAT_SCORE_BLOCK_THRESHOLD` | `0` | `0` = не блокировать по score |
 
 ### Performance tuning (опционально)
 
@@ -414,7 +453,7 @@ Grafana: http://localhost:3000 → **BSDM Proxy Dashboard** (Prometheus) и **BS
 Перед push: `./scripts/pre-push-check.sh` (или `./scripts/install-git-hooks.sh` для auto hook).
 
 ```bash
-# Unit + integration + smoke + e2e (75 тестов)
+# Unit + integration + smoke + e2e (~250 tests)
 cargo test --workspace --all-targets
 
 # Smoke (health, metrics, HTTP forward)
@@ -444,7 +483,10 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 | [docs/README.md](docs/README.md) | **Оглавление wiki** |
 | [docs/deployment.md](docs/deployment.md) | Развёртывание: Docker, native, k8s |
 | [docs/docker.md](docs/docker.md) | Docker Compose, сборка образов, troubleshooting |
-| [docs/lite.md](docs/lite.md) | Lite: standalone proxy compose |
+| [docs/lite.md](docs/lite.md) | Lite: proxy + SQLite Search API |
+| [docs/control-plane.md](docs/control-plane.md) | DX: stats, purge, hierarchy/TLS reload, ACL CRUD |
+| [docs/semantic-cache.md](docs/semantic-cache.md) | LLM POST cache + local similarity prep |
+| [docs/ml-security.md](docs/ml-security.md) | M5 ml-worker, threat scores, feature store |
 | [docs/kubernetes.md](docs/kubernetes.md) | Kubernetes: манифесты, probes, Helm chart |
 | [docs/k8s-architecture.md](docs/k8s-architecture.md) | Kubernetes / HA deployment |
 | [docs/development.md](docs/development.md) | Сборка, тесты, CI |
@@ -488,20 +530,20 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 | **M2.5** Data plane | v0.3.1–0.3.2 | Tiered L1, streaming MISS, P1 hot path | ✅ Done |
 | **M3** Retro-search | v0.3.1+ | ClickHouse, Grafana, Search API, k8s CHI | ✅ Done |
 | **M4** Threat analytics | v0.5.x | Rule-based алерты, C&C / Shannon, Grafana/AM | ✅ Done |
-| **M5** ML security | v1.0.x | ML anomaly, phishing, C&C detection | ~0% |
+| **M5** ML security | Unreleased / 0.5.x+ | UEBA, phishing lexical, C&C beacon, threat-score write-back | ✅ Done |
 
-Кратко: **M3/M4 closed** (ClickHouse retro-search + threat analytics / Grafana Alerting). **M5** — ML anomaly / phishing / C&C.
+Кратко: **M1–M5 closed**. Unreleased: DX control plane + hot reload, Lite `kafka` feature, AI coalescing / API-key RL / LLM cache prep. Next: Wasm, gRPC control plane, external vector DB.
 
 ### Стратегические фазы
 
 Вектор рыночной ценности и удобства (детально — [strategic-roadmap.md](docs/strategic-roadmap.md)):
 
-| Фаза | Фокус |
-|------|--------|
-| **1. Lite** | Прокси без обязательных Kafka/ClickHouse; SQLite Search API; `docker-compose.lite.yml` ([docs/lite.md](docs/lite.md)) |
-| **2. DX** | Control Plane API, hot reload, cache purge, lite metrics без Grafana |
-| **3. Wasm** | Wasmtime-плагины, SDK, модульность ядра |
-| **4. AI-трафик** | Token-bucket RL, semantic cache для LLM, request coalescing |
+| Фаза | Фокус | Статус |
+|------|--------|--------|
+| **1. Lite** | Proxy + SQLite Search API без Kafka/CH; `kafka` Cargo feature | ✅ |
+| **2. DX** | REST control plane, hot reload (ACL/hierarchy/TLS), purge, `/api/stats` | ✅ REST; gRPC — later |
+| **3. Wasm** | Wasmtime-плагины, SDK, модульность ядра | TBD |
+| **4. AI-трафик** | Coalescing, API-key RL, LLM/semantic cache prep | ✅ prep; external vector DB — later |
 
 Порядок по умолчанию: Lite → DX → Wasm / AI.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Центральное оглавление. Страницы wiki — в каталоге `docs/`.
 
-**Текущая версия:** 0.5.0 · Analytics: Kafka → ClickHouse · [roadmap](roadmap.md)
+**Текущая версия:** 0.5.0 · M1–M5 done · Unreleased: DX/AI · Analytics: Kafka → ClickHouse (или Lite: HTTP → SQLite) · [roadmap](roadmap.md)
 
 ## Начало работы
 
@@ -33,7 +33,7 @@
 | [performance.md](performance.md) | Тюнинг RPS, bench |
 | [semantic-cache.md](semantic-cache.md) | LLM / semantic cache prep |
 | [acl.md](acl.md) | ACL + REST API |
-| [control-plane.md](control-plane.md) | DX Phase 2: stats, cache purge, ACL CRUD |
+| [control-plane.md](control-plane.md) | DX: stats, purge, hierarchy/TLS reload, ACL CRUD |
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |
@@ -41,6 +41,8 @@
 | [ml-security.md](ml-security.md) | ML worker + feature store (M5) |
 | [adr/0003-ml-worker-feature-store.md](adr/0003-ml-worker-feature-store.md) | ADR: CH feature store |
 | [search-api.md](search-api.md) | REST Search API |
+| [benchmarks-httparchive.md](benchmarks-httparchive.md) | HTTP Archive CDN URL workload |
+| [../admin-console/README.md](../admin-console/README.md) | Admin Console (Vite UI) |
 
 ## Архитектура и roadmap
 
@@ -50,7 +52,7 @@
 | [BLOCKERS.md](BLOCKERS.md) | Реестр блокеров B1–B25 |
 | [roadmap.md](roadmap.md) | Milestones Squid + ретропоиск + ML (M1–M5) |
 | [strategic-roadmap.md](strategic-roadmap.md) | Стратегия: Lite, DX, Wasm, AI-трафик |
-| [lite.md](lite.md) | Lite mode: `docker-compose.lite.yml` |
+| [lite.md](lite.md) | Lite: proxy + SQLite (`docker-compose.lite.yml`) |
 | [swg-backlog-mapping.md](swg-backlog-mapping.md) | Mapping vs SWG vendors |
 | [adr/0001-tiered-sharded-l1-cache.md](adr/0001-tiered-sharded-l1-cache.md) | ADR tiered L1 |
 | [adr/0002-clickhouse-analytics.md](adr/0002-clickhouse-analytics.md) | ADR ClickHouse |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,8 +67,10 @@ flowchart TB
 | Policy library | `proxy/src/lib.rs` — `acl`, `auth`, `categorization` | ✅ |
 | MITM | `proxy/src/tls.rs` | ✅ |
 | Hierarchy / ICP | `hierarchy.rs`, `peer_fetch.rs`, `icp.rs`, `hierarchy_config.rs` | ✅ opt-in (`HIERARCHY_ENABLED`) |
-| Event indexer | `cache-indexer/src/main.rs` | ✅ |
-| ML / analytics worker | `ml-worker` (:8091) | ✅ M5.5 write-back + M5.4 beacon + phishing + UEBA |
+| Event indexer | `cache-indexer` | ✅ Kafka→CH or Lite HTTP→SQLite |
+| Control plane | `control_api.rs` (:9090) | ✅ stats / purge / hierarchy / TLS |
+| ML / analytics worker | `ml-worker` (:8091) | ✅ M5.1–M5.5 (UEBA / phishing / C&C / write-back) |
+| Admin UI | `admin-console/` | ✅ React SPA |
 
 ---
 
@@ -79,28 +81,33 @@ TCP accept
   → HTTP/1.1 parse
   → CONNECT? → [MITM TLS | raw tunnel]
   → authenticate_proxy()          # Proxy-Authorization
+  → rate_limit (IP / user / API key)
   → check_policy()
        → categorization.categorize()   # UT1 Blacklists / OTX / custom
        → acl_engine.check_access()     # ArcSwap snapshot (lock-free read)
        → threat_score_cache.lookup()   # M5.5 opt-in O(1) ML score (async poll)
-  → L1 cache lookup (GET/HEAD)
+  → [optional] LLM exact / semantic near-hit (POST chat/completions)
+  → L1 cache lookup (GET/HEAD) → Redis L2 (opt)
+  → [if miss coalesce] singleflight waiters → COALESCED-HIT
   → [if HIERARCHY_ENABLED] resolve_source()
        → ICP query siblings (parallel UDP)
        → select parent (round-robin / weighted / closest / hash)
        → fetch_via_peer() on SiblingHit / ParentHit
   → upstream HTTP request (origin fallback)
   → cache insert + response
-  → send_to_kafka_async()         # fire-and-forget
+  → emit event (Kafka | EVENT_SINK_URL HTTP | noop)
 ```
 
 **Ключевые файлы:**
 
 | Этап | Файл | Функция |
 |------|------|---------|
-| Entry | `main.rs` | `handle_connection`, `handle_request` |
+| Entry | `main.rs`, `proxy_service.rs` | `handle_connection`, `handle_request` |
 | Auth | `auth.rs` | `AuthManager::authenticate` |
-| Policy | `main.rs` | `ProxyService::check_policy` |
-| Cache | `main.rs`, `cache_key.rs` | `http_cache`, `http_cache_key` |
+| Policy | `proxy_service.rs` | `ProxyService::check_policy` |
+| LLM cache | `semantic_cache.rs` | exact body-hash + optional near-hit |
+| Coalesce | `miss_coalesce.rs` | singleflight MISS |
+| Cache | `proxy_service.rs`, `cache_key.rs` | `http_cache`, `http_cache_key` |
 | Hierarchy | `hierarchy.rs`, `hierarchy_config.rs` | `resolve_source`, env loading |
 | Peer fetch | `peer_fetch.rs` | `fetch_via_peer` |
 | ICP | `icp.rs`, `main.rs` | `IcpServer::serve`, `IcpClient::query_peers` |
@@ -122,8 +129,9 @@ TCP accept
 ```
 CacheEvent (proxy_service / pipeline)
   → Kafka topic cache-events (env KAFKA_*, bounded queue)
-  → cache-indexer consumer
-  → ClickHouse INSERT `bsdm.http_cache` (JSONEachRow)
+     OR POST EVENT_SINK_URL (Lite)
+  → cache-indexer (Kafka consumer | /api/events)
+  → ClickHouse INSERT `bsdm.http_cache`  OR  SQLite / memory
 ```
 
 ```mermaid
@@ -152,21 +160,21 @@ sequenceDiagram
 ```
 proxy/
 ├── src/
-│   ├── main.rs          ← монолит: ProxyService, cache, Kafka, HTTP server, ICP spawn
-│   ├── lib.rs           ← acl, auth, categorization, hierarchy, icp, peers, selection
-│   ├── hierarchy.rs     ← resolve_source, sibling ICP, parent selection
-│   ├── hierarchy_config.rs ← env: HIERARCHY_ENABLED, CACHE_PARENTS, …
-│   ├── peer_fetch.rs    ← HTTP forward-proxy к parent/sibling
-│   ├── cache_key.rs     ← shared cache key (proxy + ICP handler)
-│   ├── peers.rs         ← peer registry, health, stats
-│   ├── icp.rs           ← ICP v2 UDP client/server
-│   ├── selection.rs     ← round-robin, weighted, closest, hash
-│   ├── tls.rs           ← MITM cert cache
-│   ├── metrics.rs       ← Prometheus
-│   ├── policy_config.rs ← env loading
-│   └── auth_config.rs
+│   ├── main.rs          ← startup, listeners, ICP/HTCP/discovery spawn
+│   ├── proxy_service.rs ← request path: auth → RL → policy → L1/L2 → coalesce/semantic → upstream
+│   ├── control_api.rs   ← DX REST: /api/stats, purge, hierarchy, upstream TLS
+│   ├── miss_coalesce.rs ← singleflight GET/HEAD MISS
+│   ├── semantic_cache.rs← LLM POST body-hash + local similarity index
+│   ├── threat_score_cache.rs ← M5.5 async poll + O(1) lookup
+│   ├── tag_index.rs     ← Cache-Tag / Surrogate-Key purge index
+│   ├── hierarchy.rs / hierarchy_config.rs / peer_fetch.rs / peers.rs / icp.rs / htcp.rs
+│   ├── cache_key.rs, tls.rs, metrics.rs, rate_limit.rs, upstream.rs
+│   └── lib.rs           ← module re-exports
 cache-indexer/
-└── src/main.rs          ← Kafka → ClickHouse
+└── src/                 ← Kafka|HTTP events → ClickHouse|SQLite|memory + Search API
+ml-worker/               ← M5 feature store + scores + threat-score API
+alert-worker/            ← M4 webhook alerts
+admin-console/           ← React admin UI
 e2e/                     ← smoke + E2E harness
 ```
 
@@ -245,7 +253,8 @@ M1  ██████████████  B1–B6 ✅
 M2  ██████████████  B7–B9 B13–B14 B21–B25 ✅
 M3  █████████████░  B10–B12 B17 ✅ · B20 ✅
 M4  ██████████████  B16 ✅ · B18 ✅ · B19 ✅ · B20 ✅
-M5  ██░░░░░░░░░░░░  B15 scaffold ✅ · models M5.2+```
+M5  ██████████████  B15 ✅ · M5.1–M5.5 (UEBA / phishing / C&C / write-back)
+```
 
 ---
 
@@ -258,7 +267,7 @@ Critical/high блокеры B1–B14, B17, B22–B26 — **закрыты**. An
 ### Волна 3 — M4/M5 foundation
 
 1. ~~**B16** — rich event schema~~ ✅ (`session_id`, `acl_action`, `threat_sources`)
-2. ~~**B15** — analytics / ML worker scaffold~~ ✅ (`ml-worker`, ADR 0003); trained models still open
+2. ~~**B15** — analytics / ML worker~~ ✅ (`ml-worker`, ADR 0003; M5.1–M5.5)
 3. ~~**B18** — behavioral / beacon signals~~ ✅ (`beacon_periodic`)
 4. ~~**B19** — SIEM webhook~~ ✅ (`alert-worker`)
 5. ~~**B8** — online categorization off hot path~~ ✅ (#104)
@@ -293,4 +302,4 @@ flowchart LR
 
 ---
 
-*Версия документа: 0.5.0 · M1–M4 done · M5.1 ml-worker scaffold*
+*Версия документа: 0.5.0 · M1–M5 done · DX/AI prep (control plane, coalescing, LLM cache)*

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,14 +18,14 @@
 
 ## Docker Compose (рекомендуется для dev/lab)
 
-### Lite — только прокси
+### Lite — proxy + SQLite Search API
 
 ```bash
 ./scripts/gen-ca.sh
 docker compose -f docker-compose.lite.yml up -d --build
 ```
 
-Один caching HTTPS proxy (MITM + L1), без Kafka/ClickHouse. Подробнее: [lite.md](lite.md).
+Caching HTTPS proxy + SQLite indexer / Search API (MITM + L1), без Kafka/ClickHouse. Подробнее: [lite.md](lite.md).
 
 ### Полный стек
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,20 +25,23 @@ sudo apt-get install -y \
 bsdm-proxy/
 ├── proxy/              # Основной прокси (bin: proxy)
 │   └── src/
-│       ├── main.rs     # ProxyService, HTTP server, cache, Kafka
-│       ├── lib.rs      # acl, auth, categorization, hierarchy, icp, peers
-│       ├── peer_fetch.rs, hierarchy_config.rs, cache_key.rs
-│       └── tls.rs, metrics.rs, policy_config.rs
-├── cache-indexer/      # Kafka → ClickHouse indexer + Search API
-├── bsdm-events/        # Shared CacheEvent types (proxy ↔ indexer)
+│       ├── main.rs, proxy_service.rs, control_api.rs
+│       ├── miss_coalesce.rs, semantic_cache.rs, threat_score_cache.rs
+│       ├── hierarchy*, peers, icp/htcp, rate_limit, upstream, tls, metrics
+│       └── lib.rs
+├── cache-indexer/      # Kafka|HTTP → ClickHouse|SQLite + Search API
+├── ml-worker/          # M5 features/scores + threat-score API
+├── alert-worker/       # M4 webhook alerts
+├── bsdm-events/        # Shared CacheEvent types
 ├── e2e/                # Smoke и E2E тесты
+├── admin-console/      # Unified admin UI (React)
 ├── charts/bsdm/        # Helm chart для Kubernetes
 ├── config/             # Примеры ACL-правил
 ├── packaging/          # Release-пакет (systemd, install.sh)
 ├── scripts/            # build-package, run-*-tests, pre-push-check, clickhouse SQL
 ├── grafana/            # Datasources + dashboards (Prometheus, ClickHouse)
 ├── prometheus/         # Scrape config
-├── web-config/         # Web UI для генерации конфигурации
+├── web-config/         # Legacy static config generator
 └── docs/               # Документация
 ```
 
@@ -94,7 +97,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --all-targets
 ```
 
-Ожидаемый результат: **75 тестов** (proxy unit/integration, cache-indexer, e2e smoke + e2e).
+Ожидаемый результат: зелёный suite (сотни unit/integration по workspace + e2e/smoke). Точное число — в CI.
 
 ### Smoke-тесты
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -10,8 +10,8 @@
 
 | Файл | Назначение |
 |------|------------|
-| `docker-compose.lite.yml` | **Lite:** один caching proxy (MITM + L1 spill), без Kafka/CH |
-| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, **alertmanager**, grafana; optional `alert-worker` (`--profile alerts`) |
+| `docker-compose.lite.yml` | **Lite:** proxy + SQLite indexer (MITM + L1 spill), без Kafka/CH |
+| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, **alertmanager**, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`) |
 | `docker-compose.test.yml` | Smoke/E2E external (upstream + proxy) |
 | `docker-compose.redis-l2.yml` | Два proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |
@@ -38,14 +38,14 @@ docker compose build proxy cache-indexer
 
 ---
 
-## Lite (standalone proxy)
+## Lite (proxy + SQLite Search API)
 
 ```bash
 ./scripts/gen-ca.sh
 docker compose -f docker-compose.lite.yml up -d --build
 ```
 
-Один сервис `proxy`, без analytics plane. Docs: [lite.md](lite.md).
+Сервисы: `proxy` + `cache-indexer` (`INDEX_STORE=sqlite`, `EVENT_SINK_URL`). Без Kafka/ClickHouse. Docs: [lite.md](lite.md).
 
 ## Полный стек
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -128,7 +128,7 @@ sudo perf report -i /tmp/bsdm-perf.data
 2. **`PERF_FAST_CACHE_HIT`**: HIT возвращается до ACL/categorization; Kafka и histograms опциональны.
 3. **`WORKER_COUNT`**: N процессов accept на одном порту (SO_REUSEPORT), общий L1 `Arc<HttpL1Cache>`.
 4. **Tiered bodies**: мелкие ответы inline, крупные (≥ `CACHE_SPILL_THRESHOLD_BYTES`) — mmap spill + zero-copy serve.
-4. **ACL**: `RwLock` + `check_access(&self)` — read-mostly без сериализации на каждый MISS.
+4. **ACL**: `AclEngineHandle` + `arc-swap` snapshot — lock-free read на hot path.
 5. **Kafka**: sampling через `KAFKA_SAMPLE_RATE`.
 
 ## Production vs bench

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@
 | [M2.5 — Data plane](#m25--data-plane-throughput-v03x) | v0.3.x–0.3.2 | Tiered L1, streaming, P1 hot path | ✅ Done |
 | [M3 — Retro-search](#m3--retro-search) | v0.3.1+ | ClickHouse, Search API, Grafana, k8s CHI | ✅ Done (~95%) |
 | [M4 — Threat analytics](#m4--threat-analytics-v05x) | v0.5.x | Rule-based угрозы, алерты, C&C / Shannon | ✅ Done |
-| [M5 — ML security](#m5--ml-security-v10x) | v1.0.x | Feature store, anomaly / phishing / C&C ML | ✅ Done |
+| [M5 — ML security](#m5--ml-security-v10x) | Unreleased / 0.5.x+ | Feature store, UEBA / phishing / C&C / write-back | ✅ Done |
 
 ```mermaid
 gantt
@@ -211,7 +211,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | Документ | Тема |
 |----------|------|
 | [strategic-roadmap.md](strategic-roadmap.md) | Стратегические фазы Lite / DX / Wasm / AI |
-| [lite.md](lite.md) | Lite compose: standalone proxy |
+| [lite.md](lite.md) | Lite compose: proxy + SQLite Search API |
 | [architecture.md](architecture.md) | Компоненты, блокеры |
 | [adr/0002-clickhouse-analytics.md](adr/0002-clickhouse-analytics.md) | ClickHouse ADR |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | Compose + SQL |

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -57,10 +57,10 @@
 
 | Стратегическая фаза | Пересекается с |
 |---------------------|----------------|
-| Lite | packaging, docker, optional analytics path (после M3 full stack) |
-| DX | ACL REST API (частично есть), metrics; расширяет control plane |
-| Wasm | новая платформа поверх M2 parity |
-| AI-трафик | rate limiting (B6 ✅), M5; semantic cache — отдельный трек |
+| Lite | `docker-compose.lite.yml`, SQLite indexer, optional `kafka` Cargo feature (B21) |
+| DX | REST control plane ✅ ([control-plane.md](control-plane.md)); gRPC — later |
+| Wasm | новая платформа поверх M2 parity (TBD) |
+| AI-трафик | coalescing ✅, API-key RL ✅, LLM/semantic cache prep ✅; external vector DB — later |
 
 Текущий product plan (Squid / ретропоиск / ML): [roadmap.md](roadmap.md).
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -6,9 +6,10 @@
 
 | Крейт | Путь | Назначение |
 |-------|------|------------|
-| `bsdm-proxy` | `proxy/` | HTTPS forward proxy (MITM, cache, auth, ACL, Kafka producer) |
-| `cache-indexer` | `cache-indexer/` | Kafka consumer → ClickHouse, Search API, `/metrics` |
+| `bsdm-proxy` | `proxy/` | HTTPS forward proxy (MITM, cache, auth, ACL, events) |
+| `cache-indexer` | `cache-indexer/` | Kafka|HTTP → ClickHouse|SQLite, Search API, `/metrics` |
 | `alert-worker` | `alert-worker/` | ClickHouse threat rules → SIEM/webhook (M4 / B19) |
+| `ml-worker` | `ml-worker/` | M5 features/scores + threat-score API |
 | `bsdm-events` | `bsdm-events/` | Общие типы событий (`CacheEvent`) для proxy и indexer |
 | `e2e` | `e2e/` | Smoke и E2E тесты (subprocess proxy + mock upstream) |
 
@@ -20,14 +21,16 @@
 bsdm-proxy/
 ├── proxy/                  # Основной прокси
 │   └── src/
-│       ├── main.rs         # HTTP server, cache, Kafka
-│       ├── lib.rs          # acl, auth, categorization, hierarchy, icp, peers
-│       ├── peer_fetch.rs, hierarchy_config.rs, cache_key.rs
-│       └── tls.rs, metrics.rs, policy_config.rs
-├── cache-indexer/          # Kafka → ClickHouse indexer + Search API
+│       ├── main.rs, proxy_service.rs, control_api.rs
+│       ├── miss_coalesce.rs, semantic_cache.rs, threat_score_cache.rs
+│       ├── hierarchy*, peers, icp/htcp, rate_limit, upstream, tls, metrics
+│       └── lib.rs
+├── cache-indexer/          # Kafka|HTTP → ClickHouse|SQLite + Search API
+├── ml-worker/              # M5 features/scores + threat-score API
 ├── alert-worker/           # CH rule polling → webhook / SIEM
 ├── bsdm-events/            # Shared event schema
 ├── e2e/                    # Integration tests
+├── admin-console/          # Unified admin UI (React)
 ├── charts/bsdm/            # Helm chart (K8s proxy Deployment)
 ├── config/                 # Примеры ACL-правил
 ├── packaging/              # Release tarball, systemd units, install.sh
@@ -36,11 +39,11 @@ bsdm-proxy/
 ├── grafana/                # Provisioning: datasources + dashboards + alerting
 ├── prometheus/             # Scrape config + M4 alert rules
 ├── alertmanager/           # Alertmanager template + entrypoint
-├── web-config/             # Web UI для генерации .env / compose
+├── web-config/             # Legacy static config generator
 ├── certs/                  # MITM CA (gitignored, генерируется локально)
-├── Dockerfile              # Multi-stage: proxy + cache-indexer + alert-worker
-├── docker-compose.yml      # Полный стек (+ profile `alerts`)
-├── docker-compose.lite.yml # Lite: standalone proxy (Phase 1)
+├── Dockerfile              # Multi-stage: proxy + cache-indexer + alert-worker + ml-worker
+├── docker-compose.yml      # Полный стек (+ profiles `alerts`, `ml`)
+├── docker-compose.lite.yml # Lite: proxy + SQLite indexer (Phase 1)
 ├── docker-compose.*.yml    # Профили: test, redis-l2, hierarchy, ha
 └── AGENTS.md               # Инструкции для Cursor Cloud Agent
 ```
@@ -49,8 +52,8 @@ bsdm-proxy/
 
 | Файл | Сервисы |
 |------|---------|
-| `docker-compose.lite.yml` | proxy only (MITM + L1 spill, no Kafka/CH) |
-| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, alertmanager, grafana; optional `alert-worker` (`--profile alerts`) |
+| `docker-compose.lite.yml` | proxy + SQLite cache-indexer (MITM + L1 spill, no Kafka/CH) |
+| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, alertmanager, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`) |
 | `docker-compose.test.yml` | Минимальный стек для smoke/E2E |
 | `docker-compose.redis-l2.yml` | 2× proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -38,10 +38,17 @@ CACHE_SPILL_THRESHOLD_BYTES=262144
 # CACHE_COMPRESS_MIN_BYTES=1024
 # CACHE_COMPRESS_ZSTD_LEVEL=3
 
-# Kafka (optional — cache events)
+# Kafka (optional — cache events; omit for Lite HTTP sink)
 # KAFKA_BROKERS=127.0.0.1:9092
 # KAFKA_TOPIC=cache-events
 # KAFKA_ACKS=1
+# Lite event sink (when KAFKA_BROKERS unset): POST JSON to indexer
+# EVENT_SINK_URL=http://127.0.0.1:8080/api/events
+# EVENT_SINK_TOKEN=
+
+# Control plane (metrics port REST; Bearer for mutating APIs)
+# CONTROL_API_TOKEN=change-me-in-production
+# (fallback: ACL_API_TOKEN)
 
 # Graceful shutdown
 SHUTDOWN_TIMEOUT_SECONDS=30
@@ -111,6 +118,9 @@ CATEGORIZATION_ENABLED=false
 HIERARCHY_ENABLED=false
 # CACHE_PARENTS=parent.example.com:1488:1.0
 # CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488
+# JSON peers file overrides CACHE_PARENTS/SIBLINGS; hot reload: POST /api/hierarchy/reload
+# CACHE_PEERS_PATH=/etc/bsdm-proxy/cache-peers.json
+# HIERARCHY_PEERS_PATH=/etc/bsdm-proxy/cache-peers.json
 # CACHE_SELECTION_STRATEGY=round-robin
 # ICP_BIND=0.0.0.0:3130
 # ICP_CLIENT_BIND=0.0.0.0:0
@@ -142,11 +152,19 @@ HIERARCHY_ENABLED=false
 # PEER_DISCOVERY_WEIGHT=1.0
 # PEER_DISCOVERY_DIGEST_EVERY=5
 
-# Upstream TLS (for self-signed upstream CA in tests/lab)
+# Upstream TLS (for self-signed upstream CA in tests/lab; hot reload: POST /api/upstream/tls/reload)
 # UPSTREAM_CA_CERT=/etc/bsdm-proxy/upstream-ca.crt
 
 # Upstream HTTP/2 (ALPN h2 on TLS connections, disabled by default)
 # UPSTREAM_HTTP2_ENABLED=true
+
+# M5.5 threat score write-back (optional; poll ml-worker snapshots)
+# THREAT_SCORE_ENABLED=false
+# THREAT_SCORE_POLL_URL=http://127.0.0.1:8091/api/threat-scores
+# THREAT_SCORE_POLL_INTERVAL_SECS=60
+# THREAT_SCORE_CACHE_TTL_SECS=300
+# THREAT_SCORE_WARN_THRESHOLD=0.7
+# THREAT_SCORE_BLOCK_THRESHOLD=0
 
 # Rate limiting (disabled by default)
 # RATE_LIMIT_ENABLED=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refresh project documentation so it matches the current codebase after M1–M5 completion and Unreleased DX/AI work.

## What changed

- **Status**: README / wiki / architecture / roadmap mapping mark **M1–M5 done**; Unreleased = DX control plane + AI prep (coalescing, API-key RL, LLM/semantic cache)
- **Lite**: consistently described as **proxy + SQLite Search API** (not “proxy only”) across README, docker, deployment, structure, AGENTS
- **Features / env**: control plane endpoints, `EVENT_SINK_*`, `CACHE_PEERS_PATH` / `HIERARCHY_PEERS_PATH`, threat-score vars, semantic embed dims; packaging `bsdm-proxy.env.example` updated
- **Architecture**: request/analytics paths and module map include rate limit, LLM cache, miss coalescing, HTTP event sink, ml-worker / admin-console
- **Index**: docs wiki links for httparchive benchmarks and admin-console; CHANGELOG Unreleased Documentation note

## Out of scope

No code or behavior changes. Remaining strategic gaps (gRPC control plane, Wasm, external vector DB) stay documented as future work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

