### PR TITLE
feat(dx): optional gRPC control plane (#187)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,8 @@ jobs:
             pkg-config \
             cmake \
             librdkafka-dev \
-            libclang-dev
+            libclang-dev \
+            protobuf-compiler
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -56,6 +57,11 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace --all-targets
+
+      - name: Build and test gRPC control plane feature
+        run: |
+          cargo clippy -p bsdm-proxy --features grpc --all-targets -- -D warnings
+          cargo test -p bsdm-proxy --features grpc --lib -- control_grpc
 
   security-audit:
     name: Security Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DX gRPC control plane** — optional Cargo feature `grpc`; proto `proxy/proto/control_plane.proto`; `CONTROL_GRPC_ENABLED` / `CONTROL_GRPC_BIND`; mirrors REST stats/purge/hierarchy/upstream TLS ([#187](https://github.com/onixus/bsdm-proxy/issues/187))
 - **Hierarchy peer mTLS** — `HIERARCHY_PEER_MTLS_*` wraps peer HTTP fetch in TLS + client cert ([#103](https://github.com/onixus/bsdm-proxy/issues/103))
 - **Semantic vector backend** — pluggable similarity index (`SEMANTIC_VECTOR_BACKEND=local|qdrant`) + optional HTTP embed provider; metric `bsdm_proxy_semantic_cache_vector_errors_total` ([#189](https://github.com/onixus/bsdm-proxy/issues/189))
 - **AI semantic / LLM cache prep** — `SEMANTIC_CACHE_ENABLED` POST body-hash cache for chat/completions paths; optional local cosine near-hit; docs [semantic-cache.md](docs/semantic-cache.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +235,53 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -352,6 +421,7 @@ dependencies = [
  "ldap3",
  "memmap2",
  "prometheus",
+ "prost",
  "quick_cache",
  "rand 0.9.4",
  "rcgen",
@@ -371,6 +441,9 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -892,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,12 +1178,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1129,6 +1214,12 @@ checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1246,6 +1337,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1399,6 +1503,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1648,6 +1762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,6 +1838,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -2000,6 +2126,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "picky"
 version = "7.0.0-rc.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2243,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2258,6 +2424,58 @@ dependencies = [
  "procfs",
  "protobuf",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.118",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2588,7 +2806,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2629,7 +2847,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -3516,7 +3734,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3529,6 +3747,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3558,7 +3840,7 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -141,9 +141,43 @@ curl -X POST http://127.0.0.1:9090/api/upstream/tls/reload \
 
 On failure (missing/invalid CA file) the previous client is kept and the API returns `400`.
 
+## gRPC control plane (optional)
+
+Feature-flagged (`--features grpc`), **off by default**. REST stays the Lite / admin-console path.
+
+```bash
+# Build
+cargo build -p bsdm-proxy --features grpc --bin proxy
+
+# Run
+CONTROL_GRPC_ENABLED=true \
+CONTROL_GRPC_BIND=127.0.0.1:50051 \
+CONTROL_API_TOKEN=secret \
+cargo run -p bsdm-proxy --features grpc --bin proxy
+```
+
+| Variable | Default | Role |
+|----------|---------|------|
+| `CONTROL_GRPC_ENABLED` | `false` | Start gRPC server (requires build with `grpc` feature) |
+| `CONTROL_GRPC_BIND` | `127.0.0.1:50051` | Listen address |
+
+Auth matches REST: mutating RPCs need `authorization: Bearer <CONTROL_API_TOKEN>` when the token is set. Public: `GetStats`, `ListHierarchyPeers`, `GetUpstreamTls`.
+
+Proto: [`proxy/proto/control_plane.proto`](../proxy/proto/control_plane.proto).
+
+```bash
+# Example (grpcurl)
+grpcurl -plaintext localhost:50051 list
+grpcurl -plaintext localhost:50051 bsdm.control.v1.ControlPlane/GetStats
+grpcurl -plaintext -H 'authorization: Bearer secret' \
+  -d '{"all":true}' localhost:50051 bsdm.control.v1.ControlPlane/PurgeCache
+```
+
+ACL CRUD remains REST-only (`/api/acl/*`).
+
 ## Roadmap leftovers
 
 - [x] Cache-Tags / Surrogate-Key purge (`{"tag":"..."}`)
 - [x] Hierarchy peer hot reload (`/api/hierarchy/*`)
 - [x] Upstream TLS hot reload (`/api/upstream/tls*`)
-- [ ] gRPC control plane
+- [x] gRPC control plane (`--features grpc`, [#187](https://github.com/onixus/bsdm-proxy/issues/187))

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,12 +9,13 @@
 | Rust | **1.88+** (рекомендуется latest stable) |
 | Cargo | stable |
 | librdkafka | dev-пакет (`librdkafka-dev`) — только при сборке с feature `kafka` (default) |
+| protoc | `protobuf-compiler` — только при сборке с feature `grpc` |
 | OpenSSL | dev-пакет (`libssl-dev`) |
 
 **Debian/Ubuntu:**
 ```bash
 sudo apt-get install -y \
-  libssl-dev pkg-config cmake librdkafka-dev libclang-dev
+  libssl-dev pkg-config cmake librdkafka-dev libclang-dev protobuf-compiler
 ```
 
 ## Структура workspace
@@ -50,6 +51,9 @@ bsdm-proxy/
 ```bash
 # Debug (default: auth-basic + kafka)
 cargo build -p bsdm-proxy --bin proxy
+
+# Optional gRPC control plane (needs protoc; runtime: CONTROL_GRPC_ENABLED=true)
+cargo build -p bsdm-proxy --features grpc --bin proxy
 
 # Lite — без rdkafka (HTTP EVENT_SINK only)
 cargo build -p bsdm-proxy --no-default-features --features auth-basic --bin proxy

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -24,20 +24,14 @@ Blockers B1–B26: all ✅ in [BLOCKERS.md](BLOCKERS.md) (GitHub #32–#56).
 | [#108](https://github.com/onixus/bsdm-proxy/issues/108) | DNS sinkhole / DNS security | P3 backlog |
 | [#99](https://github.com/onixus/bsdm-proxy/issues/99) | ICAP adapter | P3 backlog |
 
-## Closing with implementation PR
-
-| Issue | Title |
-|-------|-------|
-| [#101](https://github.com/onixus/bsdm-proxy/issues/101) | Squid rock ↔ spill sizing guide |
-| [#103](https://github.com/onixus/bsdm-proxy/issues/103) | Hierarchy peer mTLS |
-| [#189](https://github.com/onixus/bsdm-proxy/issues/189) | External vector DB (Qdrant) for semantic cache |
-
 ## Next strategic backlog
 
 | Issue | Phase |
 |-------|-------|
-| [#187](https://github.com/onixus/bsdm-proxy/issues/187) | DX — gRPC control plane |
 | [#188](https://github.com/onixus/bsdm-proxy/issues/188) | Wasm — Wasmtime plugin host |
+
+*(#101 / #103 / #189 / #187 closed via implementation PRs.)*
+
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,7 +198,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 | Фаза | Фокус | Ключевые элементы |
 |------|--------|-------------------|
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
-| **2. DX** | Control plane | ✅ REST ACL/stats/purge/hierarchy/upstream-TLS reload; next: [gRPC #187](https://github.com/onixus/bsdm-proxy/issues/187) |
+| **2. DX** | Control plane | ✅ REST + optional gRPC (`--features grpc`, [#187](https://github.com/onixus/bsdm-proxy/issues/187)) |
 | **3. Wasm** | Плагины | [Wasmtime plugin host #188](https://github.com/onixus/bsdm-proxy/issues/188) |
 | **4. AI-трафик** | LLM / API proxy | ✅ coalescing + API-key RL + LLM/semantic cache + Qdrant vector backend ([#189](https://github.com/onixus/bsdm-proxy/issues/189)) |
 

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -58,7 +58,7 @@
 | Стратегическая фаза | Пересекается с |
 |---------------------|----------------|
 | Lite | `docker-compose.lite.yml`, SQLite indexer, optional `kafka` Cargo feature (B21) |
-| DX | REST control plane ✅ ([control-plane.md](control-plane.md)); next: [gRPC #187](https://github.com/onixus/bsdm-proxy/issues/187) |
+| DX | REST control plane ✅ ([control-plane.md](control-plane.md)); gRPC ✅ (`--features grpc`, [#187](https://github.com/onixus/bsdm-proxy/issues/187)) |
 | Wasm | [Wasmtime plugin host #188](https://github.com/onixus/bsdm-proxy/issues/188) |
 | AI-трафик | coalescing ✅, API-key RL ✅, LLM/semantic cache ✅, Qdrant vector backend ✅ ([#189](https://github.com/onixus/bsdm-proxy/issues/189)) |
 

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -49,6 +49,9 @@ CACHE_SPILL_THRESHOLD_BYTES=262144
 # Control plane (metrics port REST; Bearer for mutating APIs)
 # CONTROL_API_TOKEN=change-me-in-production
 # (fallback: ACL_API_TOKEN)
+# Optional gRPC (requires build with --features grpc)
+# CONTROL_GRPC_ENABLED=false
+# CONTROL_GRPC_BIND=127.0.0.1:50051
 
 # Graceful shutdown
 SHUTDOWN_TIMEOUT_SECONDS=30

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -52,9 +52,18 @@ reqwest = { version = "0.13", features = ["json", "form"] }
 sspi = { version = "0.21.1", optional = true, features = ["network_client"] }
 kerberos_keytab = { version = "0.0.3", optional = true }
 
+# Optional gRPC control plane (feature `grpc`)
+tonic = { version = "0.12", optional = true }
+prost = { version = "0.13", optional = true }
+tower = { version = "0.5", optional = true }
+
+[build-dependencies]
+tonic-build = { version = "0.12", optional = true }
+
 [features]
 default = ["auth-basic", "kafka"]
 kafka = ["dep:rdkafka"]
+grpc = ["dep:tonic", "dep:prost", "dep:tower", "dep:tonic-build"]
 auth-basic = []
 auth-ldap = ["ldap3"]
 auth-ntlm = ["sspi"]

--- a/proxy/build.rs
+++ b/proxy/build.rs
@@ -1,0 +1,10 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "grpc")]
+    {
+        tonic_build::configure()
+            .build_server(true)
+            .build_client(true)
+            .compile_protos(&["proto/control_plane.proto"], &["proto"])?;
+    }
+    Ok(())
+}

--- a/proxy/proto/control_plane.proto
+++ b/proxy/proto/control_plane.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+package bsdm.control.v1;
+
+// Optional gRPC control plane (feature `grpc`, CONTROL_GRPC_ENABLED=true).
+// Auth: metadata `authorization: Bearer <CONTROL_API_TOKEN>` for mutating RPCs
+// (same policy as REST). Public: GetStats, ListHierarchyPeers, GetUpstreamTls.
+
+service ControlPlane {
+  rpc GetStats(Empty) returns (StatsResponse);
+  rpc PurgeCache(PurgeRequest) returns (PurgeResponse);
+  rpc ListHierarchyPeers(Empty) returns (PeersListResponse);
+  rpc ReloadHierarchy(Empty) returns (HierarchyReloadResponse);
+  rpc GetUpstreamTls(Empty) returns (UpstreamTlsSnapshot);
+  rpc ReloadUpstreamTls(Empty) returns (UpstreamTlsReloadResponse);
+}
+
+message Empty {}
+
+message CacheStats {
+  uint64 hits = 1;
+  uint64 misses = 2;
+  uint64 bypasses = 3;
+  double hit_ratio = 4;
+  uint64 entries = 5;
+  uint64 capacity = 6;
+  uint64 shards = 7;
+  uint64 tags = 8;
+}
+
+message StatsResponse {
+  string service = 1;
+  uint64 uptime_secs = 2;
+  uint64 requests_in_flight = 3;
+  CacheStats cache = 4;
+}
+
+message PurgeRequest {
+  bool all = 1;
+  string url = 2;
+  string method = 3;
+  string tag = 4;
+  repeated string tags = 5;
+}
+
+message PurgeResponse {
+  string status = 1;
+  string scope = 2;
+  uint64 removed = 3;
+  string url = 4;
+  repeated string tags = 5;
+}
+
+message PeerInfo {
+  string id = 1;
+  string host = 2;
+  uint32 port = 3;
+  string peer_type = 4;
+  double weight = 5;
+  uint32 icp_port = 6; // 0 = unset
+  bool healthy = 7;
+  bool is_static = 8;
+}
+
+message PeersListResponse {
+  bool enabled = 1;
+  repeated PeerInfo peers = 2;
+}
+
+message HierarchyReloadResponse {
+  string status = 1;
+  string source = 2;
+  uint64 added = 3;
+  uint64 removed = 4;
+  uint64 preserved_discovery = 5;
+  string error = 6;
+}
+
+message UpstreamTlsSnapshot {
+  bool http2_enabled = 1;
+  string ca_cert_path = 2;
+  bool custom_ca = 3;
+  uint64 reloaded_at_unix = 4;
+}
+
+message UpstreamTlsReloadResponse {
+  string status = 1;
+  UpstreamTlsSnapshot tls = 2;
+  string error = 3;
+}

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -123,21 +123,31 @@ impl ControlApiState {
     }
 
     fn is_authorized(&self, headers: &HeaderMap) -> bool {
+        let bearer = headers
+            .get(AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "));
+        self.is_authorized_bearer(bearer)
+    }
+
+    /// Shared auth check for REST and gRPC (`authorization: Bearer …`).
+    pub fn is_authorized_bearer(&self, bearer: Option<&str>) -> bool {
         let Some(expected) = &self.api_token else {
             return true;
         };
-        headers
-            .get(AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.strip_prefix("Bearer "))
-            .is_some_and(|token| token == expected)
+        bearer.is_some_and(|token| token == expected)
     }
 
-    fn stats(&self) -> Response<Body> {
+    /// Whether mutating control RPCs require a Bearer token.
+    pub fn auth_required(&self) -> bool {
+        self.api_token.is_some()
+    }
+
+    pub fn stats_payload(&self) -> StatsResponse {
         let hits = self.metrics.cache_hits_total.get();
         let misses = self.metrics.cache_misses_total.get();
         let bypasses = self.metrics.cache_bypasses_total.get();
-        let payload = StatsResponse {
+        StatsResponse {
             service: "bsdm-proxy",
             uptime_secs: self.started_at.elapsed().as_secs(),
             requests_in_flight: self.metrics.requests_in_flight.get() as u64,
@@ -151,8 +161,11 @@ impl ControlApiState {
                 shards: self.http_cache.shard_count(),
                 tags: self.http_cache.tag_count(),
             },
-        };
-        match serde_json::to_string(&payload) {
+        }
+    }
+
+    fn stats(&self) -> Response<Body> {
+        match serde_json::to_string(&self.stats_payload()) {
             Ok(body) => json_response(StatusCode::OK, &body),
             Err(_) => json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -161,12 +174,12 @@ impl ControlApiState {
         }
     }
 
-    async fn hierarchy_peers(&self) -> Response<Body> {
+    pub async fn hierarchy_peers_payload(&self) -> PeersListResponse {
         let Some(registry) = &self.peer_registry else {
-            return json_response(
-                StatusCode::OK,
-                r#"{"enabled":false,"peers":[],"source_hint":"set HIERARCHY_ENABLED=true"}"#,
-            );
+            return PeersListResponse {
+                enabled: false,
+                peers: Vec::new(),
+            };
         };
         let peers = registry.all_peers().await;
         let mut items = Vec::with_capacity(peers.len());
@@ -184,10 +197,20 @@ impl ControlApiState {
             });
         }
         items.sort_by(|a, b| a.id.cmp(&b.id));
-        let payload = PeersListResponse {
+        PeersListResponse {
             enabled: true,
             peers: items,
-        };
+        }
+    }
+
+    async fn hierarchy_peers(&self) -> Response<Body> {
+        let payload = self.hierarchy_peers_payload().await;
+        if !payload.enabled {
+            return json_response(
+                StatusCode::OK,
+                r#"{"enabled":false,"peers":[],"source_hint":"set HIERARCHY_ENABLED=true"}"#,
+            );
+        }
         match serde_json::to_string(&payload) {
             Ok(body) => json_response(StatusCode::OK, &body),
             Err(_) => json_response(
@@ -197,24 +220,37 @@ impl ControlApiState {
         }
     }
 
-    async fn hierarchy_reload(&self) -> Response<Body> {
+    pub async fn hierarchy_reload_payload(&self) -> Result<HierarchyReloadPayload, String> {
         let Some(registry) = &self.peer_registry else {
-            return json_response(
-                StatusCode::SERVICE_UNAVAILABLE,
-                r#"{"error":"hierarchy disabled (HIERARCHY_ENABLED=false)"}"#,
-            );
+            return Err("hierarchy disabled (HIERARCHY_ENABLED=false)".into());
         };
-        match reload_static_peers(registry, self.hierarchy_use_htcp).await {
+        let report = reload_static_peers(registry, self.hierarchy_use_htcp).await?;
+        Ok(HierarchyReloadPayload {
+            status: "reloaded",
+            source: report.source.as_str().to_string(),
+            added: report.stats.added as u64,
+            removed: report.stats.removed as u64,
+            preserved_discovery: report.stats.preserved_discovery as u64,
+        })
+    }
+
+    async fn hierarchy_reload(&self) -> Response<Body> {
+        match self.hierarchy_reload_payload().await {
             Ok(report) => {
                 let body = format!(
-                    r#"{{"status":"reloaded","source":"{}","added":{},"removed":{},"preserved_discovery":{}}}"#,
-                    report.source.as_str(),
-                    report.stats.added,
-                    report.stats.removed,
-                    report.stats.preserved_discovery
+                    r#"{{"status":"{}","source":"{}","added":{},"removed":{},"preserved_discovery":{}}}"#,
+                    report.status,
+                    report.source,
+                    report.added,
+                    report.removed,
+                    report.preserved_discovery
                 );
                 json_response(StatusCode::OK, &body)
             }
+            Err(e) if e.contains("hierarchy disabled") => json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                r#"{"error":"hierarchy disabled (HIERARCHY_ENABLED=false)"}"#,
+            ),
             Err(e) => json_response(
                 StatusCode::BAD_REQUEST,
                 &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
@@ -222,8 +258,12 @@ impl ControlApiState {
         }
     }
 
+    pub fn upstream_tls_snapshot(&self) -> crate::upstream::UpstreamTlsSnapshot {
+        (*self.upstream_client.snapshot()).clone()
+    }
+
     fn upstream_tls_status(&self) -> Response<Body> {
-        match serde_json::to_string(self.upstream_client.snapshot().as_ref()) {
+        match serde_json::to_string(&self.upstream_tls_snapshot()) {
             Ok(body) => json_response(StatusCode::OK, &body),
             Err(_) => json_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -232,8 +272,14 @@ impl ControlApiState {
         }
     }
 
+    pub fn upstream_tls_reload_payload(
+        &self,
+    ) -> Result<crate::upstream::UpstreamTlsSnapshot, String> {
+        self.upstream_client.reload_from_env()
+    }
+
     fn upstream_tls_reload(&self) -> Response<Body> {
-        match self.upstream_client.reload_from_env() {
+        match self.upstream_tls_reload_payload() {
             Ok(snap) => match serde_json::to_string(&UpstreamTlsReloadResponse {
                 status: "reloaded",
                 tls: snap,
@@ -249,6 +295,69 @@ impl ControlApiState {
                 &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
             ),
         }
+    }
+
+    pub async fn purge_payload(&self, req: PurgeRequest) -> Result<PurgeResult, String> {
+        if req.all {
+            let removed = self.http_cache.clear();
+            if let Some(l2) = &self.l2_cache {
+                l2.flush_prefix().await;
+            }
+            info!("Control API: purged entire L1 cache ({removed} entries)");
+            return Ok(PurgeResult {
+                status: "purged".into(),
+                scope: "all".into(),
+                removed,
+                url: None,
+                tags: Vec::new(),
+            });
+        }
+
+        let tags = collect_purge_tags(&req);
+        if !tags.is_empty() {
+            let mut removed = 0usize;
+            for tag in &tags {
+                let keys = self.http_cache.keys_for_tag(tag);
+                for key in &keys {
+                    if self.http_cache.remove(key).is_some() {
+                        removed += 1;
+                    }
+                    if let Some(l2) = &self.l2_cache {
+                        l2.delete(key.as_ref()).await;
+                    }
+                }
+            }
+            info!("Control API: purged tags={tags:?} removed={removed}");
+            return Ok(PurgeResult {
+                status: "purged".into(),
+                scope: "tag".into(),
+                removed,
+                url: None,
+                tags,
+            });
+        }
+
+        let Some(url) = req.url.as_deref().filter(|u| !u.is_empty()) else {
+            return Err(
+                "provide {\"url\":\"...\"}, {\"tag\":\"...\"}, {\"tags\":[...]}, or {\"all\":true}"
+                    .into(),
+            );
+        };
+
+        let method = req.method.as_deref().unwrap_or("GET");
+        let key = http_cache_key(method, url);
+        let removed_l1 = self.http_cache.remove(&key).is_some();
+        if let Some(l2) = &self.l2_cache {
+            l2.delete(key.as_ref()).await;
+        }
+        info!("Control API: purge url={url} method={method} l1={removed_l1}");
+        Ok(PurgeResult {
+            status: "purged".into(),
+            scope: "url".into(),
+            removed: if removed_l1 { 1 } else { 0 },
+            url: Some(url.to_string()),
+            tags: Vec::new(),
+        })
     }
 
     async fn purge(&self, body: Bytes) -> Response<Body> {
@@ -269,89 +378,60 @@ impl ControlApiState {
             }
         };
 
-        if req.all {
-            let removed = self.http_cache.clear();
-            if let Some(l2) = &self.l2_cache {
-                l2.flush_prefix().await;
-            }
-            info!("Control API: purged entire L1 cache ({removed} entries)");
-            return json_response(
+        match self.purge_payload(req).await {
+            Ok(r) if r.scope == "all" => json_response(
                 StatusCode::OK,
-                &format!(r#"{{"status":"purged","scope":"all","removed":{removed}}}"#),
-            );
-        }
-
-        let tags = collect_purge_tags(&req);
-        if !tags.is_empty() {
-            let mut removed = 0usize;
-            for tag in &tags {
-                let keys = self.http_cache.keys_for_tag(tag);
-                for key in &keys {
-                    if self.http_cache.remove(key).is_some() {
-                        removed += 1;
-                    }
-                    if let Some(l2) = &self.l2_cache {
-                        l2.delete(key.as_ref()).await;
-                    }
-                }
-            }
-            info!("Control API: purged tags={tags:?} removed={removed}");
-            return json_response(
+                &format!(
+                    r#"{{"status":"purged","scope":"all","removed":{}}}"#,
+                    r.removed
+                ),
+            ),
+            Ok(r) if r.scope == "tag" => json_response(
                 StatusCode::OK,
                 &format!(
                     r#"{{"status":"purged","scope":"tag","tags":[{}],"removed":{}}}"#,
-                    tags.iter()
+                    r.tags
+                        .iter()
                         .map(|t| format!("\"{}\"", escape_json(t)))
                         .collect::<Vec<_>>()
                         .join(","),
-                    removed
+                    r.removed
                 ),
-            );
-        }
-
-        let Some(url) = req.url.as_deref().filter(|u| !u.is_empty()) else {
-            return json_response(
-                StatusCode::BAD_REQUEST,
-                r#"{"error":"provide {\"url\":\"...\"}, {\"tag\":\"...\"}, {\"tags\":[...]}, or {\"all\":true}"}"#,
-            );
-        };
-
-        let method = req.method.as_deref().unwrap_or("GET");
-        let key = http_cache_key(method, url);
-        let removed_l1 = self.http_cache.remove(&key).is_some();
-        if let Some(l2) = &self.l2_cache {
-            l2.delete(key.as_ref()).await;
-        }
-        info!("Control API: purge url={url} method={method} l1={removed_l1}");
-        json_response(
-            StatusCode::OK,
-            &format!(
-                r#"{{"status":"purged","scope":"url","url":"{}","removed":{}}}"#,
-                escape_json(url),
-                if removed_l1 { 1 } else { 0 }
             ),
-        )
+            Ok(r) => json_response(
+                StatusCode::OK,
+                &format!(
+                    r#"{{"status":"purged","scope":"url","url":"{}","removed":{}}}"#,
+                    escape_json(r.url.as_deref().unwrap_or("")),
+                    r.removed
+                ),
+            ),
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(r#"{{"error":"{}"}}"#, escape_json(&e)),
+            ),
+        }
     }
 }
 
-#[derive(Debug, Serialize)]
-struct StatsResponse {
-    service: &'static str,
-    uptime_secs: u64,
-    requests_in_flight: u64,
-    cache: CacheStats,
+#[derive(Debug, Clone, Serialize)]
+pub struct StatsResponse {
+    pub service: &'static str,
+    pub uptime_secs: u64,
+    pub requests_in_flight: u64,
+    pub cache: CacheStats,
 }
 
-#[derive(Debug, Serialize)]
-struct CacheStats {
-    hits: u64,
-    misses: u64,
-    bypasses: u64,
-    hit_ratio: f64,
-    entries: usize,
-    capacity: usize,
-    shards: usize,
-    tags: usize,
+#[derive(Debug, Clone, Serialize)]
+pub struct CacheStats {
+    pub hits: u64,
+    pub misses: u64,
+    pub bypasses: u64,
+    pub hit_ratio: f64,
+    pub entries: usize,
+    pub capacity: usize,
+    pub shards: usize,
+    pub tags: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -360,33 +440,51 @@ struct UpstreamTlsReloadResponse {
     tls: crate::upstream::UpstreamTlsSnapshot,
 }
 
-#[derive(Debug, Serialize)]
-struct PeersListResponse {
-    enabled: bool,
-    peers: Vec<PeerListItem>,
+#[derive(Debug, Clone, Serialize)]
+pub struct PeersListResponse {
+    pub enabled: bool,
+    pub peers: Vec<PeerListItem>,
 }
 
-#[derive(Debug, Serialize)]
-struct PeerListItem {
-    id: String,
-    host: String,
-    port: u16,
-    peer_type: String,
-    weight: f64,
-    icp_port: Option<u16>,
-    healthy: bool,
-    is_static: bool,
+#[derive(Debug, Clone, Serialize)]
+pub struct PeerListItem {
+    pub id: String,
+    pub host: String,
+    pub port: u16,
+    pub peer_type: String,
+    pub weight: f64,
+    pub icp_port: Option<u16>,
+    pub healthy: bool,
+    pub is_static: bool,
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct PurgeRequest {
+#[derive(Debug, Clone)]
+pub struct HierarchyReloadPayload {
+    pub status: &'static str,
+    pub source: String,
+    pub added: u64,
+    pub removed: u64,
+    pub preserved_discovery: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PurgeResult {
+    pub status: String,
+    pub scope: String,
+    pub removed: usize,
+    pub url: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct PurgeRequest {
     #[serde(default)]
-    all: bool,
-    url: Option<String>,
-    method: Option<String>,
-    tag: Option<String>,
+    pub all: bool,
+    pub url: Option<String>,
+    pub method: Option<String>,
+    pub tag: Option<String>,
     #[serde(default)]
-    tags: Vec<String>,
+    pub tags: Vec<String>,
 }
 
 fn collect_purge_tags(req: &PurgeRequest) -> Vec<String> {

--- a/proxy/src/control_grpc.rs
+++ b/proxy/src/control_grpc.rs
@@ -1,0 +1,294 @@
+//! Optional gRPC control plane (Cargo feature `grpc`).
+//!
+//! Enable at build: `--features grpc`
+//! Enable at runtime: `CONTROL_GRPC_ENABLED=true` (bind `CONTROL_GRPC_BIND`, default `127.0.0.1:50051`).
+
+use std::sync::Arc;
+
+use tonic::metadata::MetadataMap;
+use tonic::{Request, Response, Status};
+use tracing::info;
+
+use crate::control_api::{ControlApiState, PurgeRequest as ApiPurgeRequest};
+
+pub mod proto {
+    tonic::include_proto!("bsdm.control.v1");
+}
+
+use proto::control_plane_server::{ControlPlane, ControlPlaneServer};
+use proto::*;
+
+#[derive(Clone)]
+struct ControlPlaneService {
+    state: Arc<ControlApiState>,
+}
+
+fn bearer_from_metadata(meta: &MetadataMap) -> Option<&str> {
+    meta.get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            v.strip_prefix("Bearer ")
+                .or_else(|| v.strip_prefix("bearer "))
+        })
+}
+
+#[allow(clippy::result_large_err)]
+fn require_auth(state: &ControlApiState, meta: &MetadataMap) -> Result<(), Status> {
+    if !state.auth_required() {
+        return Ok(());
+    }
+    if state.is_authorized_bearer(bearer_from_metadata(meta)) {
+        Ok(())
+    } else {
+        Err(Status::unauthenticated("unauthorized"))
+    }
+}
+
+#[tonic::async_trait]
+impl ControlPlane for ControlPlaneService {
+    async fn get_stats(&self, _req: Request<Empty>) -> Result<Response<StatsResponse>, Status> {
+        let s = self.state.stats_payload();
+        Ok(Response::new(StatsResponse {
+            service: s.service.to_string(),
+            uptime_secs: s.uptime_secs,
+            requests_in_flight: s.requests_in_flight,
+            cache: Some(CacheStats {
+                hits: s.cache.hits,
+                misses: s.cache.misses,
+                bypasses: s.cache.bypasses,
+                hit_ratio: s.cache.hit_ratio,
+                entries: s.cache.entries as u64,
+                capacity: s.cache.capacity as u64,
+                shards: s.cache.shards as u64,
+                tags: s.cache.tags as u64,
+            }),
+        }))
+    }
+
+    async fn purge_cache(
+        &self,
+        req: Request<PurgeRequest>,
+    ) -> Result<Response<PurgeResponse>, Status> {
+        require_auth(&self.state, req.metadata())?;
+        let p = req.into_inner();
+        let api_req = ApiPurgeRequest {
+            all: p.all,
+            url: if p.url.is_empty() { None } else { Some(p.url) },
+            method: if p.method.is_empty() {
+                None
+            } else {
+                Some(p.method)
+            },
+            tag: if p.tag.is_empty() { None } else { Some(p.tag) },
+            tags: p.tags,
+        };
+        match self.state.purge_payload(api_req).await {
+            Ok(r) => Ok(Response::new(PurgeResponse {
+                status: r.status,
+                scope: r.scope,
+                removed: r.removed as u64,
+                url: r.url.unwrap_or_default(),
+                tags: r.tags,
+            })),
+            Err(e) => Err(Status::invalid_argument(e)),
+        }
+    }
+
+    async fn list_hierarchy_peers(
+        &self,
+        _req: Request<Empty>,
+    ) -> Result<Response<PeersListResponse>, Status> {
+        let payload = self.state.hierarchy_peers_payload().await;
+        Ok(Response::new(PeersListResponse {
+            enabled: payload.enabled,
+            peers: payload
+                .peers
+                .into_iter()
+                .map(|p| PeerInfo {
+                    id: p.id,
+                    host: p.host,
+                    port: p.port as u32,
+                    peer_type: p.peer_type,
+                    weight: p.weight,
+                    icp_port: p.icp_port.unwrap_or(0) as u32,
+                    healthy: p.healthy,
+                    is_static: p.is_static,
+                })
+                .collect(),
+        }))
+    }
+
+    async fn reload_hierarchy(
+        &self,
+        req: Request<Empty>,
+    ) -> Result<Response<HierarchyReloadResponse>, Status> {
+        require_auth(&self.state, req.metadata())?;
+        match self.state.hierarchy_reload_payload().await {
+            Ok(r) => Ok(Response::new(HierarchyReloadResponse {
+                status: r.status.to_string(),
+                source: r.source,
+                added: r.added,
+                removed: r.removed,
+                preserved_discovery: r.preserved_discovery,
+                error: String::new(),
+            })),
+            Err(e) if e.contains("hierarchy disabled") => Err(Status::failed_precondition(e)),
+            Err(e) => Err(Status::invalid_argument(e)),
+        }
+    }
+
+    async fn get_upstream_tls(
+        &self,
+        _req: Request<Empty>,
+    ) -> Result<Response<UpstreamTlsSnapshot>, Status> {
+        let s = self.state.upstream_tls_snapshot();
+        Ok(Response::new(UpstreamTlsSnapshot {
+            http2_enabled: s.http2_enabled,
+            ca_cert_path: s.ca_cert_path.unwrap_or_default(),
+            custom_ca: s.custom_ca,
+            reloaded_at_unix: s.reloaded_at_unix,
+        }))
+    }
+
+    async fn reload_upstream_tls(
+        &self,
+        req: Request<Empty>,
+    ) -> Result<Response<UpstreamTlsReloadResponse>, Status> {
+        require_auth(&self.state, req.metadata())?;
+        match self.state.upstream_tls_reload_payload() {
+            Ok(s) => Ok(Response::new(UpstreamTlsReloadResponse {
+                status: "reloaded".into(),
+                tls: Some(UpstreamTlsSnapshot {
+                    http2_enabled: s.http2_enabled,
+                    ca_cert_path: s.ca_cert_path.unwrap_or_default(),
+                    custom_ca: s.custom_ca,
+                    reloaded_at_unix: s.reloaded_at_unix,
+                }),
+                error: String::new(),
+            })),
+            Err(e) => Err(Status::invalid_argument(e)),
+        }
+    }
+}
+
+/// Bind and serve the control-plane gRPC API until the process exits.
+pub async fn serve_control_grpc(state: Arc<ControlApiState>, bind: &str) -> Result<(), String> {
+    let addr = bind
+        .parse()
+        .map_err(|e| format!("invalid CONTROL_GRPC_BIND {bind}: {e}"))?;
+    info!("Control plane gRPC listening on {bind}");
+    tonic::transport::Server::builder()
+        .add_service(ControlPlaneServer::new(ControlPlaneService { state }))
+        .serve(addr)
+        .await
+        .map_err(|e| format!("gRPC serve error: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::Metrics;
+    use crate::sharded_cache::HttpL1Cache;
+    use crate::upstream::{UpstreamClientHandle, UpstreamTlsConfig};
+    use tokio::net::TcpListener;
+
+    fn test_state() -> Arc<ControlApiState> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let upstream =
+            UpstreamClientHandle::new(UpstreamTlsConfig::default()).expect("upstream client");
+        Arc::new(ControlApiState::new(
+            metrics, cache, None, None, None, false, upstream,
+        ))
+    }
+
+    #[tokio::test]
+    async fn grpc_get_stats_and_purge() {
+        let state = test_state();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let svc_state = state.clone();
+        let bind = addr.to_string();
+        tokio::spawn(async move {
+            let _ = serve_control_grpc(svc_state, &bind).await;
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut client =
+            proto::control_plane_client::ControlPlaneClient::connect(format!("http://{addr}"))
+                .await
+                .expect("connect");
+
+        let stats = client
+            .get_stats(Request::new(Empty {}))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(stats.service, "bsdm-proxy");
+        assert!(stats.cache.as_ref().unwrap().capacity > 0);
+
+        let purge = client
+            .purge_cache(Request::new(PurgeRequest {
+                all: true,
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(purge.scope, "all");
+    }
+
+    #[tokio::test]
+    async fn grpc_purge_requires_bearer_when_token_set() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let upstream =
+            UpstreamClientHandle::new(UpstreamTlsConfig::default()).expect("upstream client");
+        let state = Arc::new(ControlApiState::new(
+            metrics,
+            cache,
+            None,
+            Some("secret".into()),
+            None,
+            false,
+            upstream,
+        ));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let svc_state = state.clone();
+        let bind = addr.to_string();
+        tokio::spawn(async move {
+            let _ = serve_control_grpc(svc_state, &bind).await;
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut client =
+            proto::control_plane_client::ControlPlaneClient::connect(format!("http://{addr}"))
+                .await
+                .unwrap();
+
+        let err = client
+            .purge_cache(Request::new(PurgeRequest {
+                all: true,
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+
+        let mut req = Request::new(PurgeRequest {
+            all: true,
+            ..Default::default()
+        });
+        req.metadata_mut()
+            .insert("authorization", "Bearer secret".parse().unwrap());
+        let ok = client.purge_cache(req).await.unwrap().into_inner();
+        assert_eq!(ok.scope, "all");
+    }
+}

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -14,6 +14,8 @@ pub mod cache_freshness;
 pub mod cache_key;
 pub mod categorization;
 pub mod control_api;
+#[cfg(feature = "grpc")]
+pub mod control_grpc;
 pub mod hierarchy;
 pub mod hierarchy_config;
 pub mod htcp;

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -272,8 +272,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         shutdown_rx.clone(),
         metrics_port,
         acl_api,
-        Some(control_api),
+        Some(control_api.clone()),
     ));
+
+    #[cfg(feature = "grpc")]
+    {
+        let grpc_enabled = std::env::var("CONTROL_GRPC_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        if grpc_enabled {
+            let bind = std::env::var("CONTROL_GRPC_BIND")
+                .unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+            let grpc_state = control_api.clone();
+            tokio::spawn(async move {
+                if let Err(e) =
+                    bsdm_proxy::control_grpc::serve_control_grpc(grpc_state, &bind).await
+                {
+                    warn!("Control plane gRPC stopped: {e}");
+                }
+            });
+        } else {
+            info!("Control plane gRPC disabled (set CONTROL_GRPC_ENABLED=true; build with --features grpc)");
+        }
+    }
 
     if should_start_icp_server(&hierarchy_config) {
         let icp_bind = icp_server_bind_addr();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optional **gRPC control plane** for typed ops / automation clients alongside existing REST (Lite / admin-console unchanged).

Closes #187

## Changes

- Proto: `proxy/proto/control_plane.proto` (`bsdm.control.v1.ControlPlane`)
- Cargo feature `grpc` (default **off**) — `tonic` / `prost`; build needs `protoc`
- Runtime: `CONTROL_GRPC_ENABLED=true`, `CONTROL_GRPC_BIND=127.0.0.1:50051`
- Auth parity with REST: Bearer `CONTROL_API_TOKEN` for mutating RPCs; public GetStats / ListHierarchyPeers / GetUpstreamTls
- Shared typed helpers on `ControlApiState` used by REST + gRPC
- Docs: `docs/control-plane.md`, development, roadmap; CI installs `protobuf-compiler` and tests `--features grpc`

## Non-goals (as in issue)

- Replacing REST
- ACL CRUD over gRPC (still REST `/api/acl/*`)
- Wasm (#188)

## Testing

```bash
cargo test -p bsdm-proxy --lib -- control_api
cargo test -p bsdm-proxy --features grpc --lib -- control_grpc
cargo clippy -p bsdm-proxy --features grpc --all-targets -- -D warnings
cargo fmt --all -- --check
```

## Example

```bash
CONTROL_GRPC_ENABLED=true CONTROL_API_TOKEN=secret \
  cargo run -p bsdm-proxy --features grpc --bin proxy
grpcurl -plaintext localhost:50051 bsdm.control.v1.ControlPlane/GetStats
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

