### PR TITLE
feat(wasm): Wasmtime request-hook host PoC (#188)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,6 +63,11 @@ jobs:
           cargo clippy -p bsdm-proxy --features grpc --all-targets -- -D warnings
           cargo test -p bsdm-proxy --features grpc --lib -- control_grpc
 
+      - name: Build and test Wasm plugin host feature
+        run: |
+          cargo clippy -p bsdm-proxy --features wasm --lib -- -D warnings
+          cargo test -p bsdm-proxy --features wasm --lib -- wasm_host
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Wasm plugin host PoC** — Cargo feature `wasm` (Wasmtime); post-auth request hook with fuel limits; PoC `examples/wasm/deny_blocked_suffix.wat`; docs [wasm-plugins.md](docs/wasm-plugins.md) ([#188](https://github.com/onixus/bsdm-proxy/issues/188))
 - **DX gRPC control plane** — optional Cargo feature `grpc`; proto `proxy/proto/control_plane.proto`; `CONTROL_GRPC_ENABLED` / `CONTROL_GRPC_BIND`; mirrors REST stats/purge/hierarchy/upstream TLS ([#187](https://github.com/onixus/bsdm-proxy/issues/187))
 - **Hierarchy peer mTLS** — `HIERARCHY_PEER_MTLS_*` wraps peer HTTP fetch in TLS + client cert ([#103](https://github.com/onixus/bsdm-proxy/issues/103))
 - **Semantic vector backend** — pluggable similarity index (`SEMANTIC_VECTOR_BACKEND=local|qdrant`) + optional HTTP embed provider; metric `bsdm_proxy_semantic_cache_vector_errors_total` ([#189](https://github.com/onixus/bsdm-proxy/issues/189))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+dependencies = [
+ "object 0.37.3",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +462,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wasmtime",
  "zstd",
 ]
 
@@ -593,6 +609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +676,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "540b193ff98b825a1f250a75b3118911af918a734154c69d80bcfcf91e7e9522"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cb269598b9557ab942d687d3c1086d77c4b50dcf35813f3a65ba306fd42279"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46566d7c83a8bff4150748d66020f4c7224091952aa4b4df1ec4959c39d937a1"
+dependencies = [
+ "bumpalo",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.14.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df8a86a34236cc75a8a6a271973da779c2aeb36c43b6e14da474cf931317082"
+dependencies = [
+ "cranelift-codegen-shared",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf75340b6a57b7c7c1b74f10d3d90883ee6d43a554be8131a4046c2ebcf5eb65"
+
+[[package]]
+name = "cranelift-control"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e84495bc5d23d86aad8c86f8ade4af765b94882af60d60e271d3153942f1978"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963c17147b80df351965e57c04d20dbedc85bcaf44c3436780a59a3f1ff1b1c2"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727f02acbc4b4cb2ba38a6637101d579db50190df1dd05168c68e762851a3dd5"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b00cc2e03c748f2531eea01c871f502b909d30295fdcad43aec7bf5c5b4667"
+
+[[package]]
+name = "cranelift-native"
+version = "0.113.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbeaf978dc7c1a2de8bbb9162510ed218eb156697bc45590b8fbdd69bb08e8de"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -900,6 +1040,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1127,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1156,6 +1314,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "group"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1485,6 +1664,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1708,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1540,6 +1727,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1685,10 +1881,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1753,6 +1967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +2014,15 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmap2"
@@ -1960,6 +2192,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2342,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2310,6 +2569,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,7 +2714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -2463,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -2499,13 +2770,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33e7f8a43ccc7f93b330fef4baf271764674926f3f4d40f4a196d54de8af26"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "sptr",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "parking_lot",
 ]
@@ -2726,7 +3018,7 @@ dependencies = [
  "combine",
  "futures",
  "futures-util",
- "itertools",
+ "itertools 0.13.0",
  "itoa",
  "num-bigint 0.4.6",
  "percent-encoding",
@@ -2746,6 +3038,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+dependencies = [
+ "hashbrown 0.14.5",
+ "log",
+ "rustc-hash",
+ "slice-group-by",
+ "smallvec",
 ]
 
 [[package]]
@@ -3337,10 +3642,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slice-group-by"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3377,6 +3691,12 @@ name = "sponge-cursor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
+name = "sptr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sspi"
@@ -3518,6 +3838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,6 +3854,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -3938,6 +4273,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4078,6 +4425,244 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.218.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491f7e48672d0a1efdeadf897d98ac1f45942c26c3829cb44a6b828f6f26155f"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.253.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.218.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
+dependencies = [
+ "ahash",
+ "bitflags 2.13.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.253.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.218.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b30ceafa77646f56747369b0f2a0296016a40b447d32e6907439f2e4bb7695"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.218.1",
+]
+
+[[package]]
+name = "wasmtime"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e762e163fd305770c6c341df3290f0cabb3c264e7952943018e9a1ced8d917"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "indexmap 2.14.0",
+ "libc",
+ "libm",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.36.7",
+ "once_cell",
+ "paste",
+ "postcard",
+ "psm",
+ "pulley-interpreter",
+ "rustix 0.38.44",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "sptr",
+ "target-lexicon",
+ "wasmparser 0.218.1",
+ "wasmtime-asm-macros",
+ "wasmtime-component-macro",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "wasmtime-jit-icache-coherence",
+ "wasmtime-slab",
+ "wasmtime-versioned-export-macros",
+ "wat",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-asm-macros"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63caa7aebb546374e26257a1900fb93579171e7c02514cde26805b9ece3ef812"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-component-macro"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61a4b5ce2ad9c15655e830f0eac0c38b8def30c74ecac71f452d3901e491b68"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-component-util"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e87a1212270dbb84a49af13d82594e00a92769d6952b0ea7fc4366c949f6ad"
+
+[[package]]
+name = "wasmtime-cranelift"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb40dddf38c6a5eefd5ce7c1baf43b00fe44eada11a319fab22e993a960262f"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.12.1",
+ "log",
+ "object 0.36.7",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 1.0.69",
+ "wasmparser 0.218.1",
+ "wasmtime-environ",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8613075e89e94a48c05862243c2b718eef1b9c337f51493ebf951e149a10fa19"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.14.0",
+ "log",
+ "object 0.36.7",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.218.1",
+ "wasmparser 0.218.1",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-jit-icache-coherence"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da47fba49af72581bc0dc67c8faaf5ee550e6f106e285122a184a675193701a5"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wasmtime-slab"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770e10cdefb15f2b6304152978e115bd062753c1ebe7221c0b6b104fa0419ff6"
+
+[[package]]
+name = "wasmtime-versioned-export-macros"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bef2a726fd8d1ee9b0144655e16c492dc32eb4c7c9f7e3309fcffe637870933"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "253.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.253.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.253.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -4455,6 +5040,24 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-parser"
+version = "0.218.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f104473e8546f8096f1fa483d337101a98dc9525d67f4275816bcd177fe3e2be"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.218.1",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,7 +30,7 @@ checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -55,7 +64,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -78,6 +87,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,15 +106,6 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
-
-[[package]]
-name = "ar_archive_writer"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
-dependencies = [
- "object 0.37.3",
-]
 
 [[package]]
 name = "arbitrary"
@@ -448,7 +454,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "socket2 0.5.10",
  "sspi",
  "tempfile",
@@ -491,6 +497,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -567,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -664,10 +673,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -679,31 +706,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.113.1"
+name = "cranelift-assembler-x64"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540b193ff98b825a1f250a75b3118911af918a734154c69d80bcfcf91e7e9522"
+checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.133.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.133.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb269598b9557ab942d687d3c1086d77c4b50dcf35813f3a65ba306fd42279"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46566d7c83a8bff4150748d66020f4c7224091952aa4b4df1ec4959c39d937a1"
+checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
  "bumpalo",
+ "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -712,56 +760,69 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
+ "libm",
  "log",
+ "postcard",
+ "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df8a86a34236cc75a8a6a271973da779c2aeb36c43b6e14da474cf931317082"
+checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
 dependencies = [
+ "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf75340b6a57b7c7c1b74f10d3d90883ee6d43a554be8131a4046c2ebcf5eb65"
+checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e84495bc5d23d86aad8c86f8ade4af765b94882af60d60e271d3153942f1978"
+checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963c17147b80df351965e57c04d20dbedc85bcaf44c3436780a59a3f1ff1b1c2"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727f02acbc4b4cb2ba38a6637101d579db50190df1dd05168c68e762851a3dd5"
+checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -769,20 +830,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b00cc2e03c748f2531eea01c871f502b909d30295fdcad43aec7bf5c5b4667"
+checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
 
 [[package]]
 name = "cranelift-native"
-version = "0.113.1"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbeaf978dc7c1a2de8bbb9162510ed218eb156697bc45590b8fbdd69bb08e8de"
+checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
 dependencies = [
  "cranelift-codegen",
  "libc",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.133.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
 name = "crc32fast"
@@ -868,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c906a87e53a36ff795d72e06e8162a83c5436e3ea89e942a9cb9fc083f0a384f"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1006,7 +1073,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core 0.10.1",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -1127,12 +1194,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1315,11 +1376,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "stable_deref_trait",
 ]
@@ -1367,23 +1429,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -1664,12 +1727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,18 +1787,18 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1829,7 +1886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1879,12 +1936,6 @@ dependencies = [
  "tokio-util",
  "url",
 ]
-
-[[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -1968,12 +2019,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"
@@ -2193,22 +2241,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
  "memchr",
 ]
 
@@ -2289,7 +2328,7 @@ dependencies = [
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2303,7 +2342,7 @@ dependencies = [
  "fiat-crypto",
  "primefield",
  "primeorder",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2317,7 +2356,7 @@ dependencies = [
  "elliptic-curve",
  "primefield",
  "primeorder",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2342,12 +2381,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -2426,7 +2459,7 @@ dependencies = [
  "rustcrypto-group",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "sha3",
  "thiserror 2.0.18",
  "x25519-dalek",
@@ -2770,24 +2803,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
-dependencies = [
- "ar_archive_writer",
- "cc",
-]
-
-[[package]]
 name = "pulley-interpreter"
-version = "26.0.1"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33e7f8a43ccc7f93b330fef4baf271764674926f3f4d40f4a196d54de8af26"
+checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
 dependencies = [
  "cranelift-bitset",
  "log",
- "sptr",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "46.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2797,7 +2832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403c1a912fec895cafb223201e368234842acb9220aaf08ab042ae89ba5f135c"
 dependencies = [
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
  "hashbrown 0.17.1",
  "parking_lot",
 ]
@@ -3042,14 +3077,16 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.10.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
- "hashbrown 0.14.5",
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
- "slice-group-by",
+ "serde",
  "smallvec",
 ]
 
@@ -3216,6 +3253,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -3469,6 +3512,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -3552,7 +3599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
 
@@ -3564,12 +3611,23 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
 
@@ -3642,12 +3700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slice-group-by"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
-
-[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,12 +3743,6 @@ name = "sponge-cursor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
-
-[[package]]
-name = "sptr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sspi"
@@ -3744,7 +3790,7 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tokio",
  "tracing",
@@ -3839,9 +3885,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -4279,12 +4325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4429,11 +4469,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491f7e48672d0a1efdeadf897d98ac1f45942c26c3829cb44a6b828f6f26155f"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
- "leb128",
+ "leb128fmt",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -4448,13 +4489,12 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059739c2eac26eea736389a7d6d30b41a8201490bea204d0facde19183359849"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
- "ahash",
  "bitflags 2.13.0",
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "semver",
  "serde",
@@ -4473,94 +4513,108 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.218.1"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b30ceafa77646f56747369b0f2a0296016a40b447d32e6907439f2e4bb7695"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.218.1",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "26.0.1"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e762e163fd305770c6c341df3290f0cabb3c264e7952943018e9a1ced8d917"
+checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
- "anyhow",
+ "addr2line",
+ "async-trait",
  "bitflags 2.13.0",
  "bumpalo",
  "cc",
  "cfg-if",
- "hashbrown 0.14.5",
- "indexmap 2.14.0",
+ "futures",
  "libc",
- "libm",
  "log",
  "mach2",
  "memfd",
- "object 0.36.7",
+ "object",
  "once_cell",
- "paste",
  "postcard",
- "psm",
  "pulley-interpreter",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "smallvec",
- "sptr",
  "target-lexicon",
- "wasmparser 0.218.1",
- "wasmtime-asm-macros",
- "wasmtime-component-macro",
- "wasmtime-cranelift",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
- "wasmtime-jit-icache-coherence",
- "wasmtime-slab",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
  "wat",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "26.0.1"
+name = "wasmtime-environ"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63caa7aebb546374e26257a1900fb93579171e7c02514cde26805b9ece3ef812"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "wasmtime-component-macro"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a4b5ce2ad9c15655e830f0eac0c38b8def30c74ecac71f452d3901e491b68"
+checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
 dependencies = [
  "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
- "wasmtime-component-util",
- "wasmtime-wit-bindgen",
- "wit-parser",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
-name = "wasmtime-component-util"
-version = "26.0.1"
+name = "wasmtime-internal-component-util"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e87a1212270dbb84a49af13d82594e00a92769d6952b0ea7fc4366c949f6ad"
+checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
 
 [[package]]
-name = "wasmtime-cranelift"
-version = "26.0.1"
+name = "wasmtime-internal-core"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb40dddf38c6a5eefd5ce7c1baf43b00fe44eada11a319fab22e993a960262f"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
- "anyhow",
+ "hashbrown 0.17.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "46.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
+dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
@@ -4568,79 +4622,79 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
- "object 0.36.7",
+ "object",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 1.0.69",
- "wasmparser 0.218.1",
+ "thiserror 2.0.18",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
- "wasmtime-versioned-export-macros",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "26.0.1"
+name = "wasmtime-internal-fiber"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613075e89e94a48c05862243c2b718eef1b9c337f51493ebf951e149a10fa19"
+checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
 dependencies = [
- "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap 2.14.0",
- "log",
- "object 0.36.7",
- "postcard",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon",
- "wasm-encoder 0.218.1",
- "wasmparser 0.218.1",
- "wasmprinter",
-]
-
-[[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da47fba49af72581bc0dc67c8faaf5ee550e6f106e285122a184a675193701a5"
-dependencies = [
- "anyhow",
+ "cc",
  "cfg-if",
  "libc",
- "windows-sys 0.59.0",
+ "rustix 1.1.4",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-slab"
-version = "26.0.1"
+name = "wasmtime-internal-jit-debug"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770e10cdefb15f2b6304152978e115bd062753c1ebe7221c0b6b104fa0419ff6"
+checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
 
 [[package]]
-name = "wasmtime-versioned-export-macros"
-version = "26.0.1"
+name = "wasmtime-internal-jit-icache-coherence"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8efb877c9e5e67239d4553bb44dd2a34ae5cfb728f3cf2c5e64439c6ca6ee7"
+checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "46.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "46.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "wasmtime-wit-bindgen"
-version = "26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bef2a726fd8d1ee9b0144655e16c492dc32eb4c7c9f7e3309fcffe637870933"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "wit-parser",
 ]
 
 [[package]]
@@ -5040,24 +5094,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-parser"
-version = "0.218.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f104473e8546f8096f1fa483d337101a98dc9525d67f4275816bcd177fe3e2be"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.218.1",
-]
 
 [[package]]
 name = "writeable"

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 | [semantic-cache.md](semantic-cache.md) | LLM / semantic cache prep |
 | [acl.md](acl.md) | ACL + REST API |
 | [control-plane.md](control-plane.md) | DX: stats, purge, hierarchy/TLS reload, ACL CRUD |
+| [wasm-plugins.md](wasm-plugins.md) | Wasmtime request hooks (feature `wasm`) |
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,6 +55,9 @@ cargo build -p bsdm-proxy --bin proxy
 # Optional gRPC control plane (needs protoc; runtime: CONTROL_GRPC_ENABLED=true)
 cargo build -p bsdm-proxy --features grpc --bin proxy
 
+# Optional Wasm plugin host (runtime: WASM_ENABLED + WASM_MODULE_PATH)
+cargo build -p bsdm-proxy --features wasm --bin proxy
+
 # Lite — без rdkafka (HTTP EVENT_SINK only)
 cargo build -p bsdm-proxy --no-default-features --features auth-basic --bin proxy
 cargo build -p cache-indexer --no-default-features --bin cache-indexer

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -28,9 +28,10 @@ Blockers B1–B26: all ✅ in [BLOCKERS.md](BLOCKERS.md) (GitHub #32–#56).
 
 | Issue | Phase |
 |-------|-------|
-| [#188](https://github.com/onixus/bsdm-proxy/issues/188) | Wasm — Wasmtime plugin host |
+| [#99](https://github.com/onixus/bsdm-proxy/issues/99) | P3 ICAP adapter |
+| [#108](https://github.com/onixus/bsdm-proxy/issues/108) | P3 DNS sinkhole |
 
-*(#101 / #103 / #189 / #187 closed via implementation PRs.)*
+*(#101 / #103 / #189 / #187 / #188 closed via implementation PRs.)*
 
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,7 +199,7 @@ Backlog mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md)
 |------|--------|-------------------|
 | **1. Lite** | VPS / edge, низкий порог | ✅ `docker-compose.lite.yml` + SQLite indexer; ✅ Cargo `kafka` feature (B21) |
 | **2. DX** | Control plane | ✅ REST + optional gRPC (`--features grpc`, [#187](https://github.com/onixus/bsdm-proxy/issues/187)) |
-| **3. Wasm** | Плагины | [Wasmtime plugin host #188](https://github.com/onixus/bsdm-proxy/issues/188) |
+| **3. Wasm** | Плагины | ✅ PoC Wasmtime hook (`--features wasm`, [#188](https://github.com/onixus/bsdm-proxy/issues/188)) |
 | **4. AI-трафик** | LLM / API proxy | ✅ coalescing + API-key RL + LLM/semantic cache + Qdrant vector backend ([#189](https://github.com/onixus/bsdm-proxy/issues/189)) |
 
 Порядок реализации по умолчанию: **Lite → DX → Wasm / AI** (AI coalescing может частично пересекаться с perf-треком раньше Wasm).

--- a/docs/strategic-roadmap.md
+++ b/docs/strategic-roadmap.md
@@ -59,7 +59,7 @@
 |---------------------|----------------|
 | Lite | `docker-compose.lite.yml`, SQLite indexer, optional `kafka` Cargo feature (B21) |
 | DX | REST control plane ✅ ([control-plane.md](control-plane.md)); gRPC ✅ (`--features grpc`, [#187](https://github.com/onixus/bsdm-proxy/issues/187)) |
-| Wasm | [Wasmtime plugin host #188](https://github.com/onixus/bsdm-proxy/issues/188) |
+| Wasm | Wasmtime request hooks ✅ PoC ([wasm-plugins.md](wasm-plugins.md), [#188](https://github.com/onixus/bsdm-proxy/issues/188)) |
 | AI-трафик | coalescing ✅, API-key RL ✅, LLM/semantic cache ✅, Qdrant vector backend ✅ ([#189](https://github.com/onixus/bsdm-proxy/issues/189)) |
 
 Текущий product plan (Squid / ретропоиск / ML): [roadmap.md](roadmap.md).  

--- a/docs/wasm-plugins.md
+++ b/docs/wasm-plugins.md
@@ -1,0 +1,77 @@
+# Wasm plugins (Strategic Phase 3)
+
+Optional **Wasmtime** request hooks so policy/transform logic can ship as `.wasm` / `.wat` modules without rebuilding the proxy.
+
+Issue: [#188](https://github.com/onixus/bsdm-proxy/issues/188) · Roadmap: [strategic-roadmap.md](strategic-roadmap.md) Phase 3.
+
+## Status (PoC)
+
+| Item | Status |
+|------|--------|
+| Feature flag `wasm` (default off) | ✅ |
+| Hook point: after auth + rate-limit, before ACL | ✅ HTTP + CONNECT |
+| Host ABI (`bsdm` imports) | ✅ |
+| Fuel / memory limits | ✅ |
+| PoC deny-suffix plugin | ✅ `examples/wasm/deny_blocked_suffix.wat` |
+| Rust/AS SDK | sketch via ABI docs (full SDK later) |
+| WASI FS/net | **not** granted |
+
+## Build & run
+
+```bash
+# Needs a Rust toolchain that can link wasmtime (same as proxy)
+cargo build -p bsdm-proxy --features wasm --bin proxy
+
+WASM_ENABLED=true \
+WASM_MODULE_PATH=examples/wasm/deny_blocked_suffix.wat \
+WASM_FUEL=50000 \
+WASM_FAIL_OPEN=true \
+cargo run -p bsdm-proxy --features wasm --bin proxy
+```
+
+Lite builds stay without wasmtime: `--no-default-features --features auth-basic` (do **not** enable `wasm`).
+
+| Env | Default | Role |
+|-----|---------|------|
+| `WASM_ENABLED` | `false` | Load module at startup |
+| `WASM_MODULE_PATH` | — | Path to `.wasm` or `.wat` |
+| `WASM_FUEL` | `50000` | Wasmtime fuel units per request |
+| `WASM_FAIL_OPEN` | `true` | On trap/fuel: allow request (`false` → 502) |
+
+## Hook placement
+
+```
+authenticate → rate_limit → [Wasm on_request] → ACL/policy → cache → upstream
+```
+
+- **Deny** → `403` with `X-Wasm-Hook: deny`
+- **Allow** → optional request header rewrites from the guest, then ACL
+
+## Guest ABI
+
+Module must export `memory` and `on_request` (no params).
+
+Imports from module `bsdm`:
+
+| Import | Signature | Behavior |
+|--------|-----------|----------|
+| `url_contains` | `(ptr,len) -> i32` | 1 if request URL contains UTF-8 needle |
+| `method_eq` | `(ptr,len) -> i32` | 1 if method equals needle (ASCII case-insensitive) |
+| `set_request_header` | `(nptr,nlen,vptr,vlen)` | Queue header to set on allow |
+| `deny` | `(rptr,rlen)` | Deny with reason string |
+
+PoC guest (`examples/wasm/deny_blocked_suffix.wat`): deny if URL contains `.blocked.test`; else set `x-wasm-hook: allow`.
+
+## Security constraints
+
+- No WASI filesystem or network in the PoC host linker
+- Fuel + store memory/instance limits
+- Treat untrusted modules carefully; prefer fail-closed (`WASM_FAIL_OPEN=false`) in production when plugins are mandatory
+- Not a multi-tenant SaaS isolation boundary yet
+
+## Next steps
+
+- Richer context (headers map, user groups) via host getters
+- `pre-upstream` / `post-response` hooks
+- Rust/AssemblyScript SDK crate compiling to the ABI
+- Hot-reload module path via control plane

--- a/examples/wasm/deny_blocked_suffix.wat
+++ b/examples/wasm/deny_blocked_suffix.wat
@@ -1,0 +1,29 @@
+;; BSDM-Proxy Wasm PoC (#188) — deny URLs containing ".blocked.test"
+;; Host imports: bsdm.url_contains / set_request_header / deny
+;; Export: on_request, memory
+;;
+;; Build/run:
+;;   cargo build -p bsdm-proxy --features wasm --bin proxy
+;;   WASM_ENABLED=true WASM_MODULE_PATH=examples/wasm/deny_blocked_suffix.wat \
+;;     cargo run -p bsdm-proxy --features wasm --bin proxy
+
+(module
+  (import "bsdm" "url_contains" (func $url_contains (param i32 i32) (result i32)))
+  (import "bsdm" "set_request_header" (func $set_header (param i32 i32 i32 i32)))
+  (import "bsdm" "deny" (func $deny (param i32 i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) ".blocked.test")
+  (data (i32.const 16) "blocked by wasm PoC")
+  (data (i32.const 48) "x-wasm-hook")
+  (data (i32.const 64) "allow")
+  (func (export "on_request")
+    (if (i32.eqz (call $url_contains (i32.const 0) (i32.const 13)))
+      (then
+        (call $set_header (i32.const 48) (i32.const 11) (i32.const 64) (i32.const 5))
+      )
+      (else
+        (call $deny (i32.const 16) (i32.const 19))
+      )
+    )
+  )
+)

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -53,6 +53,12 @@ CACHE_SPILL_THRESHOLD_BYTES=262144
 # CONTROL_GRPC_ENABLED=false
 # CONTROL_GRPC_BIND=127.0.0.1:50051
 
+# Optional Wasm request hooks (requires build with --features wasm)
+# WASM_ENABLED=false
+# WASM_MODULE_PATH=/etc/bsdm-proxy/hooks/deny_blocked_suffix.wat
+# WASM_FUEL=50000
+# WASM_FAIL_OPEN=true
+
 # Graceful shutdown
 SHUTDOWN_TIMEOUT_SECONDS=30
 

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -58,7 +58,7 @@ prost = { version = "0.13", optional = true }
 tower = { version = "0.5", optional = true }
 
 # Optional Wasm plugin host (feature `wasm`)
-wasmtime = { version = "26", default-features = false, features = ["cranelift", "runtime", "wat"], optional = true }
+wasmtime = { version = "46", default-features = false, features = ["cranelift", "runtime", "wat"], optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.12", optional = true }

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -57,6 +57,9 @@ tonic = { version = "0.12", optional = true }
 prost = { version = "0.13", optional = true }
 tower = { version = "0.5", optional = true }
 
+# Optional Wasm plugin host (feature `wasm`)
+wasmtime = { version = "26", default-features = false, features = ["cranelift", "runtime", "wat"], optional = true }
+
 [build-dependencies]
 tonic-build = { version = "0.12", optional = true }
 
@@ -64,6 +67,7 @@ tonic-build = { version = "0.12", optional = true }
 default = ["auth-basic", "kafka"]
 kafka = ["dep:rdkafka"]
 grpc = ["dep:tonic", "dep:prost", "dep:tower", "dep:tonic-build"]
+wasm = ["dep:wasmtime"]
 auth-basic = []
 auth-ldap = ["ldap3"]
 auth-ntlm = ["sspi"]

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -42,6 +42,8 @@ pub mod tag_index;
 pub mod threat_score_cache;
 pub mod tls;
 pub mod upstream;
+#[cfg(feature = "wasm")]
+pub mod wasm_host;
 
 // Re-export commonly used types
 pub use acl::{AclAction, AclDecision, AclEngine, AclEngineHandle, AclRule};

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -48,6 +48,8 @@ use crate::streaming_miss::TeeMissBody;
 use crate::threat_score_cache::ThreatScoreCache;
 use crate::tls::CertCache;
 use crate::upstream::{UpstreamClientHandle, UpstreamTlsConfig};
+#[cfg(feature = "wasm")]
+use crate::wasm_host::{try_load_from_env, WasmHookDecision, WasmHookEngine, WasmHookRequest};
 
 pub struct ProxyPolicy {
     pub acl_engine: Option<Arc<AclEngineHandle>>,
@@ -299,6 +301,8 @@ pub struct ProxyService {
     semantic_config: SemanticCacheConfig,
     semantic_index: SemanticIndex,
     peer_tls: PeerTlsConfig,
+    #[cfg(feature = "wasm")]
+    wasm_hook: Option<Arc<WasmHookEngine>>,
 }
 
 impl ProxyService {
@@ -391,6 +395,8 @@ impl ProxyService {
         if let Err(e) = peer_tls.validate() {
             tracing::warn!("Hierarchy peer mTLS config invalid: {e}");
         }
+        #[cfg(feature = "wasm")]
+        let wasm_hook = try_load_from_env();
 
         Self {
             cert_cache,
@@ -417,6 +423,8 @@ impl ProxyService {
             semantic_config,
             semantic_index,
             peer_tls,
+            #[cfg(feature = "wasm")]
+            wasm_hook,
         }
     }
 
@@ -891,6 +899,87 @@ impl ProxyService {
             }
             AclAction::Allow => Response::new(empty()),
         }
+    }
+
+    /// Optional Wasm request hook (feature `wasm`): after auth/RL, before ACL policy.
+    /// Returns `Some(response)` when the guest denies (or hard-fails with fail_open=false).
+    #[cfg(feature = "wasm")]
+    pub(crate) fn run_wasm_hook(
+        &self,
+        method: &str,
+        url: &str,
+        client_ip: &str,
+        username: Option<&str>,
+        headers: &mut hyper::HeaderMap,
+    ) -> Option<Response<Body>> {
+        let Some(hook) = &self.wasm_hook else {
+            return None;
+        };
+        let decision = match hook.evaluate(WasmHookRequest {
+            method: method.to_string(),
+            url: url.to_string(),
+            client_ip: client_ip.to_string(),
+            username: username.map(str::to_string),
+        }) {
+            Ok(d) => d,
+            Err(e) => {
+                if hook.fail_open() {
+                    warn!("Wasm hook error (fail-open): {e}");
+                    return None;
+                }
+                warn!("Wasm hook error (fail-closed): {e}");
+                return Some(
+                    Response::builder()
+                        .status(StatusCode::BAD_GATEWAY)
+                        .header("Content-Type", "text/plain; charset=utf-8")
+                        .body(full(Bytes::from(format!(
+                            "502 Bad Gateway: wasm hook: {e}"
+                        ))))
+                        .unwrap_or_else(|_| {
+                            Response::new(full(Bytes::from_static(b"502 Bad Gateway")))
+                        }),
+                );
+            }
+        };
+        match decision {
+            WasmHookDecision::Allow { set_headers } => {
+                for (name, value) in set_headers {
+                    if let (Ok(hn), Ok(hv)) = (
+                        HeaderName::from_bytes(name.as_bytes()),
+                        HeaderValue::from_str(&value),
+                    ) {
+                        headers.insert(hn, hv);
+                    }
+                }
+                None
+            }
+            WasmHookDecision::Deny { reason } => {
+                debug!("Wasm hook deny: {reason}");
+                Some(
+                    Response::builder()
+                        .status(StatusCode::FORBIDDEN)
+                        .header("Content-Type", "text/plain; charset=utf-8")
+                        .header("X-Wasm-Hook", "deny")
+                        .body(full(Bytes::from(format!("403 Forbidden: {reason}"))))
+                        .unwrap_or_else(|_| {
+                            Response::new(full(Bytes::from_static(b"403 Forbidden")))
+                        }),
+                )
+            }
+        }
+    }
+
+    /// CONNECT path: evaluate Wasm hook (no request header rewrite needed).
+    #[cfg(feature = "wasm")]
+    pub(crate) fn run_wasm_hook_connect(
+        &self,
+        method: &str,
+        url: &str,
+        client_ip: &str,
+        username: Option<&str>,
+    ) -> Option<Response<Body>> {
+        let mut headers = hyper::HeaderMap::new();
+        self.run_wasm_hook(method, url, client_ip, username, &mut headers)
     }
 
     pub(crate) async fn authenticate_proxy(
@@ -1388,6 +1477,26 @@ impl ProxyService {
             .as_deref()
             .map(|u| u.groups.iter().map(String::as_str).collect())
             .unwrap_or_default();
+
+        #[cfg(feature = "wasm")]
+        {
+            let req_mut = req.as_mut().expect("request present");
+            if let Some(resp) = self.run_wasm_hook(
+                method,
+                &url,
+                &client_ip,
+                username.as_deref(),
+                req_mut.headers_mut(),
+            ) {
+                let code = resp.status().as_u16();
+                if let Some(g) = guard.take() {
+                    g.finish(code, 0, 0);
+                } else if let Some(scope) = fast_scope.take() {
+                    scope.finish(code);
+                }
+                return resp;
+            }
+        }
 
         let domain = Self::extract_domain(&url);
         let (policy_decision, categories, threat_sources) = self

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -471,6 +471,17 @@ pub async fn handle_connection(
 
                 let connect_url = format!("https://{}", authority);
                 let connect_domain = parse_authority(&authority).0;
+
+                #[cfg(feature = "wasm")]
+                if let Some(resp) = service.run_wasm_hook_connect(
+                    "CONNECT",
+                    &connect_url,
+                    &client_ip,
+                    policy_username,
+                ) {
+                    return Ok::<_, Infallible>(resp);
+                }
+
                 let (policy_decision, _, _) = service
                     .check_policy(
                         &connect_url,

--- a/proxy/src/wasm_host.rs
+++ b/proxy/src/wasm_host.rs
@@ -1,0 +1,392 @@
+//! Optional Wasmtime request hook host (Cargo feature `wasm`).
+//!
+//! Guest ABI (imports from module `bsdm`):
+//! - `url_contains(ptr, len) -> i32` — 1 if request URL contains UTF-8 needle
+//! - `method_eq(ptr, len) -> i32` — 1 if method equals needle (case-insensitive)
+//! - `set_request_header(name_ptr, name_len, val_ptr, val_len)` — queue header rewrite
+//! - `deny(reason_ptr, reason_len)` — mark request denied
+//!
+//! Guest must export `on_request` (no params / no results) and `memory`.
+//!
+//! Security: fuel-limited; no WASI FS/net. Fail-open/closed via `WASM_FAIL_OPEN`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use tracing::{info, warn};
+use wasmtime::{Caller, Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
+
+#[derive(Debug, Clone)]
+pub struct WasmHookConfig {
+    pub enabled: bool,
+    pub module_path: Option<String>,
+    pub fuel: u64,
+    pub fail_open: bool,
+}
+
+impl WasmHookConfig {
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("WASM_ENABLED")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        let module_path = std::env::var("WASM_MODULE_PATH")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let fuel = std::env::var("WASM_FUEL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(50_000);
+        let fail_open = std::env::var("WASM_FAIL_OPEN")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+            .unwrap_or(true);
+        Self {
+            enabled,
+            module_path,
+            fuel: fuel.max(1),
+            fail_open,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WasmHookRequest {
+    pub method: String,
+    pub url: String,
+    pub client_ip: String,
+    pub username: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum WasmHookDecision {
+    Allow {
+        set_headers: HashMap<String, String>,
+    },
+    Deny {
+        reason: String,
+    },
+}
+
+struct HostState {
+    request: WasmHookRequest,
+    denied: bool,
+    deny_reason: String,
+    set_headers: HashMap<String, String>,
+    limits: StoreLimits,
+}
+
+/// Compiled Wasm hook module + engine.
+#[derive(Clone)]
+pub struct WasmHookEngine {
+    engine: Engine,
+    module: Module,
+    fuel: u64,
+    fail_open: bool,
+}
+
+impl WasmHookEngine {
+    pub fn from_config(cfg: &WasmHookConfig) -> Result<Option<Self>, String> {
+        if !cfg.enabled {
+            return Ok(None);
+        }
+        let path = cfg
+            .module_path
+            .as_deref()
+            .ok_or_else(|| "WASM_MODULE_PATH required when WASM_ENABLED=true".to_string())?;
+        Self::load_path(path, cfg.fuel, cfg.fail_open).map(Some)
+    }
+
+    pub fn load_path(path: &str, fuel: u64, fail_open: bool) -> Result<Self, String> {
+        let bytes = std::fs::read(path).map_err(|e| format!("read {path}: {e}"))?;
+        Self::load_bytes(&bytes, Path::new(path), fuel, fail_open)
+    }
+
+    pub fn load_bytes(
+        bytes: &[u8],
+        label: &Path,
+        fuel: u64,
+        fail_open: bool,
+    ) -> Result<Self, String> {
+        let mut config = Config::new();
+        config.consume_fuel(true);
+        config.cranelift_opt_level(wasmtime::OptLevel::Speed);
+        let engine = Engine::new(&config).map_err(|e| format!("wasm engine: {e}"))?;
+        let module =
+            if label.extension().and_then(|e| e.to_str()) == Some("wat") || looks_like_wat(bytes) {
+                Module::new(&engine, bytes).map_err(|e| format!("compile wat: {e}"))?
+            } else {
+                Module::new(&engine, bytes).map_err(|e| format!("compile wasm: {e}"))?
+            };
+        info!(
+            "Wasm hook loaded from {} (fuel={fuel}, fail_open={fail_open})",
+            label.display()
+        );
+        Ok(Self {
+            engine,
+            module,
+            fuel: fuel.max(1),
+            fail_open,
+        })
+    }
+
+    pub fn evaluate(&self, request: WasmHookRequest) -> Result<WasmHookDecision, String> {
+        let mut linker = Linker::new(&self.engine);
+        register_host(&mut linker)?;
+
+        let host = HostState {
+            request,
+            denied: false,
+            deny_reason: String::new(),
+            set_headers: HashMap::new(),
+            limits: StoreLimitsBuilder::new()
+                .memory_size(16 << 20)
+                .instances(1)
+                .memories(1)
+                .tables(2)
+                .build(),
+        };
+        let mut store = Store::new(&self.engine, host);
+        store.limiter(|s| &mut s.limits);
+        store
+            .set_fuel(self.fuel)
+            .map_err(|e| format!("set fuel: {e}"))?;
+
+        let instance = linker
+            .instantiate(&mut store, &self.module)
+            .map_err(|e| format!("instantiate: {e}"))?;
+        let on_request = instance
+            .get_typed_func::<(), ()>(&mut store, "on_request")
+            .map_err(|e| format!("export on_request: {e}"))?;
+        on_request
+            .call(&mut store, ())
+            .map_err(|e| format!("on_request trap: {e}"))?;
+
+        let host = store.into_data();
+        if host.denied {
+            Ok(WasmHookDecision::Deny {
+                reason: if host.deny_reason.is_empty() {
+                    "wasm deny".into()
+                } else {
+                    host.deny_reason
+                },
+            })
+        } else {
+            Ok(WasmHookDecision::Allow {
+                set_headers: host.set_headers,
+            })
+        }
+    }
+
+    pub fn fail_open(&self) -> bool {
+        self.fail_open
+    }
+}
+
+fn looks_like_wat(bytes: &[u8]) -> bool {
+    let s = String::from_utf8_lossy(bytes);
+    let t = s.trim_start();
+    t.starts_with("(module") || t.starts_with(";;")
+}
+
+fn read_guest_str(
+    caller: &mut Caller<'_, HostState>,
+    ptr: i32,
+    len: i32,
+) -> Result<String, String> {
+    if ptr < 0 || len < 0 {
+        return Err("invalid ptr/len".into());
+    }
+    let mem = caller
+        .get_export("memory")
+        .and_then(|e| e.into_memory())
+        .ok_or_else(|| "missing memory export".to_string())?;
+    let data = mem
+        .data(caller)
+        .get(ptr as usize..(ptr as usize + len as usize))
+        .ok_or_else(|| "guest string OOB".to_string())?;
+    String::from_utf8(data.to_vec()).map_err(|e| format!("utf8: {e}"))
+}
+
+fn register_host(linker: &mut Linker<HostState>) -> Result<(), String> {
+    linker
+        .func_wrap(
+            "bsdm",
+            "url_contains",
+            |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
+                match read_guest_str(&mut caller, ptr, len) {
+                    Ok(needle) => {
+                        if caller.data().request.url.contains(&needle) {
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    Err(_) => 0,
+                }
+            },
+        )
+        .map_err(|e| format!("link url_contains: {e}"))?;
+
+    linker
+        .func_wrap(
+            "bsdm",
+            "method_eq",
+            |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
+                match read_guest_str(&mut caller, ptr, len) {
+                    Ok(needle) => {
+                        if caller
+                            .data()
+                            .request
+                            .method
+                            .eq_ignore_ascii_case(needle.trim())
+                        {
+                            1
+                        } else {
+                            0
+                        }
+                    }
+                    Err(_) => 0,
+                }
+            },
+        )
+        .map_err(|e| format!("link method_eq: {e}"))?;
+
+    linker
+        .func_wrap(
+            "bsdm",
+            "set_request_header",
+            |mut caller: Caller<'_, HostState>, np: i32, nl: i32, vp: i32, vl: i32| {
+                let Ok(name) = read_guest_str(&mut caller, np, nl) else {
+                    return;
+                };
+                let Ok(value) = read_guest_str(&mut caller, vp, vl) else {
+                    return;
+                };
+                if !name.is_empty() {
+                    caller
+                        .data_mut()
+                        .set_headers
+                        .insert(name.to_ascii_lowercase(), value);
+                }
+            },
+        )
+        .map_err(|e| format!("link set_request_header: {e}"))?;
+
+    linker
+        .func_wrap(
+            "bsdm",
+            "deny",
+            |mut caller: Caller<'_, HostState>, ptr: i32, len: i32| {
+                let reason = read_guest_str(&mut caller, ptr, len).unwrap_or_default();
+                let host = caller.data_mut();
+                host.denied = true;
+                host.deny_reason = reason;
+            },
+        )
+        .map_err(|e| format!("link deny: {e}"))?;
+
+    Ok(())
+}
+
+/// PoC guest: deny URLs containing `.blocked.test`; else allow and set `x-wasm-hook: allow`.
+pub const POC_DENY_SUFFIX_WAT: &str = r#"(module
+  (import "bsdm" "url_contains" (func $url_contains (param i32 i32) (result i32)))
+  (import "bsdm" "set_request_header" (func $set_header (param i32 i32 i32 i32)))
+  (import "bsdm" "deny" (func $deny (param i32 i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) ".blocked.test")
+  (data (i32.const 16) "blocked by wasm PoC")
+  (data (i32.const 48) "x-wasm-hook")
+  (data (i32.const 64) "allow")
+  (func (export "on_request")
+    (if (i32.eqz (call $url_contains (i32.const 0) (i32.const 13)))
+      (then
+        (call $set_header (i32.const 48) (i32.const 11) (i32.const 64) (i32.const 5))
+      )
+      (else
+        (call $deny (i32.const 16) (i32.const 19))
+      )
+    )
+  )
+)
+"#;
+
+/// Build engine from in-memory WAT (tests / embedded PoC).
+pub fn engine_from_wat(wat: &str, fuel: u64, fail_open: bool) -> Result<WasmHookEngine, String> {
+    WasmHookEngine::load_bytes(wat.as_bytes(), Path::new("inline.wat"), fuel, fail_open)
+}
+
+pub fn try_load_from_env() -> Option<Arc<WasmHookEngine>> {
+    let cfg = WasmHookConfig::from_env();
+    match WasmHookEngine::from_config(&cfg) {
+        Ok(Some(eng)) => Some(Arc::new(eng)),
+        Ok(None) => None,
+        Err(e) => {
+            warn!("Wasm hook disabled: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poc_allows_and_sets_header() {
+        let eng = engine_from_wat(POC_DENY_SUFFIX_WAT, 100_000, false).unwrap();
+        let d = eng
+            .evaluate(WasmHookRequest {
+                method: "GET".into(),
+                url: "https://example.com/ok".into(),
+                client_ip: "127.0.0.1".into(),
+                username: None,
+            })
+            .unwrap();
+        match d {
+            WasmHookDecision::Allow { set_headers } => {
+                assert_eq!(
+                    set_headers.get("x-wasm-hook").map(String::as_str),
+                    Some("allow")
+                );
+            }
+            WasmHookDecision::Deny { reason } => panic!("unexpected deny: {reason}"),
+        }
+    }
+
+    #[test]
+    fn poc_denies_blocked_suffix() {
+        let eng = engine_from_wat(POC_DENY_SUFFIX_WAT, 100_000, false).unwrap();
+        let d = eng
+            .evaluate(WasmHookRequest {
+                method: "GET".into(),
+                url: "https://evil.blocked.test/phish".into(),
+                client_ip: "10.0.0.1".into(),
+                username: Some("alice".into()),
+            })
+            .unwrap();
+        match d {
+            WasmHookDecision::Deny { reason } => {
+                assert!(reason.contains("blocked"));
+            }
+            WasmHookDecision::Allow { .. } => panic!("expected deny"),
+        }
+    }
+
+    #[test]
+    fn fuel_exhaustion_errors() {
+        let eng = engine_from_wat(POC_DENY_SUFFIX_WAT, 1, false).unwrap();
+        let err = eng
+            .evaluate(WasmHookRequest {
+                method: "GET".into(),
+                url: "https://example.com/".into(),
+                client_ip: "127.0.0.1".into(),
+                username: None,
+            })
+            .unwrap_err();
+        assert!(
+            err.contains("fuel") || err.contains("trap") || err.contains("on_request"),
+            "err={err}"
+        );
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Optional Wasmtime **request-hook host** behind Cargo feature `wasm` (default off). Closes #188.

Guest ABI (`bsdm.*`): `url_contains`, `method_eq`, `set_request_header`, `deny`. Hook runs after auth + rate-limit, before ACL (HTTP + CONNECT). Fuel-limited; no WASI FS/net.

## Security
- **wasmtime 46.0.1** (bumped from 26 after cargo-audit found 15 advisories on 26.0.1, incl. critical RUSTSEC-2026-0095/0096)
- Store memory/instance limits; `WASM_FAIL_OPEN` default true

## Docs / PoC
- `docs/wasm-plugins.md`
- `examples/wasm/deny_blocked_suffix.wat`
- CI builds `--features wasm`

## Test plan
- [x] `cargo test -p bsdm-proxy --features wasm wasm_host`
- [x] `cargo audit` clean for wasmtime (only allowed unmaintained warnings)
- [x] CI Security Audit green after bump
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

