### PR TITLE
docs: fix capacity planning estimates

### DIFF
--- a/docs/adr/0002-clickhouse-analytics.md
+++ b/docs/adr/0002-clickhouse-analytics.md
@@ -20,7 +20,7 @@ Roadmap M3–M5 workloads:
 | M4 Threat analytics | windows, periodic patterns, GROUP BY | ClickHouse |
 | M5 ML | batch feature extraction | ClickHouse |
 
-Corporate medium: **~4M events/day**, 42-day retention ([capacity-planning.md](../capacity-planning.md)).
+Corporate medium (estimate): **~4M events/day**, 42-day retention ([capacity-planning.md](../capacity-planning.md)).
 
 OpenSearch was RAM-heavy and optimized for full-text search; BSDM queries are **structured analytics**. Migration completed in phases 0–4 ([#125](https://github.com/onixus/bsdm-proxy/issues/125)).
 

--- a/docs/capacity-planning.md
+++ b/docs/capacity-planning.md
@@ -2,27 +2,37 @@
 
 Планирование ёмкости для корпоративного развёртывания BSDM-Proxy.
 
-> Wiki (актуальная версия): [Capacity Planning](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning)
+> Wiki: [Capacity Planning](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning) (держите в синхроне с этим файлом).
 
-## Референс-сценарий
+## Статус цифр
 
-| Параметр | Значение |
-|----------|----------|
-| Пользователи | 5 000 |
-| Серверы | 300 |
-| Hot logs (ClickHouse) | 42 дня (TTL) |
-| Cold logs | 28 дней (4 недели) |
-| Events/day (medium) | ~4M |
-| Peak RPS | ~330–350 |
+Таблицы ниже — **estimate / planning sketch**, не результат нагрузочного прогона на N пользователей.
+Ориентиры сверены с арифметикой событий и lab-бенчами data plane; пиковый RPS и железо analytics plane
+нужно перемерить на своём трафике (MITM %, hit-rate, `KAFKA_SAMPLE_RATE`, req/page).
 
-## Рекомендуемые лимиты кеша
+Peak RPS в рефе — **прокси-запросы / CacheEvent**, не page loads. При ~70 ресурсах на
+страницу (HTTP Archive median) 350 RPS ≈ единицы полноценных page/s.
 
-| Профиль | `CACHE_CAPACITY` | `MAX_CACHE_BODY_SIZE` | `CACHE_TTL` | `CACHE_COMPRESSION` | `REDIS_L2` | `CACHE_SHARDS` | `CACHE_SPILL_THRESHOLD` |
-|---------|------------------|----------------------|-------------|---------------------|------------|----------------|-------------------------|
-| Lab / dev (defaults) | 10 000 | 10 MB | 3600 | off | off | 16 | 256 KB |
-| Малый prod | 50 000 | 4 MB | 3600 | zstd | optional | 16 | 256 KB |
-| **Corporate medium** | **100 000** | **2 MB** | **7200** | **zstd** | **on** | **16–32** | **256 KB** |
-| Экономия RAM | 5 000 | 512 KB | 600 | off | off | 8 | 128 KB |
+## Референс-сценарий (corporate medium)
+
+| Параметр | Значение | Как получено |
+|----------|----------|--------------|
+| Пользователи | 5 000 | сценарий-ориентир |
+| Серверы (endpoints) | 300 | сценарий-ориентир (не «нагрузка на proxy») |
+| Hot logs (ClickHouse) | 42 дня (TTL) | политика хранения |
+| Cold logs | 28 дней | политика хранения |
+| Events/day | ~4M | ≈ 800 событий/user/day × 5k |
+| Avg RPS | ~46 | 4M / 86 400 |
+| Peak RPS | ~330–350 | ≈ ×7–8 к среднему (офисный пик) |
+
+## Профили кеша
+
+| Профиль | Пользователи (ориентир) | `CACHE_CAPACITY` | `MAX_CACHE_BODY_SIZE` | `CACHE_TTL` | `CACHE_COMPRESSION` | `REDIS_L2` | `CACHE_SHARDS` | `CACHE_SPILL_THRESHOLD` |
+|---------|-------------------------|------------------|----------------------|-------------|---------------------|------------|----------------|-------------------------|
+| Lab / dev (defaults) | — | 10 000 | 10 MB | 3600 | off | off | 16 | 256 KB |
+| **Малый prod** | **~0.5–1.5k** | **50 000** | **4 MB** | **3600** | **zstd** | **optional** | **16** | **256 KB** |
+| Corporate medium | ~5k | 100 000 | 2 MB | 7200 | zstd | on | 16–32 | 256 KB |
+| Экономия RAM | lab / edge | 5 000 | 512 KB | 600 | off | off | 8 | 128 KB |
 
 ```bash
 # Corporate medium — см. packaging/config/bsdm-proxy.env.example
@@ -36,17 +46,51 @@ CACHE_SPILL_THRESHOLD_BYTES=262144
 REDIS_L2_ENABLED=true
 ```
 
-## Ресурсы (medium, ~4M events/day)
+```bash
+# Малый prod (~1k users) — Lite SWG или полный стек с урезанным analytics
+CACHE_CAPACITY=50000
+MAX_CACHE_BODY_SIZE=4194304
+CACHE_TTL_SECONDS=3600
+CACHE_COMPRESSION=zstd
+CACHE_SHARDS=16
+CACHE_SPILL_THRESHOLD_BYTES=262144
+WORKER_COUNT=1
+REDIS_L2_ENABLED=false
+```
 
-| Компонент | Кол-во | vCPU | RAM | Диск |
-|-----------|--------|------|-----|------|
+## Ресурсы: corporate medium (~4M events/day)
+
+vCPU / RAM / диск в строках — **на один инстанс**. Итоги считаются явно для CH=1 и CH=3.
+
+| Компонент | Кол-во | vCPU / инст. | RAM / инст. | Диск / инст. |
+|-----------|--------|--------------|-------------|--------------|
 | bsdm-proxy | 4 | 8 | 16 GB | 50 GB SSD |
 | Redis L2 | 2 | 4 | 32 GB | 100 GB |
 | Kafka | 3 | 4 | 16 GB | 200 GB |
-| ClickHouse | 1–3 | 8 | 32 GB | 500 GB NVMe |
-| **Итого** | — | ~80 | ~350 GB | ~1.3 TB |
+| ClickHouse | 1 или 3 | 8 | 32 GB | 500 GB NVMe |
 
-Полные формулы, модели нагрузки и риски — на [wiki](https://github.com/onixus/bsdm-proxy/wiki/Capacity-Planning).
+| Итого | vCPU | RAM | Диск |
+|-------|------|-----|------|
+| **CH ×1** (типичный старт) | **60** | **208 GB** | **~1.5 TB** |
+| **CH ×3** (HA analytics) | **76** | **272 GB** | **~2.5 TB** |
+
+Monitoring (Prometheus / Grafana / Alertmanager) — обычно на отдельных нодах; в итоги выше не входит
+(~2–4 vCPU / 4–8 GB).
+
+Data plane при ~350 peak RPS сам по себе легче, чем 4×8 vCPU: запас заложен под MITM, ACL,
+иерархию и рост. Тяжесть рефа — **Kafka + ClickHouse + Redis L2**.
+
+## Ресурсы: малый prod (~1k users)
+
+Ориентир: peak **~60–70 RPS**, **~0.8M** events/day (×0.2 от medium). Не линейный «÷5» всей
+таблицы medium — analytics plane масштабируется ступеньками.
+
+| Вариант | Состав | vCPU | RAM | Диск |
+|---------|--------|------|-----|------|
+| **Lite SWG** (без Kafka/CH) | 2× proxy за LB | ~8 | ~16 GB | ~80 GB SSD |
+| **Полный** | 2× proxy + Kafka 1–3 + CH×1 (+ Redis opt.) | ~20–30 | ~50–80 GB | ~0.5 TB |
+
+На инстанс proxy: **4 vCPU / 8 GB / 40 GB SSD** (spill + CA). Redis L2 при ~1k **не обязателен**.
 
 ## Squid rock ↔ BSDM spill (HTTP Archive / large objects)
 
@@ -70,7 +114,7 @@ Typical HA warm objects are a few MB. Keep spill threshold **well below** median
 # Squid-tuned parity sketch (see scripts/squid-benchmark-tuned.conf)
 WORKER_COUNT=4
 CACHE_SHARDS=16
-CACHE_CAPACITY=10000          # entries per shard (not bytes)
+CACHE_CAPACITY=10000          # entries (not bytes); sharded across CACHE_SHARDS
 CACHE_SPILL_THRESHOLD_BYTES=262144   # 256 KiB — bodies ≥ this → mmap spill
 MAX_CACHE_BODY_SIZE=10485760         # 10 MiB (matches Squid maximum_object_size)
 CACHE_SPILL_DIR=/var/cache/bsdm-proxy/spill

--- a/docs/k8s-architecture.md
+++ b/docs/k8s-architecture.md
@@ -50,7 +50,9 @@ flowchart TB
   P -->|/metrics| PM
 ```
 
-### Референс sizing (5k users, ~350 peak RPS)
+### Референс sizing (corporate medium ≈5k users, ~350 peak RPS)
+
+Estimate — см. оговорки в [capacity-planning.md](capacity-planning.md). Итоги кластера считайте по CH×1 vs CH×3.
 
 | Компонент | K8s | Replicas | CPU/pod | RAM/pod |
 |-----------|-----|----------|---------|---------|
@@ -60,7 +62,7 @@ flowchart TB
 | Kafka | Strimzi / external | 3 | 2 / 4 | 8 Gi |
 | ClickHouse | StatefulSet / managed / ClickHouse Cloud | 1–3 | 8 / 8 | 32 Gi |
 
-Полные цифры: [capacity-planning.md](capacity-planning.md).
+Для ~1k users (малый prod): обычно **2** replica proxy, Redis optional, CH×1. Полные цифры: [capacity-planning.md](capacity-planning.md).
 
 ---
 

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -22,7 +22,14 @@ CACHE_SPILL_THRESHOLD_BYTES=262144
 # Private spill dir (created 0o700; spill files 0o600). Use a dedicated path in production.
 # CACHE_SPILL_DIR=/var/cache/bsdm-proxy/spill
 
-# Corporate medium (5000 users, 300 servers) — uncomment for production:
+# Sizing estimates: docs/capacity-planning.md (not a measured load test).
+# Малый prod (~0.5–1.5k users):
+# CACHE_CAPACITY=50000
+# MAX_CACHE_BODY_SIZE=4194304
+# CACHE_TTL_SECONDS=3600
+# CACHE_COMPRESSION=zstd
+# REDIS_L2_ENABLED=false
+# Corporate medium (~5k users) — uncomment for larger sites:
 # CACHE_CAPACITY=100000
 # MAX_CACHE_BODY_SIZE=2097152
 # CACHE_TTL_SECONDS=7200


### PR DESCRIPTION
## Summary
- Mark corporate medium capacity numbers as **estimate / planning sketch** (not a measured 5k-user load test) and document how avg/peak RPS relate to ~4M events/day.
- Recalculate cluster totals: **CH×1 → 60 vCPU / 208 GB / ~1.5 TB**, **CH×3 → 76 / 272 GB / ~2.5 TB** (replacing incorrect ~80 / ~350 GB).
- Align **малый prod** with **~0.5–1.5k users**, add Lite vs full sizing, and sync `env.example` / k8s notes / ADR wording.
- Wiki already updated in sync (`Capacity-Planning`, `Specifications`).

## Test plan
- [ ] Skim `docs/capacity-planning.md` totals vs per-instance rows (CH×1 and CH×3)
- [ ] Confirm малый prod env snippet matches `packaging/config/bsdm-proxy.env.example`
- [ ] Spot-check wiki Capacity-Planning / Specifications match repo


Made with [Cursor](https://cursor.com)