### PR TITLE
feat(dns): RPZ-lite sinkhole sidecar (#108)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,11 @@
 
 BSDM-Proxy is a single Rust/Cargo product: a caching HTTPS forward proxy with MITM
 TLS, auth, ACL, Prometheus metrics, and an optional Kafka → cache-indexer → ClickHouse
-analytics pipeline (plus optional `alert-worker` webhook alerts and `ml-worker`
-feature-store scoring). The Cargo workspace has six crates: `proxy/` (bin `proxy`),
-`cache-indexer/` (bin `cache-indexer`), `alert-worker/` (bin `alert-worker`),
-`ml-worker/` (bin `ml-worker`), `bsdm-events/` (shared event types), and
+analytics pipeline (plus optional `alert-worker` webhook alerts, `ml-worker`
+feature-store scoring, and `dns-sinkhole` UDP RPZ-lite sidecar). The Cargo workspace
+has seven crates: `proxy/` (bin `proxy`), `cache-indexer/` (bin `cache-indexer`),
+`alert-worker/` (bin `alert-worker`), `ml-worker/` (bin `ml-worker`),
+`dns-sinkhole/` (bin `dns-sinkhole`), `bsdm-events/` (shared event types), and
 `e2e/` (test harness). Standard build,
 lint, test, and run commands live in `README.md` and `docs/development.md` — use those
 as the source of truth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **DNS sinkhole sidecar** — workspace crate `dns-sinkhole` (UDP RPZ-lite proxy); ADR 0004; compose profile `dns-sinkhole`; docs [dns-sinkhole.md](docs/dns-sinkhole.md) ([#108](https://github.com/onixus/bsdm-proxy/issues/108))
 - **Wasm plugin host PoC** — Cargo feature `wasm` (Wasmtime); post-auth request hook with fuel limits; PoC `examples/wasm/deny_blocked_suffix.wat`; docs [wasm-plugins.md](docs/wasm-plugins.md) ([#188](https://github.com/onixus/bsdm-proxy/issues/188))
 - **DX gRPC control plane** — optional Cargo feature `grpc`; proto `proxy/proto/control_plane.proto`; `CONTROL_GRPC_ENABLED` / `CONTROL_GRPC_BIND`; mirrors REST stats/purge/hierarchy/upstream TLS ([#187](https://github.com/onixus/bsdm-proxy/issues/187))
 - **Hierarchy peer mTLS** — `HIERARCHY_PEER_MTLS_*` wraps peer HTTP fetch in TLS + client cert ([#103](https://github.com/onixus/bsdm-proxy/issues/103))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-sinkhole"
+version = "0.5.0"
+dependencies = [
+ "prometheus",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "cache-indexer",
     "alert-worker",
     "ml-worker",
+    "dns-sinkhole",
     "e2e",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY proxy ./proxy
 COPY cache-indexer ./cache-indexer
 COPY alert-worker ./alert-worker
 COPY ml-worker ./ml-worker
+COPY dns-sinkhole ./dns-sinkhole
 COPY e2e ./e2e
 
 # Настройка окружения для статической линковки
@@ -52,7 +53,7 @@ RUN if [ "$LITE_BUILD" = "1" ]; then \
         --no-default-features -p cache-indexer; \
     else \
       cargo build --release --target x86_64-unknown-linux-musl \
-        -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker; \
+        -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker -p dns-sinkhole; \
     fi
 
 # ============================================================
@@ -113,3 +114,22 @@ COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/ml-worker /u
 
 EXPOSE 8091
 CMD ["ml-worker"]
+
+# ============================================================
+# DNS sinkhole sidecar (RPZ-lite UDP proxy, P3 / #108)
+# ============================================================
+FROM alpine:3.21 AS dns-sinkhole
+RUN apk add --no-cache \
+    ca-certificates \
+    libgcc \
+    wget
+
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/dns-sinkhole /usr/local/bin/dns-sinkhole
+COPY examples/dns/blocklist.rpz /etc/bsdm-proxy/blocklist.rpz
+
+ENV DNS_SINKHOLE_ZONE_PATH=/etc/bsdm-proxy/blocklist.rpz \
+    DNS_SINKHOLE_BIND=0.0.0.0:53 \
+    METRICS_PORT=8092
+
+EXPOSE 53/udp 8092
+CMD ["dns-sinkhole"]

--- a/dns-sinkhole/Cargo.toml
+++ b/dns-sinkhole/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dns-sinkhole"
+version = "0.5.0"
+edition = "2021"
+license = "MIT"
+authors = ["BSDM-Proxy Contributors"]
+description = "Optional UDP DNS sinkhole / RPZ-lite proxy (sidecar, not in bsdm-proxy)"
+repository = "https://github.com/onixus/bsdm-proxy"
+keywords = ["dns", "rpz", "sinkhole", "security"]
+categories = ["network-programming"]
+
+[[bin]]
+name = "dns-sinkhole"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+prometheus = "0.14"
+
+[dev-dependencies]
+tokio = { workspace = true }
+tempfile = "3.14"

--- a/dns-sinkhole/src/config.rs
+++ b/dns-sinkhole/src/config.rs
@@ -1,0 +1,95 @@
+//! Runtime config from environment.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockAction {
+    /// Answer A/AAAA with configured sinkhole addresses.
+    Sinkhole,
+    /// Answer NXDOMAIN (RCODE=3).
+    NxDomain,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub enabled: bool,
+    pub bind: SocketAddr,
+    pub upstream: SocketAddr,
+    pub zone_path: String,
+    pub action: BlockAction,
+    pub sinkhole_a: [u8; 4],
+    pub sinkhole_aaaa: [u8; 16],
+    pub ttl: u32,
+    pub metrics_port: u16,
+    pub upstream_timeout: Duration,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, String> {
+        let enabled = env_bool("DNS_SINKHOLE_ENABLED", true);
+        let bind = std::env::var("DNS_SINKHOLE_BIND")
+            .unwrap_or_else(|_| "0.0.0.0:53".into())
+            .parse()
+            .map_err(|e| format!("DNS_SINKHOLE_BIND: {e}"))?;
+        let upstream = std::env::var("DNS_SINKHOLE_UPSTREAM")
+            .unwrap_or_else(|_| "1.1.1.1:53".into())
+            .parse()
+            .map_err(|e| format!("DNS_SINKHOLE_UPSTREAM: {e}"))?;
+        let zone_path = std::env::var("DNS_SINKHOLE_ZONE_PATH")
+            .map_err(|_| "DNS_SINKHOLE_ZONE_PATH is required".to_string())?;
+        let action = match std::env::var("DNS_SINKHOLE_ACTION")
+            .unwrap_or_else(|_| "sinkhole".into())
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "sinkhole" | "a" => BlockAction::Sinkhole,
+            "nxdomain" | "nx" => BlockAction::NxDomain,
+            other => return Err(format!("DNS_SINKHOLE_ACTION invalid: {other}")),
+        };
+        let sinkhole_a =
+            parse_ipv4(&std::env::var("DNS_SINKHOLE_A").unwrap_or_else(|_| "127.0.0.1".into()))?;
+        let sinkhole_aaaa =
+            parse_ipv6(&std::env::var("DNS_SINKHOLE_AAAA").unwrap_or_else(|_| "::1".into()))?;
+        let ttl = std::env::var("DNS_SINKHOLE_TTL")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(300_u32);
+        let metrics_port = std::env::var("METRICS_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(8092_u16);
+        let timeout_ms = std::env::var("DNS_SINKHOLE_UPSTREAM_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2_000_u64);
+        Ok(Self {
+            enabled,
+            bind,
+            upstream,
+            zone_path,
+            action,
+            sinkhole_a,
+            sinkhole_aaaa,
+            ttl: ttl.max(1),
+            metrics_port,
+            upstream_timeout: Duration::from_millis(timeout_ms.max(1)),
+        })
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    std::env::var(key)
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(default)
+}
+
+fn parse_ipv4(s: &str) -> Result<[u8; 4], String> {
+    let ip: std::net::Ipv4Addr = s.parse().map_err(|e| format!("DNS_SINKHOLE_A: {e}"))?;
+    Ok(ip.octets())
+}
+
+fn parse_ipv6(s: &str) -> Result<[u8; 16], String> {
+    let ip: std::net::Ipv6Addr = s.parse().map_err(|e| format!("DNS_SINKHOLE_AAAA: {e}"))?;
+    Ok(ip.octets())
+}

--- a/dns-sinkhole/src/dns.rs
+++ b/dns-sinkhole/src/dns.rs
@@ -1,0 +1,219 @@
+//! Minimal DNS message codec (UDP, single question).
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+pub const TYPE_A: u16 = 1;
+pub const TYPE_AAAA: u16 = 28;
+pub const CLASS_IN: u16 = 1;
+pub const RCODE_NXDOMAIN: u8 = 3;
+pub const RCODE_FORMERR: u8 = 1;
+pub const RCODE_SERVFAIL: u8 = 2;
+
+#[derive(Debug, Clone)]
+pub struct Question {
+    pub name: String,
+    pub qtype: u16,
+    pub qclass: u16,
+}
+
+#[derive(Debug, Clone)]
+pub struct Query {
+    pub id: u16,
+    pub recursion_desired: bool,
+    pub question: Question,
+    /// Raw bytes of the question section (for echo in responses).
+    pub question_bytes: Vec<u8>,
+}
+
+pub fn parse_query(buf: &[u8]) -> Result<Query, String> {
+    if buf.len() < 12 {
+        return Err("short header".into());
+    }
+    let id = u16::from_be_bytes([buf[0], buf[1]]);
+    let flags = u16::from_be_bytes([buf[2], buf[3]]);
+    let qdcount = u16::from_be_bytes([buf[4], buf[5]]);
+    if qdcount != 1 {
+        return Err(format!("expected 1 question, got {qdcount}"));
+    }
+    let qr = (flags >> 15) & 1;
+    if qr != 0 {
+        return Err("not a query".into());
+    }
+    let rd = (flags & 0x0100) != 0;
+
+    let (name, mut off) = read_name(buf, 12)?;
+    if off + 4 > buf.len() {
+        return Err("short question".into());
+    }
+    let qtype = u16::from_be_bytes([buf[off], buf[off + 1]]);
+    let qclass = u16::from_be_bytes([buf[off + 2], buf[off + 3]]);
+    off += 4;
+    let question_bytes = buf[12..off].to_vec();
+
+    Ok(Query {
+        id,
+        recursion_desired: rd,
+        question: Question {
+            name,
+            qtype,
+            qclass,
+        },
+        question_bytes,
+    })
+}
+
+fn read_name(buf: &[u8], mut off: usize) -> Result<(String, usize), String> {
+    let mut labels = Vec::new();
+    let mut jumped = false;
+    let mut end_off = off;
+    let mut hops = 0;
+    loop {
+        if off >= buf.len() {
+            return Err("name OOB".into());
+        }
+        let len = buf[off];
+        if len == 0 {
+            if !jumped {
+                end_off = off + 1;
+            }
+            break;
+        }
+        if len & 0xC0 == 0xC0 {
+            if off + 1 >= buf.len() {
+                return Err("bad pointer".into());
+            }
+            let ptr = (((len as u16) & 0x3F) << 8) | buf[off + 1] as u16;
+            if !jumped {
+                end_off = off + 2;
+            }
+            off = ptr as usize;
+            jumped = true;
+            hops += 1;
+            if hops > 10 {
+                return Err("pointer loop".into());
+            }
+            continue;
+        }
+        off += 1;
+        let end = off + len as usize;
+        if end > buf.len() {
+            return Err("label OOB".into());
+        }
+        let label = std::str::from_utf8(&buf[off..end]).map_err(|e| format!("label utf8: {e}"))?;
+        labels.push(label.to_ascii_lowercase());
+        off = end;
+        if !jumped {
+            end_off = off;
+        }
+    }
+    Ok((labels.join("."), end_off))
+}
+
+#[cfg(test)]
+pub fn encode_name(name: &str) -> Vec<u8> {
+    let mut out = Vec::new();
+    if name.is_empty() || name == "." {
+        out.push(0);
+        return out;
+    }
+    for label in name.trim_end_matches('.').split('.') {
+        let b = label.as_bytes();
+        out.push(b.len() as u8);
+        out.extend_from_slice(b);
+    }
+    out.push(0);
+    out
+}
+
+/// Build a response: NXDOMAIN or answers with A/AAAA.
+pub fn build_response(
+    query: &Query,
+    rcode: u8,
+    answers: &[(u16, u32, &[u8])], // (rtype, ttl, rdata)
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(128);
+    out.extend_from_slice(&query.id.to_be_bytes());
+    // QR=1, Opcode=0, AA=1 if we answered, RD copy, RA=1, RCODE
+    let mut flags: u16 = 0x8000; // QR
+    if query.recursion_desired {
+        flags |= 0x0100; // RD
+    }
+    flags |= 0x0080; // RA
+    if !answers.is_empty() {
+        flags |= 0x0400; // AA
+    }
+    flags |= rcode as u16;
+    out.extend_from_slice(&flags.to_be_bytes());
+    out.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT
+    out.extend_from_slice(&(answers.len() as u16).to_be_bytes()); // ANCOUNT
+    out.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+    out.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+    out.extend_from_slice(&query.question_bytes);
+
+    for (rtype, ttl, rdata) in answers {
+        // pointer to question name at offset 12
+        out.extend_from_slice(&[0xC0, 0x0C]);
+        out.extend_from_slice(&rtype.to_be_bytes());
+        out.extend_from_slice(&CLASS_IN.to_be_bytes());
+        out.extend_from_slice(&ttl.to_be_bytes());
+        out.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
+        out.extend_from_slice(rdata);
+    }
+    out
+}
+
+pub fn a_rdata(ip: Ipv4Addr) -> [u8; 4] {
+    ip.octets()
+}
+
+pub fn aaaa_rdata(ip: Ipv6Addr) -> [u8; 16] {
+    ip.octets()
+}
+
+pub fn formerr(id: u16) -> Vec<u8> {
+    let mut out = vec![0u8; 12];
+    out[0..2].copy_from_slice(&id.to_be_bytes());
+    out[2] = 0x80; // QR
+    out[3] = RCODE_FORMERR;
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_query(name: &str, qtype: u16) -> Vec<u8> {
+        let mut q = Vec::new();
+        q.extend_from_slice(&0x1234u16.to_be_bytes());
+        q.extend_from_slice(&0x0100u16.to_be_bytes()); // RD
+        q.extend_from_slice(&1u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&encode_name(name));
+        q.extend_from_slice(&qtype.to_be_bytes());
+        q.extend_from_slice(&CLASS_IN.to_be_bytes());
+        q
+    }
+
+    #[test]
+    fn roundtrip_query_and_a_answer() {
+        let raw = sample_query("blocked.test", TYPE_A);
+        let q = parse_query(&raw).unwrap();
+        assert_eq!(q.question.name, "blocked.test");
+        assert_eq!(q.question.qtype, TYPE_A);
+        let ip = Ipv4Addr::new(127, 0, 0, 1);
+        let resp = build_response(&q, 0, &[(TYPE_A, 300, &a_rdata(ip))]);
+        assert_eq!(&resp[0..2], &0x1234u16.to_be_bytes());
+        assert_eq!(resp[3] & 0x0f, 0); // NOERROR
+        assert_eq!(u16::from_be_bytes([resp[6], resp[7]]), 1); // ANCOUNT
+    }
+
+    #[test]
+    fn nxdomain_rcode() {
+        let raw = sample_query("x.test", TYPE_A);
+        let q = parse_query(&raw).unwrap();
+        let resp = build_response(&q, RCODE_NXDOMAIN, &[]);
+        assert_eq!(resp[3] & 0x0f, RCODE_NXDOMAIN);
+    }
+}

--- a/dns-sinkhole/src/main.rs
+++ b/dns-sinkhole/src/main.rs
@@ -1,0 +1,108 @@
+mod config;
+mod dns;
+mod server;
+mod zone;
+
+use config::Config;
+use prometheus::{Encoder, TextEncoder};
+use server::Metrics;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::{error, info};
+use zone::Zone;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,dns_sinkhole=info".into()),
+        )
+        .init();
+
+    let cfg = Config::from_env().map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+    if !cfg.enabled {
+        info!("DNS_SINKHOLE_ENABLED=false — exiting");
+        return Ok(());
+    }
+
+    let zone = Zone::load_path(Path::new(&cfg.zone_path)).map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+    info!(
+        path = %cfg.zone_path,
+        rules = zone.len(),
+        "zone loaded"
+    );
+
+    let metrics = Arc::new(Metrics::new()?);
+    {
+        let metrics = metrics.clone();
+        let port = cfg.metrics_port;
+        tokio::spawn(async move {
+            run_admin(port, metrics).await;
+        });
+    }
+
+    let zone = Arc::new(zone);
+    server::run(cfg, zone, metrics).await?;
+    Ok(())
+}
+
+async fn run_admin(port: u16, metrics: Arc<Metrics>) {
+    let addr = format!("0.0.0.0:{port}");
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("admin bind {addr}: {e}");
+            return;
+        }
+    };
+    info!("admin http://{addr}/health");
+    loop {
+        let Ok((mut sock, _)) = listener.accept().await else {
+            continue;
+        };
+        let metrics = metrics.clone();
+        tokio::spawn(async move {
+            let mut buf = [0u8; 1024];
+            let _ = sock.read(&mut buf).await;
+            let req = String::from_utf8_lossy(&buf);
+            let (status, body, ctype) = if req.starts_with("GET /health") {
+                ("200 OK", b"ok\n".as_slice(), "text/plain")
+            } else if req.starts_with("GET /metrics") {
+                let encoder = TextEncoder::new();
+                let families = metrics.registry.gather();
+                let mut buf = Vec::new();
+                if encoder.encode(&families, &mut buf).is_ok() {
+                    let body = String::from_utf8_lossy(&buf).into_owned();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    return;
+                }
+                (
+                    "500 Internal Server Error",
+                    b"encode error\n".as_slice(),
+                    "text/plain",
+                )
+            } else {
+                ("404 Not Found", b"not found\n".as_slice(), "text/plain")
+            };
+            let resp = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: {ctype}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.write_all(body).await;
+        });
+    }
+}

--- a/dns-sinkhole/src/server.rs
+++ b/dns-sinkhole/src/server.rs
@@ -1,0 +1,262 @@
+//! UDP DNS proxy loop.
+
+use crate::config::{BlockAction, Config};
+use crate::dns::{
+    a_rdata, aaaa_rdata, build_response, formerr, parse_query, Query, CLASS_IN, RCODE_NXDOMAIN,
+    RCODE_SERVFAIL, TYPE_A, TYPE_AAAA,
+};
+use crate::zone::{Zone, ZoneAction};
+use prometheus::{IntCounter, Registry};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tracing::{debug, info, warn};
+
+pub struct Metrics {
+    pub queries: IntCounter,
+    pub blocked: IntCounter,
+    pub forwarded: IntCounter,
+    pub errors: IntCounter,
+    pub registry: Registry,
+}
+
+impl Metrics {
+    pub fn new() -> Result<Self, String> {
+        let registry = Registry::new();
+        let queries = IntCounter::new("dns_sinkhole_queries_total", "DNS queries received")
+            .map_err(|e| e.to_string())?;
+        let blocked = IntCounter::new("dns_sinkhole_blocked_total", "Queries blocked by zone")
+            .map_err(|e| e.to_string())?;
+        let forwarded =
+            IntCounter::new("dns_sinkhole_forwarded_total", "Queries forwarded upstream")
+                .map_err(|e| e.to_string())?;
+        let errors = IntCounter::new("dns_sinkhole_errors_total", "Handler errors")
+            .map_err(|e| e.to_string())?;
+        registry
+            .register(Box::new(queries.clone()))
+            .map_err(|e| e.to_string())?;
+        registry
+            .register(Box::new(blocked.clone()))
+            .map_err(|e| e.to_string())?;
+        registry
+            .register(Box::new(forwarded.clone()))
+            .map_err(|e| e.to_string())?;
+        registry
+            .register(Box::new(errors.clone()))
+            .map_err(|e| e.to_string())?;
+        Ok(Self {
+            queries,
+            blocked,
+            forwarded,
+            errors,
+            registry,
+        })
+    }
+}
+
+pub async fn run(cfg: Config, zone: Arc<Zone>, metrics: Arc<Metrics>) -> Result<(), String> {
+    let sock = Arc::new(
+        UdpSocket::bind(cfg.bind)
+            .await
+            .map_err(|e| format!("bind {}: {e}", cfg.bind))?,
+    );
+    info!(
+        bind = %cfg.bind,
+        upstream = %cfg.upstream,
+        zone_rules = zone.len(),
+        action = ?cfg.action,
+        "dns-sinkhole listening"
+    );
+
+    let mut buf = vec![0u8; 4096];
+    loop {
+        let (n, peer) = match sock.recv_from(&mut buf).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("recv: {e}");
+                metrics.errors.inc();
+                continue;
+            }
+        };
+        metrics.queries.inc();
+        let packet = buf[..n].to_vec();
+        let sock = sock.clone();
+        let zone = zone.clone();
+        let metrics = metrics.clone();
+        let cfg = cfg.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle_one(&sock, peer, &packet, &cfg, &zone, &metrics).await {
+                debug!("handle {peer}: {e}");
+                metrics.errors.inc();
+            }
+        });
+    }
+}
+
+async fn handle_one(
+    sock: &UdpSocket,
+    peer: SocketAddr,
+    packet: &[u8],
+    cfg: &Config,
+    zone: &Zone,
+    metrics: &Metrics,
+) -> Result<(), String> {
+    let query = match parse_query(packet) {
+        Ok(q) => q,
+        Err(e) => {
+            let id = if packet.len() >= 2 {
+                u16::from_be_bytes([packet[0], packet[1]])
+            } else {
+                0
+            };
+            let _ = sock.send_to(&formerr(id), peer).await;
+            return Err(e);
+        }
+    };
+
+    if query.question.qclass != CLASS_IN {
+        let resp = build_response(&query, 0, &[]);
+        sock.send_to(&resp, peer)
+            .await
+            .map_err(|e| format!("send: {e}"))?;
+        return Ok(());
+    }
+
+    if let Some(action) = zone.lookup(&query.question.name) {
+        metrics.blocked.inc();
+        let resp = build_block_response(cfg, &query, action);
+        sock.send_to(&resp, peer)
+            .await
+            .map_err(|e| format!("send: {e}"))?;
+        return Ok(());
+    }
+
+    metrics.forwarded.inc();
+    let upstream = forward(cfg, packet).await?;
+    sock.send_to(&upstream, peer)
+        .await
+        .map_err(|e| format!("send: {e}"))?;
+    Ok(())
+}
+
+fn build_block_response(cfg: &Config, query: &Query, action: &ZoneAction) -> Vec<u8> {
+    match action {
+        ZoneAction::A(ip) if query.question.qtype == TYPE_A || query.question.qtype == 255 => {
+            let rdata = a_rdata(*ip);
+            build_response(query, 0, &[(TYPE_A, cfg.ttl, &rdata)])
+        }
+        ZoneAction::Aaaa(ip)
+            if query.question.qtype == TYPE_AAAA || query.question.qtype == 255 =>
+        {
+            let rdata = aaaa_rdata(*ip);
+            build_response(query, 0, &[(TYPE_AAAA, cfg.ttl, &rdata)])
+        }
+        ZoneAction::A(_) | ZoneAction::Aaaa(_) => {
+            // Wrong type for explicit RR — empty NOERROR (NODATA)
+            build_response(query, 0, &[])
+        }
+        ZoneAction::Policy => match cfg.action {
+            BlockAction::NxDomain => build_response(query, RCODE_NXDOMAIN, &[]),
+            BlockAction::Sinkhole => match query.question.qtype {
+                TYPE_A => {
+                    let ip = Ipv4Addr::from(cfg.sinkhole_a);
+                    let rdata = a_rdata(ip);
+                    build_response(query, 0, &[(TYPE_A, cfg.ttl, &rdata)])
+                }
+                TYPE_AAAA => {
+                    let ip = Ipv6Addr::from(cfg.sinkhole_aaaa);
+                    let rdata = aaaa_rdata(ip);
+                    build_response(query, 0, &[(TYPE_AAAA, cfg.ttl, &rdata)])
+                }
+                _ => build_response(query, RCODE_NXDOMAIN, &[]),
+            },
+        },
+    }
+}
+
+async fn forward(cfg: &Config, packet: &[u8]) -> Result<Vec<u8>, String> {
+    let sock = UdpSocket::bind("0.0.0.0:0")
+        .await
+        .map_err(|e| format!("upstream bind: {e}"))?;
+    sock.send_to(packet, cfg.upstream)
+        .await
+        .map_err(|e| format!("upstream send: {e}"))?;
+    let mut buf = vec![0u8; 4096];
+    let result = tokio::time::timeout(cfg.upstream_timeout, sock.recv_from(&mut buf)).await;
+    match result {
+        Ok(Ok((n, _))) => Ok(buf[..n].to_vec()),
+        Ok(Err(e)) => Err(format!("upstream recv: {e}")),
+        Err(_) => Err("upstream timeout".into()),
+    }
+}
+
+/// SERVFAIL helper for tests / callers.
+#[allow(dead_code)]
+pub fn servfail(query: &Query) -> Vec<u8> {
+    build_response(query, RCODE_SERVFAIL, &[])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dns::{encode_name, CLASS_IN, TYPE_A};
+    use std::time::Duration;
+
+    fn sample_query(name: &str, qtype: u16) -> Vec<u8> {
+        let mut q = Vec::new();
+        q.extend_from_slice(&0xABCDu16.to_be_bytes());
+        q.extend_from_slice(&0x0100u16.to_be_bytes());
+        q.extend_from_slice(&1u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&0u16.to_be_bytes());
+        q.extend_from_slice(&encode_name(name));
+        q.extend_from_slice(&qtype.to_be_bytes());
+        q.extend_from_slice(&CLASS_IN.to_be_bytes());
+        q
+    }
+
+    #[tokio::test]
+    async fn blocks_zone_name_with_sinkhole() {
+        let zone = Arc::new(Zone::parse("blocked.test CNAME .\n").unwrap());
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cfg = Config {
+            enabled: true,
+            bind: "127.0.0.1:0".parse().unwrap(),
+            upstream: "1.1.1.1:53".parse().unwrap(),
+            zone_path: String::new(),
+            action: BlockAction::Sinkhole,
+            sinkhole_a: [127, 0, 0, 1],
+            sinkhole_aaaa: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            ttl: 60,
+            metrics_port: 0,
+            upstream_timeout: Duration::from_millis(500),
+        };
+        let sock = Arc::new(UdpSocket::bind(cfg.bind).await.unwrap());
+        let addr = sock.local_addr().unwrap();
+        let zone_c = zone.clone();
+        let metrics_c = metrics.clone();
+        let cfg_c = cfg.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 512];
+            let (n, peer) = sock.recv_from(&mut buf).await.unwrap();
+            handle_one(&sock, peer, &buf[..n], &cfg_c, &zone_c, &metrics_c)
+                .await
+                .unwrap();
+        });
+
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let q = sample_query("blocked.test", TYPE_A);
+        client.send_to(&q, addr).await.unwrap();
+        let mut buf = [0u8; 512];
+        let (n, _) = tokio::time::timeout(Duration::from_secs(2), client.recv_from(&mut buf))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(n > 12);
+        assert_eq!(buf[3] & 0x0f, 0); // NOERROR
+        assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 1); // ANCOUNT
+        assert_eq!(&buf[n - 4..n], &[127, 0, 0, 1]);
+        assert_eq!(metrics.blocked.get(), 1);
+    }
+}

--- a/dns-sinkhole/src/zone.rs
+++ b/dns-sinkhole/src/zone.rs
@@ -1,0 +1,191 @@
+//! RPZ-lite / plain domain blocklist loader.
+
+use std::collections::HashMap;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoneAction {
+    /// Use global sinkhole / NXDOMAIN policy.
+    Policy,
+    /// Explicit A from zone file.
+    A(Ipv4Addr),
+    /// Explicit AAAA from zone file.
+    Aaaa(Ipv6Addr),
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Zone {
+    /// Exact FQDN (lowercase, no trailing dot) → action.
+    exact: HashMap<String, ZoneAction>,
+    /// Suffix match: hostname ends with `.{suffix}` or equals suffix.
+    suffixes: Vec<(String, ZoneAction)>,
+}
+
+impl Zone {
+    pub fn load_path(path: &Path) -> Result<Self, String> {
+        let text = std::fs::read_to_string(path).map_err(|e| format!("read zone: {e}"))?;
+        Self::parse(&text)
+    }
+
+    pub fn parse(text: &str) -> Result<Self, String> {
+        let mut zone = Self::default();
+        for (lineno, raw) in text.lines().enumerate() {
+            let cleaned = strip_comment(raw);
+            let line = cleaned.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if line.starts_with('$') {
+                // $TTL etc. — ignore for PoC
+                continue;
+            }
+            parse_line(&mut zone, line).map_err(|e| format!("zone line {}: {e}", lineno + 1))?;
+        }
+        Ok(zone)
+    }
+
+    pub fn lookup(&self, qname: &str) -> Option<&ZoneAction> {
+        let name = normalize_name(qname);
+        if let Some(a) = self.exact.get(&name) {
+            return Some(a);
+        }
+        for (suf, action) in &self.suffixes {
+            if name == *suf || name.ends_with(&format!(".{suf}")) {
+                return Some(action);
+            }
+        }
+        None
+    }
+
+    pub fn len(&self) -> usize {
+        self.exact.len() + self.suffixes.len()
+    }
+}
+
+fn strip_comment(line: &str) -> String {
+    let mut out = String::new();
+    let mut in_quote = false;
+    for ch in line.chars() {
+        if ch == '"' {
+            in_quote = !in_quote;
+        }
+        if !in_quote && (ch == ';' || ch == '#') {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn normalize_name(name: &str) -> String {
+    let n = name.trim().trim_end_matches('.').to_ascii_lowercase();
+    n
+}
+
+fn parse_line(zone: &mut Zone, line: &str) -> Result<(), String> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.is_empty() {
+        return Ok(());
+    }
+
+    // Plain list: single token (optional leading '.' for suffix)
+    if parts.len() == 1 {
+        let tok = parts[0];
+        if let Some(suf) = tok.strip_prefix('.') {
+            zone.suffixes
+                .push((normalize_name(suf), ZoneAction::Policy));
+        } else {
+            zone.exact.insert(normalize_name(tok), ZoneAction::Policy);
+        }
+        return Ok(());
+    }
+
+    // RPZ-lite: name [TTL] type rdata...
+    let name_raw = parts[0];
+    let mut idx = 1;
+    // skip optional TTL
+    if parts
+        .get(idx)
+        .is_some_and(|p| p.chars().all(|c| c.is_ascii_digit()))
+    {
+        idx += 1;
+    }
+    // skip optional class IN
+    if parts.get(idx).is_some_and(|p| p.eq_ignore_ascii_case("IN")) {
+        idx += 1;
+    }
+    let rtype = parts
+        .get(idx)
+        .ok_or_else(|| "missing RR type".to_string())?
+        .to_ascii_uppercase();
+    idx += 1;
+    let rdata = parts.get(idx..).unwrap_or(&[]).join(" ");
+
+    let (is_suffix, name) = if let Some(s) = name_raw.strip_prefix("*.") {
+        (true, normalize_name(s))
+    } else {
+        (false, normalize_name(name_raw))
+    };
+
+    let action = match rtype.as_str() {
+        "CNAME" => {
+            // CNAME .  → policy block
+            ZoneAction::Policy
+        }
+        "A" => {
+            let ip: Ipv4Addr = rdata.parse().map_err(|e| format!("A rdata: {e}"))?;
+            ZoneAction::A(ip)
+        }
+        "AAAA" => {
+            let ip: Ipv6Addr = rdata.parse().map_err(|e| format!("AAAA rdata: {e}"))?;
+            ZoneAction::Aaaa(ip)
+        }
+        other => return Err(format!("unsupported RR type {other}")),
+    };
+
+    if is_suffix {
+        zone.suffixes.push((name, action));
+    } else {
+        zone.exact.insert(name, action);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_rpz() {
+        let z = Zone::parse(
+            r#"
+; comment
+blocked.test. CNAME .
+*.evil.example. CNAME .
+fixed.test. A 10.0.0.1
+malware.example
+.blocked.suffix
+"#,
+        )
+        .unwrap();
+        assert!(matches!(z.lookup("blocked.test"), Some(ZoneAction::Policy)));
+        assert!(matches!(
+            z.lookup("a.evil.example"),
+            Some(ZoneAction::Policy)
+        ));
+        assert!(matches!(
+            z.lookup("fixed.test"),
+            Some(ZoneAction::A(ip)) if *ip == Ipv4Addr::new(10, 0, 0, 1)
+        ));
+        assert!(matches!(
+            z.lookup("malware.example"),
+            Some(ZoneAction::Policy)
+        ));
+        assert!(matches!(
+            z.lookup("x.blocked.suffix"),
+            Some(ZoneAction::Policy)
+        ));
+        assert!(z.lookup("clean.example").is_none());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,6 +294,35 @@ services:
       timeout: 5s
       retries: 10
 
+  # Optional DNS sinkhole sidecar (P3 / #108). RPZ-lite UDP proxy — not in proxy core.
+  #   docker compose --profile dns-sinkhole up -d --build dns-sinkhole
+  # Docs: docs/dns-sinkhole.md · ADR 0004
+  dns-sinkhole:
+    profiles: ["dns-sinkhole"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dns-sinkhole
+    ports:
+      - "5353:53/udp"
+      - "8092:8092"
+    environment:
+      - DNS_SINKHOLE_BIND=0.0.0.0:53
+      - DNS_SINKHOLE_UPSTREAM=${DNS_SINKHOLE_UPSTREAM:-1.1.1.1:53}
+      - DNS_SINKHOLE_ZONE_PATH=/etc/bsdm-proxy/blocklist.rpz
+      - DNS_SINKHOLE_ACTION=${DNS_SINKHOLE_ACTION:-sinkhole}
+      - DNS_SINKHOLE_A=${DNS_SINKHOLE_A:-127.0.0.1}
+      - METRICS_PORT=8092
+      - RUST_LOG=info,dns_sinkhole=info
+    networks:
+      - bsdm-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8092/health | grep -q ok"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
 networks:
   bsdm-net:
     driver: bridge

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@
 | [acl.md](acl.md) | ACL + REST API |
 | [control-plane.md](control-plane.md) | DX: stats, purge, hierarchy/TLS reload, ACL CRUD |
 | [wasm-plugins.md](wasm-plugins.md) | Wasmtime request hooks (feature `wasm`) |
+| [dns-sinkhole.md](dns-sinkhole.md) | Optional DNS RPZ-lite sidecar |
+| [adr/0004-dns-sinkhole-sidecar.md](adr/0004-dns-sinkhole-sidecar.md) | ADR: DNS as sidecar, not in proxy |
 | [categorization.md](categorization.md) | UT1 Blacklists, metrics, OTX |
 | [hierarchical-caching.md](hierarchical-caching.md) | ICP/HTCP hierarchy |
 | [clickhouse-analytics.md](clickhouse-analytics.md) | ClickHouse analytics |

--- a/docs/adr/0004-dns-sinkhole-sidecar.md
+++ b/docs/adr/0004-dns-sinkhole-sidecar.md
@@ -1,0 +1,28 @@
+# ADR 0004: DNS sinkhole as sidecar (not in proxy)
+
+**Status:** Accepted  
+**Date:** 2026-07-17  
+**Relates:** [#108](https://github.com/onixus/bsdm-proxy/issues/108), [dns-sinkhole.md](../dns-sinkhole.md), [swg-backlog-mapping.md](../swg-backlog-mapping.md) P3-4
+
+## Context
+
+Enterprise SWGs often advertise a **DNS security** layer (Umbrella-style): resolve-time block/sinkhole before HTTP. BSDM-Proxy is an **explicit forward proxy** with MITM, cache, and ACL. Issue #108 asks for an optional DNS module and a **scope decision**.
+
+## Decision
+
+1. **Do not** embed a DNS server or RPZ engine inside `bsdm-proxy`. DNS is a different on-ramp; coupling it to CONNECT/MITM would confuse ops and fight the documented anti-pattern “DNS-first pipeline as Umbrella”.
+2. Ship a **separate workspace binary** `dns-sinkhole`: UDP DNS proxy that applies an RPZ-lite / domain blocklist, then forwards remaining queries to an upstream resolver.
+3. Deploy as an **optional Compose profile** (and Docker target), same pattern as `alert-worker` / `ml-worker` / `icap`.
+4. Keep the PoC protocol surface small: UDP, single-question queries, A/AAAA answers, NXDOMAIN or fixed sinkhole IPs. Full BIND RPZ, DoH/DoT, and DNSSEC validation are follow-ups.
+
+## Consequences
+
+- New crate `dns-sinkhole`, docs, example zone, Dockerfile stage, compose profile.
+- Proxy ACL/UT1 remain the HTTP policy plane; DNS is complementary.
+- Closes #108 acceptance: design doc + basic RPZ/DNS proxy sketch (implemented PoC).
+
+## Non-goals
+
+- Replacing corporate Unbound/BIND
+- Inline DNS from the proxy process
+- Encrypted DNS (DoH/DoT) in v0

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,7 @@ bsdm-proxy/
 │       └── lib.rs
 ├── cache-indexer/      # Kafka|HTTP → ClickHouse|SQLite + Search API
 ├── ml-worker/          # M5 features/scores + threat-score API
+├── dns-sinkhole/       # Optional DNS RPZ-lite sidecar (P3)
 ├── alert-worker/       # M4 webhook alerts
 ├── bsdm-events/        # Shared CacheEvent types
 ├── e2e/                # Smoke и E2E тесты

--- a/docs/dns-sinkhole.md
+++ b/docs/dns-sinkhole.md
@@ -1,0 +1,97 @@
+# DNS sinkhole / DNS security (P3)
+
+Optional **DNS-layer** filtering (Cisco Umbrella–style first hop). Separate on-ramp from the explicit forward proxy.
+
+Issue: [#108](https://github.com/onixus/bsdm-proxy/issues/108) · Mapping: [swg-backlog-mapping.md](swg-backlog-mapping.md) P3-4 · ADR: [adr/0004-dns-sinkhole-sidecar.md](adr/0004-dns-sinkhole-sidecar.md)
+
+## Scope decision
+
+| Option | Verdict |
+|--------|---------|
+| Inline in `bsdm-proxy` hot path | **Rejected** — different on-ramp; pollutes cache/MITM path ([swg anti-pattern](swg-backlog-mapping.md)) |
+| Full recursive resolver / BIND RPZ | **Out of scope** for PoC — ops already have Unbound/BIND |
+| **Sidecar UDP DNS proxy** (`dns-sinkhole` crate) | **Accepted** — blocklist/RPZ-lite → sinkhole or NXDOMAIN; else forward to upstream |
+
+Clients point DHCP/DoH stub / container `dns:` at this service. The HTTPS proxy keeps ACL/UT1; DNS is an optional first hop.
+
+## Status (PoC)
+
+| Item | Status |
+|------|--------|
+| Design / ADR | ✅ |
+| Crate `dns-sinkhole` (UDP :53) | ✅ |
+| RPZ-lite zone file + plain domain list | ✅ |
+| Sinkhole A/AAAA or NXDOMAIN | ✅ |
+| Forward to upstream resolver | ✅ |
+| Compose profile `dns-sinkhole` | ✅ |
+| DoH / DoT / DNSSEC validation | ❌ later |
+| Full RFC RPZ (client-IP triggers, NSDNAME, …) | ❌ sketch only |
+
+## Run
+
+```bash
+# Blocklist example (RPZ-lite + plain names)
+DNS_SINKHOLE_ENABLED=true \
+DNS_SINKHOLE_BIND=0.0.0.0:5353 \
+DNS_SINKHOLE_UPSTREAM=1.1.1.1:53 \
+DNS_SINKHOLE_ZONE_PATH=examples/dns/blocklist.rpz \
+DNS_SINKHOLE_ACTION=sinkhole \
+DNS_SINKHOLE_A=127.0.0.1 \
+cargo run -p dns-sinkhole
+
+# Query
+dig @127.0.0.1 -p 5353 blocked.test A +short
+# → 127.0.0.1
+```
+
+| Env | Default | Role |
+|-----|---------|------|
+| `DNS_SINKHOLE_BIND` | `0.0.0.0:53` | UDP listen |
+| `DNS_SINKHOLE_UPSTREAM` | `1.1.1.1:53` | Forward resolver |
+| `DNS_SINKHOLE_ZONE_PATH` | — | Required path to zone/list file |
+| `DNS_SINKHOLE_ACTION` | `sinkhole` | `sinkhole` \| `nxdomain` |
+| `DNS_SINKHOLE_A` | `127.0.0.1` | Sinkhole IPv4 |
+| `DNS_SINKHOLE_AAAA` | `::1` | Sinkhole IPv6 |
+| `DNS_SINKHOLE_TTL` | `300` | Answer TTL |
+| `METRICS_PORT` | `8092` | `/health` + `/metrics` |
+| `DNS_SINKHOLE_ENABLED` | `true` | Set `false` to no-op exit (compose convenience) |
+
+## Zone file (RPZ-lite sketch)
+
+```text
+; comment
+$TTL 300
+blocked.test.          CNAME .
+*.evil.example.        CNAME .
+phishing.test.         A     127.0.0.1
+
+# plain list (suffix match if leading '.')
+malware.example
+.blocked.suffix
+```
+
+- `CNAME .` → treat as policy block (same as action)
+- Explicit `A` / `AAAA` in zone override sinkhole defaults for that name
+- Leading `.` on a bare name → suffix match
+
+## Compose
+
+```bash
+docker compose --profile dns-sinkhole up -d --build dns-sinkhole
+# Clients / other containers: dns: ["dns-sinkhole"]  or publish 53/udp
+```
+
+## Relation to proxy
+
+| Plane | Mechanism |
+|-------|-----------|
+| DNS first hop | This sidecar |
+| Explicit HTTP(S) proxy | ACL + categorization + Wasm + ICAP |
+
+No shared runtime. Optional future: feed sinkhole hits into ClickHouse via a small logger (not in PoC).
+
+## Tests
+
+```bash
+cargo test -p dns-sinkhole
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,7 +11,7 @@
 | Файл | Назначение |
 |------|------------|
 | `docker-compose.lite.yml` | **Lite:** proxy + SQLite indexer (MITM + L1 spill), без Kafka/CH |
-| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, **alertmanager**, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`) |
+| `docker-compose.yml` | Полный стек: proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, **alertmanager**, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`), `dns-sinkhole` (`--profile dns-sinkhole`) |
 | `docker-compose.test.yml` | Smoke/E2E external (upstream + proxy) |
 | `docker-compose.redis-l2.yml` | Два proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |
@@ -63,6 +63,15 @@ ALERT_WEBHOOK_URL=https://siem.example/hooks/bsdm \
 ```
 
 Docs: [alerting.md](alerting.md).
+
+### DNS sinkhole sidecar
+
+```bash
+docker compose --profile dns-sinkhole up -d --build dns-sinkhole
+# dig @127.0.0.1 -p 5353 blocked.test A +short
+```
+
+Docs: [dns-sinkhole.md](dns-sinkhole.md).
 
 ### Grafana / Alertmanager (M4)
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -21,17 +21,15 @@ Blockers B1–B26: all ✅ in [BLOCKERS.md](BLOCKERS.md) (GitHub #32–#56).
 
 | Issue | Title | Notes |
 |-------|-------|-------|
-| [#108](https://github.com/onixus/bsdm-proxy/issues/108) | DNS sinkhole / DNS security | P3 backlog |
-| [#99](https://github.com/onixus/bsdm-proxy/issues/99) | ICAP adapter | P3 backlog |
+| [#99](https://github.com/onixus/bsdm-proxy/issues/99) | ICAP adapter | P3 — PR in flight / merge pending |
 
 ## Next strategic backlog
 
 | Issue | Phase |
 |-------|-------|
 | [#99](https://github.com/onixus/bsdm-proxy/issues/99) | P3 ICAP adapter |
-| [#108](https://github.com/onixus/bsdm-proxy/issues/108) | P3 DNS sinkhole |
 
-*(#101 / #103 / #189 / #187 / #188 closed via implementation PRs.)*
+*(#108 DNS sinkhole closed via implementation PR; #101 / #103 / #189 / #187 / #188 closed earlier.)*
 
 
 ---

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -10,6 +10,7 @@
 | `cache-indexer` | `cache-indexer/` | Kafka|HTTP → ClickHouse|SQLite, Search API, `/metrics` |
 | `alert-worker` | `alert-worker/` | ClickHouse threat rules → SIEM/webhook (M4 / B19) |
 | `ml-worker` | `ml-worker/` | M5 features/scores + threat-score API |
+| `dns-sinkhole` | `dns-sinkhole/` | Optional DNS RPZ-lite sinkhole sidecar (P3 / #108) |
 | `bsdm-events` | `bsdm-events/` | Общие типы событий (`CacheEvent`) для proxy и indexer |
 | `e2e` | `e2e/` | Smoke и E2E тесты (subprocess proxy + mock upstream) |
 
@@ -27,6 +28,7 @@ bsdm-proxy/
 │       └── lib.rs
 ├── cache-indexer/          # Kafka|HTTP → ClickHouse|SQLite + Search API
 ├── ml-worker/              # M5 features/scores + threat-score API
+├── dns-sinkhole/           # Optional DNS RPZ-lite sidecar
 ├── alert-worker/           # CH rule polling → webhook / SIEM
 ├── bsdm-events/            # Shared event schema
 ├── e2e/                    # Integration tests
@@ -41,7 +43,7 @@ bsdm-proxy/
 ├── alertmanager/           # Alertmanager template + entrypoint
 ├── web-config/             # Legacy static config generator
 ├── certs/                  # MITM CA (gitignored, генерируется локально)
-├── Dockerfile              # Multi-stage: proxy + cache-indexer + alert-worker + ml-worker
+├── Dockerfile              # Multi-stage: proxy + cache-indexer + alert-worker + ml-worker + dns-sinkhole
 ├── docker-compose.yml      # Полный стек (+ profiles `alerts`, `ml`)
 ├── docker-compose.lite.yml # Lite: proxy + SQLite indexer (Phase 1)
 ├── docker-compose.*.yml    # Профили: test, redis-l2, hierarchy, ha
@@ -53,7 +55,7 @@ bsdm-proxy/
 | Файл | Сервисы |
 |------|---------|
 | `docker-compose.lite.yml` | proxy + SQLite cache-indexer (MITM + L1 spill, no Kafka/CH) |
-| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, alertmanager, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`) |
+| `docker-compose.yml` | proxy, cache-indexer, kafka, zookeeper, clickhouse, prometheus, alertmanager, grafana; optional `alert-worker` (`--profile alerts`), `ml-worker` (`--profile ml`), `dns-sinkhole` (`--profile dns-sinkhole`) |
 | `docker-compose.test.yml` | Минимальный стек для smoke/E2E |
 | `docker-compose.redis-l2.yml` | 2× proxy + Redis L2 |
 | `docker-compose.hierarchy.yml` | Multi-instance + ICP |

--- a/docs/swg-backlog-mapping.md
+++ b/docs/swg-backlog-mapping.md
@@ -125,7 +125,7 @@
 | P3-1 | ICAP adapter (optional AV/URL) | legacy enterprise | sidecar pattern |
 | P3-2 | Event enrichment: `acl_action`, `threat_sources` | Netskope data lake | M3 schema |
 | P3-3 ✅ | Categorization Prometheus metrics | all | M4 |
-| P3-4 | DNS sinkhole module (optional) | Cisco Umbrella layer 1 | separate crate |
+| P3-4 | DNS sinkhole module (optional) | Cisco Umbrella layer 1 | separate crate ✅ [#108](https://github.com/onixus/bsdm-proxy/issues/108) |
 
 ### P4+ — Не копировать в v1
 
@@ -261,7 +261,7 @@ gantt
 | P3-1 | [#99](https://github.com/onixus/bsdm-proxy/issues/99) ICAP adapter | P3 |
 | P3-2 | [#102](https://github.com/onixus/bsdm-proxy/issues/102) Event schema enrichment | P3 |
 | P3-3 ✅ | [#105](https://github.com/onixus/bsdm-proxy/issues/105) Categorization metrics | P3 |
-| P3-4 | [#108](https://github.com/onixus/bsdm-proxy/issues/108) DNS sinkhole module | P3 |
+| P3-4 ✅ | [#108](https://github.com/onixus/bsdm-proxy/issues/108) DNS sinkhole module | P3 |
 
 P0-1 / P0-2 tracked by PR [#93](https://github.com/onixus/bsdm-proxy/pull/93) and PR [#92](https://github.com/onixus/bsdm-proxy/pull/92).
 

--- a/examples/dns/blocklist.rpz
+++ b/examples/dns/blocklist.rpz
@@ -1,0 +1,14 @@
+; BSDM DNS sinkhole example (RPZ-lite + plain list)
+; See docs/dns-sinkhole.md
+$TTL 300
+
+; Policy blocks → sinkhole A/AAAA or NXDOMAIN (DNS_SINKHOLE_ACTION)
+blocked.test.           CNAME .
+*.evil.example.         CNAME .
+
+; Explicit sinkhole address for one name
+fixed-sinkhole.test.    A     127.0.0.1
+
+; Plain domain list
+malware.example
+.blocked.suffix

--- a/packaging/config/dns-sinkhole.env.example
+++ b/packaging/config/dns-sinkhole.env.example
@@ -1,0 +1,10 @@
+# Optional DNS sinkhole sidecar (separate binary; not in proxy)
+# See docs/dns-sinkhole.md · ADR 0004
+# DNS_SINKHOLE_BIND=0.0.0.0:53
+# DNS_SINKHOLE_UPSTREAM=1.1.1.1:53
+# DNS_SINKHOLE_ZONE_PATH=/etc/bsdm-proxy/blocklist.rpz
+# DNS_SINKHOLE_ACTION=sinkhole
+# DNS_SINKHOLE_A=127.0.0.1
+# DNS_SINKHOLE_AAAA=::1
+# DNS_SINKHOLE_TTL=300
+# METRICS_PORT=8092


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Optional **DNS sinkhole** sidecar (Umbrella-style first hop). **Closes #108**.

### Scope decision (ADR 0004)
DNS stays **out of** `bsdm-proxy` — different on-ramp from explicit forward proxy. New workspace binary `dns-sinkhole`.

### PoC
- UDP DNS proxy: RPZ-lite / plain blocklist → sinkhole A/AAAA or NXDOMAIN; else forward upstream
- Docs: [docs/dns-sinkhole.md](docs/dns-sinkhole.md), [docs/adr/0004-dns-sinkhole-sidecar.md](docs/adr/0004-dns-sinkhole-sidecar.md)
- Compose profile `dns-sinkhole`, Dockerfile target, example `examples/dns/blocklist.rpz`

### Merge
Rebased/merged `main` after #195 (ICAP) — compose/docs keep **both** `icap` and `dns-sinkhole` profiles.

### Test plan
- [x] `cargo test -p dns-sinkhole`
- [x] `cargo test -p bsdm-proxy icap` (post-merge)
- [x] Conflict resolution with main
- [ ] Full CI green after merge commit

### Non-goals
DoH/DoT, full BIND RPZ, DNSSEC validation, inline proxy DNS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

