### PR TITLE
release: 0.5.07.033 (Cargo 0.5.7+033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7+033] - 2026-07-17
+
+Release **0.5.07.033** (Cargo/semver `0.5.7+033`). Post-M5: DX control plane, Wasm, AI traffic helpers, P3 ICAP + DNS sinkhole.
+
 ### Added
 
 - **DNS sinkhole sidecar** — workspace crate `dns-sinkhole` (UDP RPZ-lite proxy); ADR 0004; compose profile `dns-sinkhole`; docs [dns-sinkhole.md](docs/dns-sinkhole.md) ([#108](https://github.com/onixus/bsdm-proxy/issues/108))
@@ -36,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Squid rock ↔ BSDM spill sizing** — [docs/capacity-planning.md](docs/capacity-planning.md) mapping + HA example ([#101](https://github.com/onixus/bsdm-proxy/issues/101))
 - **Issue tracker hygiene** — [docs/issue-tracker.md](docs/issue-tracker.md); close completed epics #165/#125/#102/#112; backlog #187 gRPC, #188 Wasm, #189 vector DB; BLOCKERS wave 3 strikethrough
 - **Project docs refresh** — README / architecture / development / structure / docker / deployment / wiki index / env.example aligned with M1–M5 done and DX/AI Unreleased (Lite = proxy+SQLite, control plane, event sink, hierarchy peers paths, threat-score vars)
+
+Release package: `./scripts/build-package.sh` → `dist/bsdm-proxy-0.5.7.033-linux-<arch>.tar.gz`  
+Notes: [docs/releases/v0.5.7+033.md](docs/releases/v0.5.7+033.md)
 
 ## [0.5.0] - 2026-07-16
 
@@ -183,6 +190,7 @@ Beta — hierarchical caching Phase 3, optional MITM CA.
 
 [GitHub Releases](https://github.com/onixus/bsdm-proxy/releases/tag/v0.2.2b)
 
+[0.5.7+033]: https://github.com/onixus/bsdm-proxy/compare/v0.5.0...v0.5.7+033
 [0.5.0]: https://github.com/onixus/bsdm-proxy/compare/v0.3.2...v0.5.0
 [0.3.2]: https://github.com/onixus/bsdm-proxy/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/onixus/bsdm-proxy/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "alert-worker"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "chrono",
  "hex",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-events"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "chrono",
  "serde",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-proxy"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "arc-swap",
  "base64",
@@ -521,7 +521,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cache-indexer"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "bsdm-events",
  "bytes",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "dns-sinkhole"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "prometheus",
  "tempfile",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "ml-worker"
-version = "0.5.0"
+version = "0.5.7+033"
 dependencies = [
  "chrono",
  "prometheus",

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 [![E2E Tests](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml/badge.svg)](https://github.com/onixus/bsdm-proxy/actions/workflows/e2e.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
+[![Version](https://img.shields.io/badge/version-0.5.07.033-blue.svg)](https://github.com/onixus/bsdm-proxy/releases)
 [![Rust](https://img.shields.io/badge/rust-1.88+-orange.svg)](https://www.rust-lang.org)
 
-> **Текущая версия:** `0.5.0` · M1–M5 done · DX/AI prep in Unreleased — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
+> **Текущая версия:** `0.5.07.033` (Cargo `0.5.7+033`) · M1–M5 + DX/Wasm/AI/P3 — см. [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](CHANGELOG.md) · [roadmap](docs/roadmap.md)
 
 ⚠️ **MITM-прокси для HTTPS.** Используйте только в корпоративной среде с согласия пользователей и в рамках законодательства.
 
@@ -160,13 +160,13 @@ Grafana: http://localhost:3000 → **BSDM HTTP Traffic (ClickHouse)** и **BSDM 
 ./scripts/build-package.sh
 ```
 
-Архив: `dist/bsdm-proxy-0.5.0-linux-<arch>.tar.gz`
+Архив: `dist/bsdm-proxy-0.5.7.033-linux-<arch>.tar.gz`
 
 Установка:
 
 ```bash
-tar xzf dist/bsdm-proxy-0.5.0-linux-x86_64.tar.gz
-cd bsdm-proxy-0.5.0-linux-x86_64
+tar xzf dist/bsdm-proxy-0.5.7.033-linux-x86_64.tar.gz
+cd bsdm-proxy-0.5.7.033-linux-x86_64
 sudo ./install.sh --create-user --systemd
 sudo cp certs/ca.key certs/ca.crt /certs/
 sudo systemctl start bsdm-proxy
@@ -515,6 +515,7 @@ CI: [rust.yml](.github/workflows/rust.yml) (fmt, clippy, build, test, cargo-audi
 | [docs/strategic-roadmap.md](docs/strategic-roadmap.md) | Стратегия: Lite, DX, Wasm, AI |
 | [docs/capacity-planning.md](docs/capacity-planning.md) | Планирование ёмкости (корп. сценарии) |
 | [CHANGELOG.md](CHANGELOG.md) | История изменений |
+| [docs/releases/v0.5.7+033.md](docs/releases/v0.5.7+033.md) | Release notes 0.5.07.033 |
 | [docs/releases/v0.5.0.md](docs/releases/v0.5.0.md) | Release notes 0.5.0 (M4) |
 | [docs/releases/v0.3.2.md](docs/releases/v0.3.2.md) | Release notes 0.3.2 |
 | [docs/releases/v0.3.1.md](docs/releases/v0.3.1.md) | Release notes 0.3.1 |

--- a/alert-worker/Cargo.toml
+++ b/alert-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alert-worker"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/bsdm-events/Cargo.toml
+++ b/bsdm-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-events"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 description = "Shared HTTP cache event schema for BSDM-Proxy Kafka pipeline"

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-indexer"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/charts/bsdm/Chart.yaml
+++ b/charts/bsdm/Chart.yaml
@@ -3,7 +3,7 @@ name: bsdm
 description: BSDM-Proxy forward proxy with optional Redis L2
 type: application
 version: 0.1.2
-appVersion: "0.5.0"
+appVersion: "0.5.7+033"
 keywords:
   - proxy
   - cache

--- a/dns-sinkhole/Cargo.toml
+++ b/dns-sinkhole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-sinkhole"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Центральное оглавление. Страницы wiki — в каталоге `docs/`.
 
-**Текущая версия:** 0.5.0 · M1–M5 done · Unreleased: DX/AI · Analytics: Kafka → ClickHouse (или Lite: HTTP → SQLite) · [roadmap](roadmap.md)
+**Текущая версия:** 0.5.07.033 (Cargo `0.5.7+033`) · M1–M5 + DX/Wasm/AI/P3 · Analytics: Kafka → ClickHouse (или Lite: HTTP → SQLite) · [roadmap](roadmap.md)
 
 ## Начало работы
 
@@ -18,7 +18,8 @@
 | [structure.md](structure.md) | Структура репозитория |
 | [licensing.md](licensing.md) | Лицензии и third-party |
 | [CHANGELOG.md](../CHANGELOG.md) | История изменений |
-| [releases/v0.5.0.md](releases/v0.5.0.md) | **Release notes 0.5.0** (M4) |
+| [releases/v0.5.7+033.md](releases/v0.5.7+033.md) | **Release notes 0.5.07.033** |
+| [releases/v0.5.0.md](releases/v0.5.0.md) | Release notes 0.5.0 (M4) |
 | [releases/v0.3.2.md](releases/v0.3.2.md) | Release notes 0.3.2 |
 | [releases/v0.3.1.md](releases/v0.3.1.md) | Release notes 0.3.1 (ClickHouse migration) |
 | [releases/v0.3.0.md](releases/v0.3.0.md) | Release notes 0.3.0 (M2) |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,8 +58,8 @@ docker compose -f docker-compose.test.yml up -d --build
 ```bash
 ./scripts/build-package.sh
 
-tar xzf dist/bsdm-proxy-0.5.0-linux-x86_64.tar.gz
-cd bsdm-proxy-0.5.0-linux-x86_64
+tar xzf dist/bsdm-proxy-0.5.7.033-linux-x86_64.tar.gz
+cd bsdm-proxy-0.5.7.033-linux-x86_64
 sudo ./install.sh --create-user --systemd
 sudo cp /path/to/ca.key /path/to/ca.crt /certs/
 sudo systemctl enable --now bsdm-proxy
@@ -136,7 +136,7 @@ proxy ──► Kafka ──► cache-indexer ──► ClickHouse (bsdm.http_ca
 
 | Артефакт | Версия |
 |----------|--------|
-| Текущий release | **0.5.0** |
+| Текущий release | **0.5.07.033** (`0.5.7+033`) |
 | Kafka (compose) | Confluent `7.9.8` |
 | ClickHouse (compose) | см. `docker-compose.yml` |
 | Rust (минимум) | `1.88+` |

--- a/docs/releases/v0.5.7+033.md
+++ b/docs/releases/v0.5.7+033.md
@@ -1,0 +1,71 @@
+# Release v0.5.07.033
+
+**Cargo / semver:** `0.5.7+033` (тег `v0.5.7+033`)  
+**Запрошенный идентификатор:** `0.5.07.033` — в Cargo недопустим (leading zeros / 4 сегмента), поэтому build-metadata `+033`.  
+**Тип:** stable release (post-M5: DX / Wasm / AI / P3 ICAP+DNS)  
+**Дата:** 2026-07-17  
+**База:** `main` после merge #185–#197
+
+> Пакет: `bsdm-proxy-0.5.7.033-linux-<arch>.tar.gz` (`+` → `.` в имени архива).
+
+## Highlights (с 0.5.0)
+
+### P3 threat / enterprise sidecars
+
+| Функция | Описание | Issue / PR |
+|---------|----------|------------|
+| **ICAP adapter** | REQMOD/RESPMOD, `ICAP_ENABLED`, compose profile `icap` | [#99](https://github.com/onixus/bsdm-proxy/issues/99) / [#195](https://github.com/onixus/bsdm-proxy/pull/195) |
+| **DNS sinkhole** | Sidecar `dns-sinkhole`, RPZ-lite, ADR 0004 | [#108](https://github.com/onixus/bsdm-proxy/issues/108) / [#197](https://github.com/onixus/bsdm-proxy/pull/197) |
+
+### Strategic: DX / Wasm / AI
+
+| Функция | Описание | Issue / PR |
+|---------|----------|------------|
+| **Wasm hooks** | Feature `wasm`, Wasmtime 46, PoC deny-suffix | [#188](https://github.com/onixus/bsdm-proxy/issues/188) / [#194](https://github.com/onixus/bsdm-proxy/pull/194) |
+| **gRPC control plane** | Feature `grpc`, stats/purge/hierarchy/TLS | [#187](https://github.com/onixus/bsdm-proxy/issues/187) / [#193](https://github.com/onixus/bsdm-proxy/pull/193) |
+| **Peer mTLS** | `HIERARCHY_PEER_MTLS_*` | [#103](https://github.com/onixus/bsdm-proxy/issues/103) |
+| **Qdrant / semantic** | `SEMANTIC_VECTOR_BACKEND=local\|qdrant` | [#189](https://github.com/onixus/bsdm-proxy/issues/189) |
+| **Spill sizing guide** | capacity-planning ↔ Squid rock | [#101](https://github.com/onixus/bsdm-proxy/issues/101) |
+| **REST DX** | ACL CRUD, purge tags, hierarchy/TLS reload, `/api/stats` | control-plane docs |
+| **AI traffic** | API-key RL, MISS coalescing, LLM semantic cache | semantic-cache docs |
+| **M5 complete** | ml-worker UEBA / phishing / C&C / write-back | [#165](https://github.com/onixus/bsdm-proxy/issues/165) |
+
+## Сборка
+
+```bash
+cargo build --release \
+  -p bsdm-proxy --bin proxy \
+  -p cache-indexer --bin cache-indexer \
+  -p alert-worker --bin alert-worker \
+  -p ml-worker --bin ml-worker \
+  -p dns-sinkhole --bin dns-sinkhole
+
+./scripts/build-package.sh
+# → dist/bsdm-proxy-0.5.7.033-linux-<arch>.tar.gz
+```
+
+## Установка
+
+```bash
+tar xzf dist/bsdm-proxy-0.5.7.033-linux-x86_64.tar.gz
+cd bsdm-proxy-0.5.7.033-linux-x86_64
+sudo ./install.sh --create-user --systemd
+sudo systemctl start bsdm-proxy bsdm-cache-indexer
+```
+
+Optional sidecars: compose profiles `icap`, `dns-sinkhole`, `ml`, `alerts` — см. [docker.md](../docker.md).
+
+## GitHub Release
+
+```bash
+git tag -a 'v0.5.7+033' -m 'BSDM-Proxy v0.5.07.033 (0.5.7+033)'
+git push origin 'v0.5.7+033'
+```
+
+Workflow [release.yml](../../.github/workflows/release.yml) publishes linux packages.
+
+## Docs
+
+- [CHANGELOG.md](../../CHANGELOG.md)
+- [dns-sinkhole.md](../dns-sinkhole.md) · [icap.md](../icap.md) · [wasm-plugins.md](../wasm-plugins.md)
+- [strategic-roadmap.md](../strategic-roadmap.md) · [issue-tracker.md](../issue-tracker.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@
 | **Ретропоиск** | Поиск и аналитика по историческому HTTP-трафику |
 | **ML-безопасность** | Аномалии, фишинг и C&C поверх логов и поведенческих сигналов |
 
-Текущая версия: **0.5.0** · [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](../CHANGELOG.md)
+Текущая версия: **0.5.07.033** (`0.5.7+033`) · [Releases](https://github.com/onixus/bsdm-proxy/releases) · [CHANGELOG](../CHANGELOG.md)
 
 Стратегический вектор (Lite → DX → Wasm → AI): **[strategic-roadmap.md](strategic-roadmap.md)**
 

--- a/ml-worker/Cargo.toml
+++ b/ml-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ml-worker"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -2,7 +2,7 @@
 
 Установка из готового release-архива. Общая документация: [README.md](../README.md) · [docs/README.md](../docs/README.md)
 
-**Текущая версия пакета:** `0.5.0` — [release notes](../docs/releases/v0.5.0.md) · [CHANGELOG](../CHANGELOG.md)
+**Текущая версия пакета:** `0.5.7.033` (Cargo `0.5.7+033` / marketing `0.5.07.033`) — [release notes](../docs/releases/v0.5.7+033.md) · [CHANGELOG](../CHANGELOG.md)
 
 ## Contents
 
@@ -21,8 +21,8 @@
 ## Quick start
 
 ```bash
-tar xzf bsdm-proxy-0.5.0-linux-x86_64.tar.gz
-cd bsdm-proxy-0.5.0-linux-x86_64
+tar xzf bsdm-proxy-0.5.7.033-linux-x86_64.tar.gz
+cd bsdm-proxy-0.5.7.033-linux-x86_64
 sudo ./install.sh --create-user --systemd
 ```
 
@@ -74,7 +74,7 @@ cat VERSION
 
 ```bash
 ./scripts/build-package.sh
-# → dist/bsdm-proxy-0.5.0-linux-<arch>.tar.gz
+# → dist/bsdm-proxy-0.5.7.033-linux-<arch>.tar.gz
 ```
 
 См. также [docs/development.md](../docs/development.md).

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-proxy"
-version = "0.5.0"
+version = "0.5.7+033"
 edition = "2021"
 license = "MIT"
 

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -6,9 +6,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 VERSION="$(grep '^version' proxy/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
-# Cargo 0.2.2-b → 0.2.2b, 0.2.3-test → 0.2.3test
+# Cargo 0.2.2-b → 0.2.2b, 0.2.3-test → 0.2.3test, 0.5.7+033 → 0.5.7.033
 PACKAGE_VERSION="${VERSION//-b/b}"
 PACKAGE_VERSION="${PACKAGE_VERSION//-test/test}"
+PACKAGE_VERSION="${PACKAGE_VERSION//+/.}"
 ARCH="$(uname -m)"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 PACKAGE_NAME="bsdm-proxy-${PACKAGE_VERSION}-${OS}-${ARCH}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cut release **0.5.07.033**.

Cargo/semver cannot express `0.5.07.033` (leading zeros / four segments), so crates use **`0.5.7+033`**. Package tarball name maps `+` → `.` → `bsdm-proxy-0.5.7.033-linux-*.tar.gz`. Git tag after merge: **`v0.5.7+033`**.

## Includes (since 0.5.0)
M5 complete, DX control plane, Wasm, AI traffic helpers, ICAP (#99), DNS sinkhole (#108). Notes: [docs/releases/v0.5.7+033.md](docs/releases/v0.5.7+033.md).

## After merge
```bash
git checkout main && git pull
git tag -a 'v0.5.7+033' -m 'BSDM-Proxy v0.5.07.033 (0.5.7+033)'
git push origin 'v0.5.7+033'
```
→ triggers [release.yml](.github/workflows/release.yml).

## Test plan
- [x] `cargo metadata` accepts `0.5.7+033`
- [x] `extract-release-notes.sh v0.5.7+033`
- [ ] CI green
- [ ] Tag + GitHub Release artifacts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08bb5882-99c3-4d38-acfc-6b1b0fc6046a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

