### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -12,6 +12,9 @@ on:
       - 'proxy/**'
   workflow_dispatch: # Позволяет запускать тесты вручную из интерфейса GitHub
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Run wrk Load Test


### PR DESCRIPTION
Potential fix for [https://github.com/onixus/bsdm-proxy/security/code-scanning/21](https://github.com/onixus/bsdm-proxy/security/code-scanning/21)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout`)

Best fix (without changing functionality):  
Edit `.github/workflows/load-test.yml` and insert:

```yaml
permissions:
  contents: read
```

directly after the `on:` section (before `jobs:`), so the `benchmark` job inherits it automatically.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
