### PR TITLE
feat(admin-console): UI overhaul — data honesty, monitoring charts, i…

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -57,6 +57,20 @@ jobs:
             fi
           done
 
+          echo "Ожидание запуска mock-upstream..."
+          for i in {1..30}; do
+            if curl -s -I http://localhost:18080/ping | grep -q "HTTP/"; then
+              echo "✅ mock-upstream успешно запущен и отвечает!"
+              break
+            fi
+            sleep 1
+            if [ $i -eq 30 ]; then
+              echo "❌ mock-upstream не запустился за 30 секунд. Логи контейнера:"
+              docker compose -f docker-compose.lite.yml logs mock-upstream
+              exit 1
+            fi
+          done
+
       - name: Run Standard Load Test Script
         run: |
           chmod +x ./scripts/run-load-test.sh

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -35,13 +35,14 @@ jobs:
       - name: Start bsdm-proxy (Lite Mode)
         run: |
           # Запускаем облегченный стек без Kafka/ClickHouse, чтобы не ловить OOM на воркере
-          docker compose -f docker-compose.lite.yml up -d proxy
-          
+          # (mock-upstream делит network namespace с proxy — см. docker-compose.lite.yml)
+          docker compose -f docker-compose.lite.yml up -d mock-upstream
+
       - name: Wait for Proxy Readiness
         run: |
           echo "Ожидание запуска прокси-сервера..."
           for i in {1..30}; do
-            if curl -s -I http://localhost:8080 | grep -q "HTTP/"; then
+            if curl -s -I http://localhost:9090/health | grep -q "HTTP/"; then
               echo "✅ bsdm-proxy успешно запущен и отвечает!"
               break
             fi
@@ -56,13 +57,15 @@ jobs:
       - name: Run Standard Load Test Script
         run: |
           chmod +x ./scripts/run-load-test.sh
-          ./scripts/run-load-test.sh
+          PROXY=http://127.0.0.1:1488 METRICS_URL=http://127.0.0.1:9090 UPSTREAM=http://127.0.0.1:18080 \
+            ./scripts/run-load-test.sh
 
       - name: Run High-Intensity wrk Benchmark (Lua Script)
         run: |
           echo "=== Запуск бенчмарка wrk с использованием wrk-proxy.lua ==="
           # Настройки адаптированы под 2 ядра GitHub воркера (-t2)
-          wrk -t2 -c100 -d30s -s ./scripts/wrk-proxy.lua http://localhost:8080
+          # wrk-proxy.lua использует прокси как forward-proxy (см. usage в самом файле)
+          wrk -t2 -c100 -d30s -s ./scripts/wrk-proxy.lua http://localhost:1488
           
       - name: Container Resource Metrics
         if: always()

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Generate MITM CA (docker-compose.lite.yml has MITM_ENABLED=true)
+        run: ./scripts/gen-ca.sh
+
       - name: Start bsdm-proxy (Lite Mode)
         run: |
           # Запускаем облегченный стек без Kafka/ClickHouse, чтобы не ловить OOM на воркере

--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -10,18 +10,31 @@ Replaces the legacy static [`web-config/`](../web-config/) generator with a mode
 |-------|--------|
 | Framework | React 19 + TypeScript |
 | Build | Vite 8 |
-| Styling | Tailwind CSS 4 (`@theme` design tokens) |
+| Styling | Tailwind CSS 4 (`@theme inline` tokens, runtime dark/light switch) |
+| Data fetching | TanStack Query (polling, retry, stale-while-revalidate) |
 | Routing | React Router 7 (client-side, no full page reloads) |
+| Charts | Hand-rolled SVG (line/sparkline/segment/bar-list) — no chart library |
 | Icons | lucide-react |
 
 ## Routes
 
 | Path | Purpose |
 |------|---------|
-| `/` | Dashboard — metric widgets, ML anomaly summary |
-| `/logs` | Retro-search logs + XAI modal on blocked requests |
+| `/` | Dashboard — RED metrics from Prometheus `/metrics` + `/api/stats`, live charts, top upstreams, ML anomalies, hierarchy peers |
+| `/logs` | Retro-search with server+client filters, live tail, pagination, CSV export, session timeline, XAI modal |
+| `/analytics` | Aggregations over the search sample: traffic over time, status/cache/decision mix, top talkers, threat severity |
+| `/threat-scores` | ML write-back snapshot with model filter and traffic drill-down |
 | `/policies` | Runtime ACL rules viewer / reload |
-| `/settings` | Config generator + API endpoint configuration |
+| `/settings` | Live node state + config generator (cache, auth, filtering, threat/ML, hierarchy/TLS, rate-limit/eBPF/Wasm, events) |
+
+## Data honesty
+
+Every fetcher returns `Sourced<T>` — payload plus provenance (`live` or `demo`).
+A failed request renders a real **error state**; sample data appears **only**
+when the user enables demo mode (Settings → Console API), and is always marked
+with a "Demo" badge. Pages whose backend endpoints don't exist yet (RPZ, Wasm,
+Cluster Mesh, AI Cache, eBPF stats) carry an explicit "Preview — no backend
+endpoint" banner.
 
 ## Quick start
 

--- a/admin-console/package-lock.json
+++ b/admin-console/package-lock.json
@@ -8,6 +8,7 @@
       "name": "admin-console",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.101.4",
         "lucide-react": "^1.25.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -995,6 +996,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.101.4",
     "lucide-react": "^1.25.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import { AppLayout } from './components/layout/AppLayout'
 import { AiSemanticCachePage } from './pages/AiSemanticCache'
+import { AnalyticsPage } from './pages/Analytics'
 import { ClusterMeshPage } from './pages/ClusterMesh'
 import { DashboardPage } from './pages/Dashboard'
 import { LogsPage } from './pages/Logs'
@@ -17,6 +18,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/logs" element={<LogsPage />} />
+          <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/threat-scores" element={<ThreatScoresPage />} />
           <Route path="/policies" element={<PoliciesPage />} />
           <Route path="/rpz" element={<RpzManagementPage />} />

--- a/admin-console/src/api/metrics.ts
+++ b/admin-console/src/api/metrics.ts
@@ -1,25 +1,8 @@
 import { loadApiSettings } from './settings'
 import { apiFetch } from './client'
-import { fetchThreatScores } from './threatScores'
-
-export interface DashboardMetric {
-  id: string
-  label: string
-  value: string | number
-  trend?: 'up' | 'down' | 'flat'
-  unit?: string
-  status?: 'ok' | 'warn' | 'error'
-}
-
-export interface MlScoreRow {
-  entity_id: string
-  entity_type: string
-  score: number
-  severity: string
-  model: string
-  scored_at: string
-  features_json?: string
-}
+import { demo, live, isDemoMode, type Sourced } from './source'
+import { groupByLabel, histogram, histogramQuantile, scrapeMetrics, sumMetric, type PromSample } from './prometheus'
+import { recordCounter, recordGauge, series, type TsPoint } from '../lib/timeseries'
 
 export interface ProxyStats {
   service: string
@@ -34,6 +17,38 @@ export interface ProxyStats {
     capacity: number
     shards: number
   }
+}
+
+export interface LatencyQuantiles {
+  p50: number
+  p95: number
+  p99: number
+}
+
+/** Everything the monitoring dashboard needs from one poll cycle. */
+export interface Telemetry {
+  stats: ProxyStats | null
+  /** Trailing-window series accumulated across polls (per-second rates / gauges). */
+  reqRate: TsPoint[]
+  errRate: TsPoint[]
+  denyRate: TsPoint[]
+  hitRatio: TsPoint[]
+  inFlight: TsPoint[]
+  latP95: TsPoint[]
+  /** Request latency quantiles in seconds (from the Prometheus histogram). */
+  latency: LatencyQuantiles | null
+  /** Cumulative request counts grouped by HTTP status class ("2xx"…). */
+  statusClasses: Record<string, number>
+  /** Cumulative request counts grouped by cache disposition (HIT/MISS/…). */
+  cacheStatus: Record<string, number>
+  /** Cumulative ACL decisions by action. */
+  aclDecisions: Record<string, number>
+  /** Top upstream hosts by cumulative request count. */
+  topUpstreams: { host: string; requests: number; errors: number }[]
+  totalRequests: number
+  cacheEvictions: number
+  rateLimitRejected: number
+  tlsHandshakeFailures: number
 }
 
 export async function fetchProxyStats(): Promise<ProxyStats | null> {
@@ -60,69 +75,156 @@ export async function purgeCache(body: {
   })
 }
 
-export async function fetchDashboardMetrics(): Promise<DashboardMetric[]> {
-  const stats = await fetchProxyStats()
-  if (stats) {
-    return [
-      {
-        id: 'hit-rate',
-        label: 'Cache hit rate',
-        value: (stats.cache.hit_ratio * 100).toFixed(1),
-        unit: '%',
-        status: 'ok',
-      },
-      { id: 'hits', label: 'Cache hits', value: stats.cache.hits, status: 'ok' },
-      { id: 'misses', label: 'Cache misses', value: stats.cache.misses, status: 'ok' },
-      {
-        id: 'entries',
-        label: 'L1 entries',
-        value: `${stats.cache.entries}/${stats.cache.capacity}`,
-        status: 'ok',
-      },
-      {
-        id: 'inflight',
-        label: 'In flight',
-        value: stats.requests_in_flight,
-        status: 'ok',
-      },
-      {
-        id: 'uptime',
-        label: 'Uptime',
-        value: formatUptime(stats.uptime_secs),
-        status: 'ok',
-      },
-    ]
+const WINDOW_MS = 30 * 60_000
+
+/**
+ * One dashboard poll: /api/stats + /metrics scrape, recorded into the
+ * in-memory time-series store so charts build up history across refreshes.
+ */
+export async function fetchTelemetry(): Promise<Sourced<Telemetry>> {
+  try {
+    const settings = loadApiSettings()
+    const [stats, snap] = await Promise.all([
+      apiFetch<ProxyStats>('/api/stats', { baseUrl: settings.metricsBaseUrl }),
+      scrapeMetrics().catch(() => null),
+    ])
+
+    const t = Date.now()
+    recordGauge('cache.hitRatio', stats.cache.hit_ratio * 100, t)
+    recordGauge('inflight', stats.requests_in_flight, t)
+    recordCounter('cache.hits', stats.cache.hits, t)
+
+    let latency: LatencyQuantiles | null = null
+    let statusClasses: Record<string, number> = {}
+    let cacheStatus: Record<string, number> = {}
+    let aclDecisions: Record<string, number> = {}
+    let topUpstreams: Telemetry['topUpstreams'] = []
+    let totalRequests = stats.cache.hits + stats.cache.misses + stats.cache.bypasses
+    let cacheEvictions = 0
+    let rateLimitRejected = 0
+    let tlsHandshakeFailures = 0
+
+    if (snap) {
+      const s = snap.samples
+      totalRequests = sumMetric(s, 'bsdm_proxy_requests_total')
+      recordCounter('req.rate', totalRequests, t)
+      recordCounter(
+        'req.err.rate',
+        sumMetric(s, 'bsdm_proxy_requests_total', (l) => l.status?.startsWith('5') ?? false),
+        t,
+      )
+      recordCounter(
+        'acl.deny.rate',
+        sumMetric(s, 'bsdm_proxy_acl_decisions_total', (l) => l.action !== 'allow'),
+        t,
+      )
+
+      const h = histogram(s, 'bsdm_proxy_request_duration_seconds')
+      if (h && h.count > 0) {
+        latency = {
+          p50: histogramQuantile(h, 0.5) ?? 0,
+          p95: histogramQuantile(h, 0.95) ?? 0,
+          p99: histogramQuantile(h, 0.99) ?? 0,
+        }
+        recordGauge('lat.p95', latency.p95 * 1000, t)
+      }
+
+      statusClasses = groupByStatusClass(s)
+      cacheStatus = Object.fromEntries(groupByLabel(s, 'bsdm_proxy_requests_total', 'cache_status'))
+      aclDecisions = Object.fromEntries(groupByLabel(s, 'bsdm_proxy_acl_decisions_total', 'action'))
+      topUpstreams = upstreamTable(s)
+      cacheEvictions = sumMetric(s, 'bsdm_proxy_cache_evictions_total')
+      rateLimitRejected = sumMetric(s, 'bsdm_proxy_rate_limit_rejected_total')
+      tlsHandshakeFailures = sumMetric(s, 'bsdm_proxy_tls_handshakes_total', (l) => l.status !== 'success')
+    } else {
+      // /metrics unreachable — still derive a request rate from cache counters.
+      recordCounter('req.rate', totalRequests, t)
+    }
+
+    return live<Telemetry>({
+      stats,
+      reqRate: series('req.rate', WINDOW_MS),
+      errRate: series('req.err.rate', WINDOW_MS),
+      denyRate: series('acl.deny.rate', WINDOW_MS),
+      hitRatio: series('cache.hitRatio', WINDOW_MS),
+      inFlight: series('inflight', WINDOW_MS),
+      latP95: series('lat.p95', WINDOW_MS),
+      latency,
+      statusClasses,
+      cacheStatus,
+      aclDecisions,
+      topUpstreams,
+      totalRequests,
+      cacheEvictions,
+      rateLimitRejected,
+      tlsHandshakeFailures,
+    })
+  } catch (err) {
+    if (isDemoMode()) return demo(demoTelemetry())
+    throw err
   }
-  return mockMetrics()
 }
 
-export async function fetchTopMlScores(): Promise<MlScoreRow[]> {
-  const snap = await fetchThreatScores()
-  return snap.scores
-    .slice()
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 10)
-    .map((s) => ({
-      entity_id: s.entity_id,
-      entity_type: s.entity_type,
-      score: s.score,
-      severity: s.severity,
-      model: s.model,
-      scored_at: s.scored_at,
+function groupByStatusClass(samples: PromSample[]): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const s of samples) {
+    if (s.name !== 'bsdm_proxy_requests_total') continue
+    const status = s.labels.status ?? ''
+    const key = status ? `${status[0]}xx` : '(none)'
+    out[key] = (out[key] ?? 0) + s.value
+  }
+  return out
+}
+
+function upstreamTable(samples: PromSample[]): Telemetry['topUpstreams'] {
+  const requests = groupByLabel(samples, 'bsdm_proxy_upstream_requests_total', 'host')
+  const errors = groupByLabel(samples, 'bsdm_proxy_upstream_errors_total', 'host')
+  return [...requests.entries()]
+    .map(([host, reqs]) => ({ host, requests: reqs, errors: errors.get(host) ?? 0 }))
+    .sort((a, b) => b.requests - a.requests)
+    .slice(0, 8)
+}
+
+/** Synthetic telemetry for explicit demo mode only. */
+function demoTelemetry(): Telemetry {
+  const now = Date.now()
+  const mk = (base: number, jitter: number, n = 60): TsPoint[] =>
+    Array.from({ length: n }, (_, i) => ({
+      t: now - (n - 1 - i) * 10_000,
+      v: Math.max(0, base + Math.sin(i / 6) * jitter + (Math.random() - 0.5) * jitter),
     }))
+  return {
+    stats: {
+      service: 'bsdm-proxy (demo)',
+      uptime_secs: 86_400 * 3 + 4_520,
+      requests_in_flight: 12,
+      cache: { hits: 112_400, misses: 16_400, bypasses: 2_100, hit_ratio: 0.872, entries: 8_204, capacity: 10_000, shards: 16 },
+    },
+    reqRate: mk(420, 60),
+    errRate: mk(3, 2),
+    denyRate: mk(8, 4),
+    hitRatio: mk(87, 3),
+    inFlight: mk(12, 6),
+    latP95: mk(38, 10),
+    latency: { p50: 0.006, p95: 0.038, p99: 0.121 },
+    statusClasses: { '2xx': 118_204, '3xx': 6_120, '4xx': 4_890, '5xx': 386 },
+    cacheStatus: { HIT: 112_400, MISS: 16_400, BYPASS: 2_100, DENIED: 3_400 },
+    aclDecisions: { allow: 126_300, deny: 3_400 },
+    topUpstreams: [
+      { host: 'cdn.example.com', requests: 48_200, errors: 12 },
+      { host: 'api.example.com', requests: 22_100, errors: 96 },
+      { host: 'static.example.org', requests: 9_450, errors: 0 },
+    ],
+    totalRequests: 130_900,
+    cacheEvictions: 1_240,
+    rateLimitRejected: 86,
+    tlsHandshakeFailures: 14,
+  }
 }
 
-function formatUptime(secs: number): string {
+export function formatUptime(secs: number): string {
   if (secs < 60) return `${secs}s`
   if (secs < 3600) return `${Math.floor(secs / 60)}m`
-  return `${(secs / 3600).toFixed(1)}h`
-}
-
-function mockMetrics(): DashboardMetric[] {
-  return [
-    { id: 'hit-rate', label: 'Cache hit rate', value: '87.2', unit: '%', trend: 'up', status: 'ok' },
-    { id: 'hits', label: 'Cache hits', value: 11240, trend: 'up', status: 'ok' },
-    { id: 'misses', label: 'Cache misses', value: 1640, trend: 'flat', status: 'ok' },
-    { id: 'entries', label: 'L1 entries', value: '3200/10000', status: 'ok' },
-  ]
+  if (secs < 86_400) return `${(secs / 3600).toFixed(1)}h`
+  return `${Math.floor(secs / 86_400)}d ${Math.floor((secs % 86_400) / 3600)}h`
 }

--- a/admin-console/src/api/node.ts
+++ b/admin-console/src/api/node.ts
@@ -1,0 +1,46 @@
+import { apiFetch } from './client'
+import { loadApiSettings } from './settings'
+import { demo, isDemoMode, live, type Sourced } from './source'
+
+/** Live control-plane state of this proxy node (real endpoints on the metrics port). */
+
+export interface HierarchyPeer {
+  name?: string
+  host?: string
+  http_port?: number
+  icp_port?: number
+  peer_type?: string
+  state?: string
+  [key: string]: unknown
+}
+
+export interface UpstreamTlsStatus {
+  [key: string]: unknown
+}
+
+export async function fetchHierarchyPeers(): Promise<Sourced<HierarchyPeer[]>> {
+  const settings = loadApiSettings()
+  try {
+    const res = await apiFetch<HierarchyPeer[] | { peers: HierarchyPeer[] }>('/api/hierarchy/peers', {
+      baseUrl: settings.metricsBaseUrl,
+    })
+    return live(Array.isArray(res) ? res : (res.peers ?? []))
+  } catch (err) {
+    if (isDemoMode())
+      return demo([
+        { name: 'parent-dc1', host: '10.0.2.1', http_port: 3128, icp_port: 3130, peer_type: 'parent', state: 'alive' },
+        { name: 'sibling-dc2', host: '10.0.2.2', http_port: 3128, icp_port: 3130, peer_type: 'sibling', state: 'alive' },
+      ])
+    throw err
+  }
+}
+
+export async function fetchUpstreamTls(): Promise<Sourced<UpstreamTlsStatus>> {
+  const settings = loadApiSettings()
+  try {
+    return live(await apiFetch<UpstreamTlsStatus>('/api/upstream/tls', { baseUrl: settings.metricsBaseUrl }))
+  } catch (err) {
+    if (isDemoMode()) return demo({ mode: 'system-roots', client_certs: 0, note: 'demo' })
+    throw err
+  }
+}

--- a/admin-console/src/api/prometheus.ts
+++ b/admin-console/src/api/prometheus.ts
@@ -47,7 +47,12 @@ function parseLabels(raw: string): Record<string, string> {
   const re = /([a-zA-Z_][a-zA-Z0-9_]*)="((?:[^"\\]|\\.)*)"/g
   let m: RegExpExecArray | null
   while ((m = re.exec(raw)) !== null) {
-    labels[m[1]] = m[2].replace(/\\"/g, '"').replace(/\\\\/g, '\\').replace(/\\n/g, '\n')
+    labels[m[1]] = m[2].replace(/\\([\\n"])/g, (_match, ch: string) => {
+      if (ch === 'n') return '\n'
+      if (ch === '"') return '"'
+      if (ch === '\\') return '\\'
+      return `\\${ch}`
+    })
   }
   return labels
 }

--- a/admin-console/src/api/prometheus.ts
+++ b/admin-console/src/api/prometheus.ts
@@ -1,0 +1,121 @@
+import { loadApiSettings } from './settings'
+
+/** One sample from the Prometheus text exposition format. */
+export interface PromSample {
+  name: string
+  labels: Record<string, string>
+  value: number
+}
+
+export interface HistogramSummary {
+  count: number
+  sum: number
+  /** Cumulative bucket counts keyed by upper bound (le). */
+  buckets: { le: number; count: number }[]
+}
+
+export interface PromSnapshot {
+  scrapedAt: number
+  samples: PromSample[]
+}
+
+export async function scrapeMetrics(): Promise<PromSnapshot> {
+  const settings = loadApiSettings()
+  const base = settings.metricsBaseUrl.trim()
+  const res = await fetch(`${base}/metrics`, { headers: { Accept: 'text/plain' } })
+  if (!res.ok) throw new Error(`GET /metrics → HTTP ${res.status}`)
+  const text = await res.text()
+  return { scrapedAt: Date.now(), samples: parsePrometheusText(text) }
+}
+
+export function parsePrometheusText(text: string): PromSample[] {
+  const samples: PromSample[] = []
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const match = line.match(/^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{([^}]*)\})?\s+([^\s]+)/)
+    if (!match) continue
+    const value = Number(match[4])
+    if (!Number.isFinite(value)) continue
+    samples.push({ name: match[1], labels: parseLabels(match[3] ?? ''), value })
+  }
+  return samples
+}
+
+function parseLabels(raw: string): Record<string, string> {
+  const labels: Record<string, string> = {}
+  const re = /([a-zA-Z_][a-zA-Z0-9_]*)="((?:[^"\\]|\\.)*)"/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(raw)) !== null) {
+    labels[m[1]] = m[2].replace(/\\"/g, '"').replace(/\\\\/g, '\\').replace(/\\n/g, '\n')
+  }
+  return labels
+}
+
+/** Sum all samples of a metric, optionally filtered by label predicate. */
+export function sumMetric(
+  samples: PromSample[],
+  name: string,
+  predicate?: (labels: Record<string, string>) => boolean,
+): number {
+  let total = 0
+  for (const s of samples) {
+    if (s.name !== name) continue
+    if (predicate && !predicate(s.labels)) continue
+    total += s.value
+  }
+  return total
+}
+
+/** Group a counter by one label, summing over the others. */
+export function groupByLabel(samples: PromSample[], name: string, label: string): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const s of samples) {
+    if (s.name !== name) continue
+    const key = s.labels[label] ?? '(none)'
+    out.set(key, (out.get(key) ?? 0) + s.value)
+  }
+  return out
+}
+
+export function histogram(samples: PromSample[], name: string): HistogramSummary | null {
+  const buckets = new Map<number, number>()
+  let count = 0
+  let sum = 0
+  let seen = false
+  for (const s of samples) {
+    if (s.name === `${name}_bucket`) {
+      const le = s.labels.le === '+Inf' ? Infinity : Number(s.labels.le)
+      buckets.set(le, (buckets.get(le) ?? 0) + s.value)
+      seen = true
+    } else if (s.name === `${name}_count`) {
+      count += s.value
+      seen = true
+    } else if (s.name === `${name}_sum`) {
+      sum += s.value
+      seen = true
+    }
+  }
+  if (!seen) return null
+  const sorted = [...buckets.entries()].sort((a, b) => a[0] - b[0]).map(([le, c]) => ({ le, count: c }))
+  return { count, sum, buckets: sorted }
+}
+
+/** Estimate a quantile from cumulative histogram buckets (linear interpolation). */
+export function histogramQuantile(h: HistogramSummary, q: number): number | null {
+  if (h.count === 0 || h.buckets.length === 0) return null
+  const target = q * h.count
+  let prevLe = 0
+  let prevCount = 0
+  for (const { le, count } of h.buckets) {
+    if (count >= target) {
+      if (!Number.isFinite(le)) return prevLe
+      const bucketCount = count - prevCount
+      if (bucketCount <= 0) return le
+      return prevLe + ((target - prevCount) / bucketCount) * (le - prevLe)
+    }
+    prevLe = Number.isFinite(le) ? le : prevLe
+    prevCount = count
+  }
+  return prevLe
+}

--- a/admin-console/src/api/rpz.ts
+++ b/admin-console/src/api/rpz.ts
@@ -236,7 +236,7 @@ export async function testDomainQuery(domain: string): Promise<RpzTestResult> {
       method: 'POST',
     })
   } catch {
-    return mockTestQuery(domain)
+    return mockTestDomain(domain)
   }
 }
 

--- a/admin-console/src/api/search.ts
+++ b/admin-console/src/api/search.ts
@@ -1,4 +1,5 @@
 import { apiFetch, searchClient } from './client'
+import { demo, isDemoMode, live, type Sourced } from './source'
 
 export interface TrafficLog {
   ts: number
@@ -32,6 +33,7 @@ export interface MlFactor {
   weight: 'high' | 'medium' | 'low'
 }
 
+/** Server-side parameters understood by the Search API. */
 export interface SearchParams {
   domain?: string
   username?: string
@@ -40,7 +42,7 @@ export interface SearchParams {
   limit?: number
 }
 
-export async function searchLogs(params: SearchParams): Promise<TrafficLog[]> {
+export async function searchLogs(params: SearchParams): Promise<Sourced<TrafficLog[]>> {
   const { baseUrl, token } = searchClient()
   const qs = new URLSearchParams()
   if (params.domain) qs.set('domain', params.domain)
@@ -50,59 +52,57 @@ export async function searchLogs(params: SearchParams): Promise<TrafficLog[]> {
   qs.set('limit', String(params.limit ?? 100))
 
   try {
-    return await apiFetch<TrafficLog[]>(`/api/search?${qs}`, { baseUrl, token })
-  } catch {
-    return mockLogs()
+    return live(await apiFetch<TrafficLog[]>(`/api/search?${qs}`, { baseUrl, token }))
+  } catch (err) {
+    if (isDemoMode()) return demo(mockLogs())
+    throw err
   }
 }
 
-/** Demo data when Search API is unavailable (local dev / offline). */
+/** Client-side filters applied on top of Search API results. */
+export interface LogFilters {
+  clientIp: string
+  statusClass: string
+  method: string
+  cacheStatus: string
+  blockReason: string
+}
+
+export const emptyLogFilters: LogFilters = {
+  clientIp: '',
+  statusClass: 'all',
+  method: 'all',
+  cacheStatus: 'all',
+  blockReason: 'all',
+}
+
+export function applyLogFilters(logs: EnrichedLog[], f: LogFilters): EnrichedLog[] {
+  return logs.filter((log) => {
+    if (f.clientIp && !(log.client_ip ?? '').includes(f.clientIp)) return false
+    if (f.statusClass !== 'all') {
+      const cls = log.status ? `${String(log.status)[0]}xx` : ''
+      if (cls !== f.statusClass) return false
+    }
+    if (f.method !== 'all' && (log.method ?? '').toUpperCase() !== f.method) return false
+    if (f.cacheStatus !== 'all' && (log.cache_status ?? '') !== f.cacheStatus) return false
+    if (f.blockReason !== 'all' && log.blockReason !== f.blockReason) return false
+    return true
+  })
+}
+
+/** Demo data for explicit demo mode only. */
 function mockLogs(): TrafficLog[] {
   const now = Math.floor(Date.now() / 1000)
-  return [
-    {
-      ts: now - 120,
-      client_ip: '10.0.1.42',
-      domain: 'evil-phish.example',
-      url: 'https://evil-phish.example/login',
-      method: 'GET',
-      status: 403,
-      cache_status: 'DENIED',
-      username: 'jdoe',
-      event_id: 'evt-001',
-    },
-    {
-      ts: now - 300,
-      client_ip: '10.0.1.88',
-      domain: 'httpbin.org',
-      url: 'https://httpbin.org/get',
-      method: 'GET',
-      status: 200,
-      cache_status: 'HIT',
-      username: 'asmith',
-      event_id: 'evt-002',
-    },
-    {
-      ts: now - 600,
-      client_ip: '10.0.1.42',
-      domain: 'c2-beacon.malware',
-      url: 'https://c2-beacon.malware/pulse',
-      method: 'POST',
-      status: 403,
-      cache_status: 'DENIED',
-      event_id: 'evt-003',
-    },
-    {
-      ts: now - 900,
-      client_ip: '192.168.0.15',
-      domain: 'github.com',
-      url: 'https://github.com/onixus/bsdm-proxy',
-      method: 'GET',
-      status: 200,
-      cache_status: 'MISS',
-      event_id: 'evt-004',
-    },
+  const sessions = ['sess-a1', 'sess-b7', 'sess-c3']
+  const rows: TrafficLog[] = [
+    { ts: now - 120, client_ip: '10.0.1.42', domain: 'evil-phish.example', url: 'https://evil-phish.example/login', method: 'GET', status: 403, cache_status: 'DENIED', username: 'jdoe', event_id: 'evt-001', session_id: sessions[0] },
+    { ts: now - 180, client_ip: '10.0.1.42', domain: 'login-redirect.example', url: 'https://login-redirect.example/go', method: 'GET', status: 302, cache_status: 'MISS', username: 'jdoe', event_id: 'evt-000', session_id: sessions[0], redirect_url: 'https://evil-phish.example/login' },
+    { ts: now - 300, client_ip: '10.0.1.88', domain: 'httpbin.org', url: 'https://httpbin.org/get', method: 'GET', status: 200, cache_status: 'HIT', username: 'asmith', event_id: 'evt-002', session_id: sessions[1] },
+    { ts: now - 600, client_ip: '10.0.1.42', domain: 'c2-beacon.malware', url: 'https://c2-beacon.malware/pulse', method: 'POST', status: 403, cache_status: 'DENIED', event_id: 'evt-003', session_id: sessions[0], parent_event_id: 'evt-001' },
+    { ts: now - 900, client_ip: '192.168.0.15', domain: 'github.com', url: 'https://github.com/onixus/bsdm-proxy', method: 'GET', status: 200, cache_status: 'MISS', event_id: 'evt-004', session_id: sessions[2] },
+    { ts: now - 1100, client_ip: '10.0.1.88', domain: 'api.example.com', url: 'https://api.example.com/v1/data', method: 'POST', status: 500, cache_status: 'BYPASS', username: 'asmith', event_id: 'evt-005', session_id: sessions[1] },
   ]
+  return rows
 }
 
 export function enrichLog(log: TrafficLog): EnrichedLog {

--- a/admin-console/src/api/source.ts
+++ b/admin-console/src/api/source.ts
@@ -1,0 +1,54 @@
+/**
+ * Data-source provenance. Every fetcher returns its payload wrapped in
+ * `Sourced<T>` so the UI can always tell live backend data from demo data.
+ * Demo data is served ONLY when the user has explicitly enabled demo mode —
+ * a failed request otherwise surfaces as an error state, never as fake numbers.
+ */
+
+export type DataSource = 'live' | 'demo'
+
+export interface Sourced<T> {
+  data: T
+  source: DataSource
+  fetchedAt: number
+}
+
+const DEMO_KEY = 'bsdm-admin-demo-mode'
+
+export function isDemoMode(): boolean {
+  try {
+    return localStorage.getItem(DEMO_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function setDemoMode(enabled: boolean): void {
+  try {
+    localStorage.setItem(DEMO_KEY, String(enabled))
+  } catch {
+    /* localStorage unavailable */
+  }
+  window.dispatchEvent(new CustomEvent('bsdm-demo-mode', { detail: enabled }))
+}
+
+export function live<T>(data: T): Sourced<T> {
+  return { data, source: 'live', fetchedAt: Date.now() }
+}
+
+export function demo<T>(data: T): Sourced<T> {
+  return { data, source: 'demo', fetchedAt: Date.now() }
+}
+
+/**
+ * Wrap a live fetch: on failure, either serve demo data (when demo mode is
+ * explicitly on) or rethrow so the query layer shows a real error state.
+ */
+export async function sourced<T>(liveFetch: () => Promise<T>, demoData: () => T): Promise<Sourced<T>> {
+  try {
+    return live(await liveFetch())
+  } catch (err) {
+    if (isDemoMode()) return demo(demoData())
+    throw err
+  }
+}

--- a/admin-console/src/api/threatScores.ts
+++ b/admin-console/src/api/threatScores.ts
@@ -1,5 +1,6 @@
 import { loadApiSettings } from './settings'
 import { apiFetch } from './client'
+import { demo, isDemoMode, live, type Sourced } from './source'
 import type { MlFactor } from './search'
 
 export interface ThreatScoreEntry {
@@ -17,14 +18,17 @@ export interface ThreatScoreSnapshot {
   scores: ThreatScoreEntry[]
 }
 
-export async function fetchThreatScores(): Promise<ThreatScoreSnapshot> {
+export async function fetchThreatScores(): Promise<Sourced<ThreatScoreSnapshot>> {
   const settings = loadApiSettings()
   try {
-    return await apiFetch<ThreatScoreSnapshot>('/api/threat-scores', {
-      baseUrl: settings.mlBaseUrl,
-    })
-  } catch {
-    return mockThreatScores()
+    return live(
+      await apiFetch<ThreatScoreSnapshot>('/api/threat-scores', {
+        baseUrl: settings.mlBaseUrl,
+      }),
+    )
+  } catch (err) {
+    if (isDemoMode()) return demo(mockThreatScores())
+    throw err
   }
 }
 

--- a/admin-console/src/components/charts/BarList.tsx
+++ b/admin-console/src/components/charts/BarList.tsx
@@ -1,0 +1,36 @@
+import { formatNumber } from './common'
+
+export interface BarListItem {
+  label: string
+  value: number
+  /** Optional secondary count shown after the value (e.g. errors). */
+  extra?: string
+  color?: string
+}
+
+/** Horizontal top-N bars with direct labels — magnitude + identity in one glance. */
+export function BarList({ items, unit = '' }: { items: BarListItem[]; unit?: string }) {
+  const max = Math.max(...items.map((i) => i.value), 1)
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.label} title={`${item.label}: ${item.value.toLocaleString()}${unit}`}>
+          <div className="flex items-baseline justify-between gap-2 text-xs">
+            <span className="truncate font-mono text-text-primary">{item.label}</span>
+            <span className="shrink-0 tabular-nums text-text-secondary">
+              {formatNumber(item.value)}
+              {unit}
+              {item.extra && <span className="ml-1.5 text-danger">{item.extra}</span>}
+            </span>
+          </div>
+          <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-surface-0">
+            <div
+              className="h-full rounded-full"
+              style={{ width: `${(item.value / max) * 100}%`, background: item.color ?? 'var(--viz-1)' }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/admin-console/src/components/charts/LineChart.tsx
+++ b/admin-console/src/components/charts/LineChart.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from 'react'
+import type { TsPoint } from '../../lib/timeseries'
+import { formatNumber, formatTime, niceTicks, seriesColor, useMeasuredWidth } from './common'
+
+export interface LineSeries {
+  name: string
+  points: TsPoint[]
+  /** Fixed categorical slot (color follows the entity, not the rank). */
+  slot: number
+}
+
+interface LineChartProps {
+  series: LineSeries[]
+  height?: number
+  unit?: string
+  /** Fill the area under a single series. */
+  area?: boolean
+  yMax?: number
+}
+
+const PAD = { top: 8, right: 12, bottom: 20, left: 42 }
+
+/**
+ * Time-series line chart: hairline grid, 2px lines, crosshair + tooltip.
+ * Legend renders for ≥2 series; a single series is named by the panel title.
+ */
+export function LineChart({ series, height = 180, unit = '', area = false, yMax }: LineChartProps) {
+  const [wrapRef, width] = useMeasuredWidth<HTMLDivElement>()
+  const [hoverX, setHoverX] = useState<number | null>(null)
+
+  const visible = series.filter((s) => s.points.length > 0)
+  const allPoints = visible.flatMap((s) => s.points)
+
+  const { tMin, tMax, vMax, ticks } = useMemo(() => {
+    const ts = allPoints.map((p) => p.t)
+    const vs = allPoints.map((p) => p.v)
+    const tMin = ts.length ? Math.min(...ts) : 0
+    const tMax = ts.length ? Math.max(...ts) : 1
+    const rawMax = yMax ?? (vs.length ? Math.max(...vs) : 1)
+    const vMax = rawMax > 0 ? rawMax * 1.1 : 1
+    return { tMin, tMax, vMax, ticks: niceTicks(0, vMax, 4) }
+  }, [allPoints, yMax])
+
+  if (visible.length === 0 || allPoints.length < 2) {
+    return (
+      <div className="flex items-center justify-center rounded-md border border-border bg-surface-0/40 text-xs text-text-secondary" style={{ height }}>
+        Collecting samples… charts fill in as the console polls.
+      </div>
+    )
+  }
+
+  const plotW = Math.max(0, width - PAD.left - PAD.right)
+  const plotH = height - PAD.top - PAD.bottom
+  const x = (t: number) => PAD.left + (tMax === tMin ? 0 : ((t - tMin) / (tMax - tMin)) * plotW)
+  const y = (v: number) => PAD.top + plotH - (v / vMax) * plotH
+
+  const hover = hoverX === null ? null : nearest(visible, tMin + ((hoverX - PAD.left) / Math.max(plotW, 1)) * (tMax - tMin))
+
+  return (
+    <div ref={wrapRef} className="relative w-full">
+      {width > 0 && (
+        <svg
+          width={width}
+          height={height}
+          role="img"
+          aria-label={`Line chart: ${visible.map((s) => s.name).join(', ')}`}
+          onMouseMove={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect()
+            setHoverX(Math.min(Math.max(e.clientX - rect.left, PAD.left), width - PAD.right))
+          }}
+          onMouseLeave={() => setHoverX(null)}
+        >
+          {ticks.map((tick) => (
+            <g key={tick}>
+              <line x1={PAD.left} x2={width - PAD.right} y1={y(tick)} y2={y(tick)} stroke="var(--viz-grid)" strokeWidth={1} />
+              <text x={PAD.left - 6} y={y(tick) + 3} textAnchor="end" fontSize={10} fill="var(--viz-muted)">
+                {formatNumber(tick)}
+              </text>
+            </g>
+          ))}
+          <line x1={PAD.left} x2={width - PAD.right} y1={PAD.top + plotH} y2={PAD.top + plotH} stroke="var(--viz-axis)" strokeWidth={1} />
+          <text x={PAD.left} y={height - 5} fontSize={10} fill="var(--viz-muted)">
+            {formatTime(tMin)}
+          </text>
+          <text x={width - PAD.right} y={height - 5} textAnchor="end" fontSize={10} fill="var(--viz-muted)">
+            {formatTime(tMax)}
+          </text>
+
+          {visible.map((s) => {
+            const color = seriesColor(s.slot)
+            const d = s.points.map((p, i) => `${i === 0 ? 'M' : 'L'}${x(p.t).toFixed(1)},${y(p.v).toFixed(1)}`).join(' ')
+            return (
+              <g key={s.name}>
+                {area && visible.length === 1 && (
+                  <path
+                    d={`${d} L${x(s.points[s.points.length - 1].t).toFixed(1)},${PAD.top + plotH} L${x(s.points[0].t).toFixed(1)},${PAD.top + plotH} Z`}
+                    fill={color}
+                    opacity={0.12}
+                  />
+                )}
+                <path d={d} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />
+              </g>
+            )
+          })}
+
+          {hover && (
+            <g>
+              <line x1={x(hover.t)} x2={x(hover.t)} y1={PAD.top} y2={PAD.top + plotH} stroke="var(--viz-axis)" strokeWidth={1} strokeDasharray="3 3" />
+              {hover.values.map(({ series: s, point }) => (
+                <circle key={s.name} cx={x(point.t)} cy={y(point.v)} r={4} fill={seriesColor(s.slot)} stroke="var(--color-surface-1)" strokeWidth={2} />
+              ))}
+            </g>
+          )}
+        </svg>
+      )}
+
+      {hover && (
+        <div
+          className="pointer-events-none absolute z-10 rounded-md border border-border bg-surface-1 px-3 py-2 text-xs shadow-lg"
+          style={{
+            left: Math.min(Math.max(x(hover.t) + 10, 0), Math.max(width - 150, 0)),
+            top: 4,
+          }}
+        >
+          <p className="font-medium text-text-secondary">{formatTime(hover.t)}</p>
+          {hover.values.map(({ series: s, point }) => (
+            <p key={s.name} className="mt-0.5 flex items-center gap-1.5 text-text-primary">
+              <span className="inline-block size-2 rounded-full" style={{ background: seriesColor(s.slot) }} />
+              {s.name}: <span className="font-semibold tabular-nums">{formatNumber(point.v)}{unit}</span>
+            </p>
+          ))}
+        </div>
+      )}
+
+      {visible.length >= 2 && (
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-text-secondary">
+          {visible.map((s) => (
+            <span key={s.name} className="inline-flex items-center gap-1.5">
+              <span className="inline-block h-0.5 w-4 rounded" style={{ background: seriesColor(s.slot) }} />
+              {s.name}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function nearest(series: LineSeries[], t: number) {
+  const values = series
+    .map((s) => {
+      let best = s.points[0]
+      for (const p of s.points) if (Math.abs(p.t - t) < Math.abs(best.t - t)) best = p
+      return { series: s, point: best }
+    })
+    .filter((v) => v.point !== undefined)
+  if (values.length === 0) return null
+  return { t: values[0].point.t, values }
+}

--- a/admin-console/src/components/charts/SegmentBar.tsx
+++ b/admin-console/src/components/charts/SegmentBar.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { formatNumber } from './common'
+
+export interface Segment {
+  label: string
+  value: number
+  color: string
+}
+
+/**
+ * Single 100% stacked bar for a categorical distribution, with 2px surface
+ * gaps between segments and an always-present legend with values.
+ */
+export function SegmentBar({ segments }: { segments: Segment[] }) {
+  const [hover, setHover] = useState<string | null>(null)
+  const shown = segments.filter((s) => s.value > 0)
+  const total = shown.reduce((sum, s) => sum + s.value, 0)
+  if (total === 0) return <p className="text-sm text-text-secondary">No data yet.</p>
+
+  return (
+    <div>
+      <div className="flex h-4 w-full gap-[2px] overflow-hidden rounded-full">
+        {shown.map((s) => (
+          <div
+            key={s.label}
+            className="h-full transition-opacity"
+            style={{
+              width: `${(s.value / total) * 100}%`,
+              minWidth: 3,
+              background: s.color,
+              opacity: hover && hover !== s.label ? 0.35 : 1,
+            }}
+            onMouseEnter={() => setHover(s.label)}
+            onMouseLeave={() => setHover(null)}
+            title={`${s.label}: ${s.value.toLocaleString()} (${((s.value / total) * 100).toFixed(1)}%)`}
+          />
+        ))}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {shown.map((s) => (
+          <span
+            key={s.label}
+            className="inline-flex items-center gap-1.5 text-text-secondary"
+            onMouseEnter={() => setHover(s.label)}
+            onMouseLeave={() => setHover(null)}
+          >
+            <span className="inline-block size-2.5 rounded-sm" style={{ background: s.color }} />
+            {s.label}
+            <span className="tabular-nums text-text-primary">{formatNumber(s.value)}</span>
+            <span className="tabular-nums">({((s.value / total) * 100).toFixed(1)}%)</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/admin-console/src/components/charts/Sparkline.tsx
+++ b/admin-console/src/components/charts/Sparkline.tsx
@@ -1,0 +1,27 @@
+import type { TsPoint } from '../../lib/timeseries'
+
+interface SparklineProps {
+  points: TsPoint[]
+  width?: number
+  height?: number
+  color?: string
+}
+
+/** Minimal trend line for stat tiles — no axes, no labels, decorative summary. */
+export function Sparkline({ points, width = 96, height = 28, color = 'var(--viz-1)' }: SparklineProps) {
+  if (points.length < 2) return <div style={{ width, height }} aria-hidden />
+
+  const vs = points.map((p) => p.v)
+  const min = Math.min(...vs)
+  const max = Math.max(...vs)
+  const span = max - min || 1
+  const x = (i: number) => (i / (points.length - 1)) * (width - 4) + 2
+  const y = (v: number) => height - 3 - ((v - min) / span) * (height - 6)
+  const d = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(p.v).toFixed(1)}`).join(' ')
+
+  return (
+    <svg width={width} height={height} aria-hidden className="shrink-0">
+      <path d={d} fill="none" stroke={color} strokeWidth={1.5} strokeLinejoin="round" strokeLinecap="round" opacity={0.9} />
+    </svg>
+  )
+}

--- a/admin-console/src/components/charts/common.ts
+++ b/admin-console/src/components/charts/common.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** Fixed categorical slot order — assigned by entity, never cycled. */
+export const SERIES_VARS = [
+  'var(--viz-1)',
+  'var(--viz-2)',
+  'var(--viz-3)',
+  'var(--viz-4)',
+  'var(--viz-5)',
+  'var(--viz-6)',
+  'var(--viz-7)',
+  'var(--viz-8)',
+] as const
+
+export function seriesColor(slot: number): string {
+  return SERIES_VARS[Math.min(slot, SERIES_VARS.length - 1)]
+}
+
+/** Status colors are reserved for state (good/warn/serious/critical), never series. */
+export const STATUS_VARS = {
+  good: 'var(--viz-good)',
+  warning: 'var(--viz-warning)',
+  serious: 'var(--viz-serious)',
+  critical: 'var(--viz-critical)',
+} as const
+
+/** Fixed color per cache disposition — color follows the entity, never its rank. */
+const CACHE_STATUS_SLOTS: Record<string, number> = {
+  HIT: 2,
+  MISS: 1,
+  BYPASS: 3,
+  DENIED: 7,
+  COALESCED: 6,
+}
+
+export function cacheStatusColor(label: string): string {
+  return seriesColor(CACHE_STATUS_SLOTS[label.toUpperCase()] ?? 4)
+}
+
+export function formatNumber(v: number): string {
+  if (!Number.isFinite(v)) return '—'
+  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
+  if (Math.abs(v) >= 10_000) return `${(v / 1000).toFixed(0)}k`
+  if (Math.abs(v) >= 1000) return `${(v / 1000).toFixed(1)}k`
+  if (Math.abs(v) >= 100) return v.toFixed(0)
+  if (Math.abs(v) >= 1) return v % 1 === 0 ? String(v) : v.toFixed(1)
+  return v.toFixed(2)
+}
+
+export function formatTime(t: number): string {
+  return new Date(t).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+/** Container width tracking for responsive SVG charts. */
+export function useMeasuredWidth<T extends HTMLElement>(): [React.RefObject<T | null>, number] {
+  const ref = useRef<T | null>(null)
+  const [width, setWidth] = useState(0)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) setWidth(entry.contentRect.width)
+    })
+    ro.observe(el)
+    setWidth(el.getBoundingClientRect().width)
+    return () => ro.disconnect()
+  }, [])
+  return [ref, width]
+}
+
+export function niceTicks(min: number, max: number, count = 4): number[] {
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return [0]
+  const span = max - min
+  const step = 10 ** Math.floor(Math.log10(span / count))
+  const err = span / count / step
+  const mult = err >= 7.5 ? 10 : err >= 3.5 ? 5 : err >= 1.5 ? 2 : 1
+  const s = step * mult
+  const ticks: number[] = []
+  for (let v = Math.ceil(min / s) * s; v <= max + 1e-9; v += s) ticks.push(v)
+  return ticks
+}

--- a/admin-console/src/components/dashboard/MetricWidget.tsx
+++ b/admin-console/src/components/dashboard/MetricWidget.tsx
@@ -1,53 +1,55 @@
 import type { ReactNode } from 'react'
-import { TrendingDown, TrendingUp, Minus } from 'lucide-react'
-import type { DashboardMetric } from '../../api/metrics'
+import type { TsPoint } from '../../lib/timeseries'
+import { Sparkline } from '../charts/Sparkline'
 
-interface MetricWidgetProps {
-  metric: DashboardMetric
+export interface StatTileProps {
+  label: string
+  value: string
+  unit?: string
+  trend?: TsPoint[]
+  trendColor?: string
+  status?: 'ok' | 'warn' | 'error'
+  hint?: string
 }
 
 const statusRing: Record<string, string> = {
-  ok: 'border-success/30',
-  warn: 'border-warning/30',
-  error: 'border-danger/30',
+  ok: 'border-border',
+  warn: 'border-warning/50',
+  error: 'border-danger/50',
 }
 
-export function MetricWidget({ metric }: MetricWidgetProps) {
-  const TrendIcon =
-    metric.trend === 'up' ? TrendingUp : metric.trend === 'down' ? TrendingDown : Minus
-
+/** Stat tile: label, hero number, optional sparkline trend. */
+export function StatTile({ label, value, unit, trend, trendColor, status = 'ok', hint }: StatTileProps) {
   return (
-    <article
-      className={`rounded-lg border bg-surface-1 p-4 ${statusRing[metric.status ?? 'ok']}`}
-    >
-      <p className="text-xs font-medium uppercase tracking-wide text-text-secondary">
-        {metric.label}
-      </p>
+    <article className={`rounded-lg border bg-surface-1 p-4 ${statusRing[status]}`} title={hint}>
+      <p className="text-xs font-medium uppercase tracking-wide text-text-secondary">{label}</p>
       <div className="mt-2 flex items-end justify-between gap-2">
-        <p className="text-2xl font-bold text-text-primary sm:text-3xl">
-          {metric.value}
-          {metric.unit && (
-            <span className="ml-1 text-base font-normal text-text-secondary">{metric.unit}</span>
-          )}
+        <p className="text-2xl font-bold text-text-primary">
+          {value}
+          {unit && <span className="ml-1 text-sm font-normal text-text-secondary">{unit}</span>}
         </p>
-        {metric.trend && (
-          <TrendIcon className="size-4 shrink-0 text-text-secondary" aria-hidden />
-        )}
+        {trend && trend.length > 1 && <Sparkline points={trend} color={trendColor} />}
       </div>
     </article>
   )
 }
 
 export function WidgetGrid({ children }: { children: ReactNode }) {
-  return (
-    <div className="grid grid-cols-1 gap-4 min-[400px]:grid-cols-2 lg:grid-cols-4">{children}</div>
-  )
+  return <div className="grid grid-cols-1 gap-4 min-[420px]:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">{children}</div>
 }
 
-export function Panel({ title, children, action }: { title: string; children: ReactNode; action?: ReactNode }) {
+export function Panel({
+  title,
+  children,
+  action,
+}: {
+  title: string
+  children: ReactNode
+  action?: ReactNode
+}) {
   return (
     <section className="rounded-lg border border-border bg-surface-1">
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
         <h2 className="text-sm font-semibold text-text-primary">{title}</h2>
         {action}
       </div>

--- a/admin-console/src/components/layout/Sidebar.tsx
+++ b/admin-console/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import {
   LayoutDashboard,
@@ -6,16 +7,23 @@ import {
   Settings,
   X,
   Activity,
+  BarChart3,
   Brain,
+  FlaskConical,
+  Moon,
   Radio,
   Cpu,
   Network,
   Sparkles,
+  Sun,
 } from 'lucide-react'
+import { isDemoMode } from '../../api/source'
+import { applyTheme, loadTheme, type Theme } from '../../lib/theme'
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard, end: true },
   { to: '/logs', label: 'Logs', icon: ScrollText },
+  { to: '/analytics', label: 'Analytics', icon: BarChart3 },
   { to: '/threat-scores', label: 'Threat scores', icon: Brain },
   { to: '/policies', label: 'Policies', icon: Shield },
   { to: '/rpz', label: 'RPZ Sinkhole', icon: Radio },
@@ -31,6 +39,21 @@ interface SidebarProps {
 }
 
 export function Sidebar({ open, onClose }: SidebarProps) {
+  const [theme, setTheme] = useState<Theme>(loadTheme)
+  const [demoOn, setDemoOn] = useState(isDemoMode)
+
+  useEffect(() => {
+    const onDemo = (e: Event) => setDemoOn(Boolean((e as CustomEvent).detail))
+    window.addEventListener('bsdm-demo-mode', onDemo)
+    return () => window.removeEventListener('bsdm-demo-mode', onDemo)
+  }, [])
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    applyTheme(next)
+  }
+
   return (
     <>
       {/* Mobile overlay */}
@@ -49,17 +72,28 @@ export function Sidebar({ open, onClose }: SidebarProps) {
             <Activity className="size-6 text-accent" />
             <span className="font-bold text-text-primary">BSDM Console</span>
           </div>
-          <button
-            type="button"
-            className="touch-target flex items-center justify-center rounded-md p-2 text-text-secondary hover:bg-surface-2 lg:hidden"
-            onClick={onClose}
-            aria-label="Close menu"
-          >
-            <X className="size-5" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              className="flex items-center justify-center rounded-md p-2 text-text-secondary hover:bg-surface-2 hover:text-text-primary"
+              onClick={toggleTheme}
+              aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+              title={theme === 'dark' ? 'Light theme' : 'Dark theme'}
+            >
+              {theme === 'dark' ? <Sun className="size-4" /> : <Moon className="size-4" />}
+            </button>
+            <button
+              type="button"
+              className="touch-target flex items-center justify-center rounded-md p-2 text-text-secondary hover:bg-surface-2 lg:hidden"
+              onClick={onClose}
+              aria-label="Close menu"
+            >
+              <X className="size-5" />
+            </button>
+          </div>
         </div>
 
-        <nav className="flex-1 space-y-1 p-3">
+        <nav className="flex-1 space-y-1 overflow-y-auto p-3">
           {navItems.map(({ to, label, icon: Icon, ...rest }) => (
             <NavLink
               key={to}
@@ -80,8 +114,14 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           ))}
         </nav>
 
-        <div className="border-t border-border p-4 text-xs text-text-secondary">
-          Single pane of glass · v0.5
+        <div className="space-y-2 border-t border-border p-4">
+          {demoOn && (
+            <div className="flex items-center gap-2 rounded-md border border-warning/40 bg-warning/10 px-2.5 py-1.5 text-xs font-semibold text-warning">
+              <FlaskConical className="size-3.5" />
+              Demo mode — sample data may render
+            </div>
+          )}
+          <p className="text-xs text-text-secondary">Single pane of glass · v0.6</p>
         </div>
       </aside>
     </>

--- a/admin-console/src/components/ui/DataState.tsx
+++ b/admin-console/src/components/ui/DataState.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from 'react'
+import { AlertTriangle, FlaskConical, RefreshCw, WifiOff } from 'lucide-react'
+import type { DataSource } from '../../api/source'
+import { Button } from './Button'
+
+/** Small pill telling the operator where a panel's numbers come from. */
+export function SourceBadge({ source }: { source: DataSource }) {
+  if (source === 'live') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-success/40 bg-success/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-success">
+        <span className="size-1.5 rounded-full bg-success" />
+        Live
+      </span>
+    )
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full border border-warning/40 bg-warning/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-warning"
+      title="Demo mode is on and the backend is unreachable — these numbers are illustrative, not real."
+    >
+      <FlaskConical className="size-3" />
+      Demo
+    </span>
+  )
+}
+
+export function ErrorState({
+  title = 'Failed to load data',
+  detail,
+  onRetry,
+}: {
+  title?: string
+  detail?: string
+  onRetry?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-danger/30 bg-danger/5 p-6 text-center">
+      <WifiOff className="size-8 text-danger" />
+      <div>
+        <p className="font-semibold text-text-primary">{title}</p>
+        {detail && <p className="mt-1 break-all font-mono text-xs text-text-secondary">{detail}</p>}
+        <p className="mt-1 text-xs text-text-secondary">
+          Check API endpoints in Settings → API, or enable demo mode to explore the UI offline.
+        </p>
+      </div>
+      {onRetry && (
+        <Button variant="secondary" onClick={onRetry}>
+          <RefreshCw className="size-4" /> Retry
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export function EmptyState({ message }: { message: string }) {
+  return <p className="py-6 text-center text-sm text-text-secondary">{message}</p>
+}
+
+export function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-surface-2 ${className}`} aria-hidden />
+}
+
+export function SkeletonRows({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="space-y-3" aria-label="Loading">
+      {Array.from({ length: rows }, (_, i) => (
+        <Skeleton key={i} className="h-9 w-full" />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Banner for pages whose backend endpoints do not exist yet. These pages
+ * render illustrative data by design and must never be mistaken for telemetry.
+ */
+export function PreviewBanner({ feature, children }: { feature: string; children?: ReactNode }) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/10 p-4">
+      <AlertTriangle className="mt-0.5 size-5 shrink-0 text-warning" />
+      <div className="text-sm">
+        <p className="font-semibold text-warning">Preview — no backend endpoint yet</p>
+        <p className="mt-0.5 text-text-secondary">
+          {feature} has no REST API in the proxy yet, so everything below is illustrative demo data.
+          {children}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/admin-console/src/components/ui/Modal.tsx
+++ b/admin-console/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { X } from 'lucide-react'
 import { Button } from './Button'
 
@@ -69,12 +69,18 @@ export function CodePreview({ content }: { content: string }) {
 }
 
 export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
   return (
     <Button
       variant="secondary"
-      onClick={() => navigator.clipboard.writeText(text).then(() => alert('Copied'))}
+      onClick={() =>
+        navigator.clipboard.writeText(text).then(() => {
+          setCopied(true)
+          window.setTimeout(() => setCopied(false), 1500)
+        })
+      }
     >
-      Copy
+      {copied ? 'Copied ✓' : 'Copy'}
     </Button>
   )
 }

--- a/admin-console/src/components/ui/Toast.tsx
+++ b/admin-console/src/components/ui/Toast.tsx
@@ -1,0 +1,78 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react'
+import { CheckCircle2, AlertTriangle, XCircle, Info, X } from 'lucide-react'
+
+export type ToastKind = 'success' | 'error' | 'warning' | 'info'
+
+interface ToastItem {
+  id: number
+  kind: ToastKind
+  message: string
+}
+
+interface ToastContextValue {
+  toast: (kind: ToastKind, message: string) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within ToastProvider')
+  return ctx
+}
+
+const kindStyles: Record<ToastKind, { box: string; Icon: typeof Info }> = {
+  success: { box: 'border-success/40 text-success', Icon: CheckCircle2 },
+  error: { box: 'border-danger/40 text-danger', Icon: XCircle },
+  warning: { box: 'border-warning/40 text-warning', Icon: AlertTriangle },
+  info: { box: 'border-border text-text-primary', Icon: Info },
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<ToastItem[]>([])
+  const nextId = useRef(0)
+
+  const dismiss = useCallback((id: number) => {
+    setItems((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const toast = useCallback(
+    (kind: ToastKind, message: string) => {
+      const id = ++nextId.current
+      setItems((prev) => [...prev.slice(-4), { id, kind, message }])
+      window.setTimeout(() => dismiss(id), kind === 'error' ? 8000 : 4000)
+    },
+    [dismiss],
+  )
+
+  const value = useMemo(() => ({ toast }), [toast])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div className="pointer-events-none fixed inset-x-0 bottom-4 z-[60] flex flex-col items-center gap-2 px-4 sm:items-end sm:pr-6">
+        {items.map(({ id, kind, message }) => {
+          const { box, Icon } = kindStyles[kind]
+          return (
+            <div
+              key={id}
+              role="status"
+              className={`pointer-events-auto flex w-full max-w-md items-start gap-3 rounded-lg border bg-surface-1 p-3 shadow-xl ${box}`}
+            >
+              <Icon className="mt-0.5 size-5 shrink-0" />
+              <p className="flex-1 text-sm text-text-primary">{message}</p>
+              <button
+                type="button"
+                className="rounded p-1 text-text-secondary hover:bg-surface-2"
+                onClick={() => dismiss(id)}
+                aria-label="Dismiss"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/admin-console/src/hooks/useSourced.ts
+++ b/admin-console/src/hooks/useSourced.ts
@@ -1,0 +1,20 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import type { Sourced } from '../api/source'
+
+/**
+ * Query wrapper for provenance-aware fetchers. Keeps the last good result on
+ * refetch errors (placeholderData) so panels degrade to "stale" rather than
+ * flashing empty.
+ */
+export function useSourcedQuery<T>(
+  key: readonly unknown[],
+  fetcher: () => Promise<Sourced<T>>,
+  opts?: { refetchInterval?: number | false; enabled?: boolean },
+): UseQueryResult<Sourced<T>, Error> {
+  return useQuery<Sourced<T>, Error>({
+    queryKey: key,
+    queryFn: fetcher,
+    refetchInterval: opts?.refetchInterval ?? false,
+    enabled: opts?.enabled ?? true,
+  })
+}

--- a/admin-console/src/index.css
+++ b/admin-console/src/index.css
@@ -1,24 +1,97 @@
 @import 'tailwindcss';
 
-@theme {
-  --color-surface-0: #0f1419;
-  --color-surface-1: #1a1f2e;
-  --color-surface-2: #242b3d;
-  --color-surface-3: #2f384f;
-  --color-accent: #e94560;
-  --color-accent-hover: #d63851;
-  --color-success: #4ecca3;
-  --color-warning: #ff9800;
-  --color-danger: #ef4444;
-  --color-text-primary: #eaeaea;
-  --color-text-secondary: #a0a0a0;
-  --color-border: #2a2a4e;
-  --font-sans: 'Segoe UI', system-ui, -apple-system, sans-serif;
-  --font-mono: 'Courier New', ui-monospace, monospace;
+/*
+ * Runtime-switchable theming: Tailwind tokens reference CSS variables
+ * (via @theme inline) whose values change with [data-theme] on <html>.
+ * Default is dark (the console's historical identity); light is opt-in.
+ */
+@theme inline {
+  --color-surface-0: var(--t-surface-0);
+  --color-surface-1: var(--t-surface-1);
+  --color-surface-2: var(--t-surface-2);
+  --color-surface-3: var(--t-surface-3);
+  --color-accent: var(--t-accent);
+  --color-accent-hover: var(--t-accent-hover);
+  --color-success: var(--t-success);
+  --color-warning: var(--t-warning);
+  --color-danger: var(--t-danger);
+  --color-text-primary: var(--t-text-primary);
+  --color-text-secondary: var(--t-text-secondary);
+  --color-border: var(--t-border);
+  --font-sans: system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: ui-monospace, 'SFMono-Regular', 'Cascadia Mono', monospace;
   --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-lg: 0.75rem;
   --touch-min: 2.75rem;
+}
+
+:root,
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --t-surface-0: #0f1419;
+  --t-surface-1: #1a1f2e;
+  --t-surface-2: #242b3d;
+  --t-surface-3: #2f384f;
+  --t-accent: #e94560;
+  --t-accent-hover: #d63851;
+  --t-success: #4ecca3;
+  --t-warning: #ff9800;
+  --t-danger: #ef4444;
+  --t-text-primary: #eaeaea;
+  --t-text-secondary: #a0a0a0;
+  --t-border: #2a3040;
+
+  /* Data-viz series palette (validated for the dark card surface #1a1f2e) */
+  --viz-1: #3987e5;
+  --viz-2: #d95926;
+  --viz-3: #199e70;
+  --viz-4: #c98500;
+  --viz-5: #d55181;
+  --viz-6: #008300;
+  --viz-7: #9085e9;
+  --viz-8: #e66767;
+  --viz-grid: #262c3b;
+  --viz-axis: #3a4155;
+  --viz-muted: #898781;
+  /* Status palette (reserved for state, never a series) */
+  --viz-good: #0ca30c;
+  --viz-warning: #fab219;
+  --viz-serious: #ec835a;
+  --viz-critical: #d03b3b;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  --t-surface-0: #f4f4f1;
+  --t-surface-1: #fcfcfb;
+  --t-surface-2: #efeeea;
+  --t-surface-3: #e3e2dc;
+  --t-accent: #c92d47;
+  --t-accent-hover: #b02540;
+  --t-success: #0a7d5e;
+  --t-warning: #a35f00;
+  --t-danger: #c22f2f;
+  --t-text-primary: #0b0b0b;
+  --t-text-secondary: #52514e;
+  --t-border: #dcdbd4;
+
+  /* Series palette stepped for the light card surface #fcfcfb */
+  --viz-1: #2a78d6;
+  --viz-2: #eb6834;
+  --viz-3: #1baf7a;
+  --viz-4: #eda100;
+  --viz-5: #e87ba4;
+  --viz-6: #008300;
+  --viz-7: #4a3aa7;
+  --viz-8: #e34948;
+  --viz-grid: #e7e6e0;
+  --viz-axis: #c3c2b7;
+  --viz-muted: #898781;
+  --viz-good: #0ca30c;
+  --viz-warning: #fab219;
+  --viz-serious: #ec835a;
+  --viz-critical: #d03b3b;
 }
 
 @layer base {

--- a/admin-console/src/lib/config/collect.ts
+++ b/admin-console/src/lib/config/collect.ts
@@ -85,6 +85,62 @@ export function collectConfig(form: ConfigFormState): ProxyConfig {
   if (form.aclApiToken) config.ACL_API_TOKEN = form.aclApiToken
   if (form.searchApiToken) config.SEARCH_API_TOKEN = form.searchApiToken
 
+  if (form.upstreamCaCert) config.UPSTREAM_CA_CERT = form.upstreamCaCert
+  if (form.upstreamHttp2Enabled) config.UPSTREAM_HTTP2_ENABLED = 'true'
+  if (form.preserveHeaderCase) config.HTTP_PRESERVE_HEADER_CASE = 'true'
+
+  if (form.threatScoreEnabled) {
+    Object.assign(config, {
+      THREAT_SCORE_ENABLED: 'true',
+      THREAT_SCORE_POLL_URL: form.threatScorePollUrl,
+      THREAT_SCORE_POLL_INTERVAL_SECS: form.threatScorePollInterval,
+      THREAT_SCORE_BLOCK_THRESHOLD: form.threatScoreBlockThreshold,
+      THREAT_SCORE_WARN_THRESHOLD: form.threatScoreWarnThreshold,
+    })
+  }
+
+  if (form.hierarchyPeersPath) config.HIERARCHY_PEERS_PATH = form.hierarchyPeersPath
+  if (form.icpServerEnabled) {
+    config.ICP_SERVER_ENABLED = 'true'
+    config.ICP_BIND = form.icpBind
+  }
+  if (form.htcpServerEnabled) {
+    config.HTCP_SERVER_ENABLED = 'true'
+    config.HTCP_BIND = form.htcpBind
+  }
+  if (form.peerDiscoveryEnabled) {
+    config.PEER_DISCOVERY_ENABLED = 'true'
+    config.PEER_DISCOVERY_MULTICAST = form.peerDiscoveryMulticast
+  }
+
+  if (form.rateLimitEnabled) {
+    config.RATE_LIMIT_ENABLED = 'true'
+    config.RATE_LIMIT_MAX_KEYS = form.rateLimitMaxKeys
+  }
+
+  if (form.ebpfXdpEnabled) {
+    Object.assign(config, {
+      EBPF_XDP_ENABLED: 'true',
+      EBPF_XDP_IFACE: form.ebpfXdpIface,
+      EBPF_XDP_MODE: form.ebpfXdpMode,
+    })
+  }
+
+  if (form.wasmEnabled) {
+    Object.assign(config, {
+      WASM_ENABLED: 'true',
+      WASM_MODULE_PATH: form.wasmModulePath,
+      WASM_FAIL_OPEN: String(form.wasmFailOpen),
+      WASM_FUEL: form.wasmFuel,
+    })
+  }
+
+  if (form.controlGrpcEnabled) {
+    config.CONTROL_GRPC_ENABLED = 'true'
+    config.CONTROL_GRPC_BIND = form.controlGrpcBind
+  }
+  if (form.controlApiToken) config.CONTROL_API_TOKEN = form.controlApiToken
+
   return config
 }
 

--- a/admin-console/src/lib/config/import.ts
+++ b/admin-console/src/lib/config/import.ts
@@ -92,6 +92,40 @@ export function applyEnvToForm(map: Record<string, string>, prev: ConfigFormStat
   if (map.CLICKHOUSE_TABLE) next.clickhouseTable = map.CLICKHOUSE_TABLE
   if (map.SEARCH_API_TOKEN) next.searchApiToken = map.SEARCH_API_TOKEN
 
+  if (map.UPSTREAM_CA_CERT) next.upstreamCaCert = map.UPSTREAM_CA_CERT
+  next.upstreamHttp2Enabled = truthyEnv(map.UPSTREAM_HTTP2_ENABLED ?? 'false')
+  next.preserveHeaderCase = truthyEnv(map.HTTP_PRESERVE_HEADER_CASE ?? 'false')
+
+  next.threatScoreEnabled = truthyEnv(map.THREAT_SCORE_ENABLED ?? 'false')
+  if (map.THREAT_SCORE_POLL_URL) next.threatScorePollUrl = map.THREAT_SCORE_POLL_URL
+  if (map.THREAT_SCORE_POLL_INTERVAL_SECS) next.threatScorePollInterval = map.THREAT_SCORE_POLL_INTERVAL_SECS
+  if (map.THREAT_SCORE_BLOCK_THRESHOLD) next.threatScoreBlockThreshold = map.THREAT_SCORE_BLOCK_THRESHOLD
+  if (map.THREAT_SCORE_WARN_THRESHOLD) next.threatScoreWarnThreshold = map.THREAT_SCORE_WARN_THRESHOLD
+
+  if (map.HIERARCHY_PEERS_PATH) next.hierarchyPeersPath = map.HIERARCHY_PEERS_PATH
+  next.icpServerEnabled = truthyEnv(map.ICP_SERVER_ENABLED ?? 'false')
+  if (map.ICP_BIND) next.icpBind = map.ICP_BIND
+  next.htcpServerEnabled = truthyEnv(map.HTCP_SERVER_ENABLED ?? 'false')
+  if (map.HTCP_BIND) next.htcpBind = map.HTCP_BIND
+  next.peerDiscoveryEnabled = truthyEnv(map.PEER_DISCOVERY_ENABLED ?? 'false')
+  if (map.PEER_DISCOVERY_MULTICAST) next.peerDiscoveryMulticast = map.PEER_DISCOVERY_MULTICAST
+
+  next.rateLimitEnabled = truthyEnv(map.RATE_LIMIT_ENABLED ?? 'false')
+  if (map.RATE_LIMIT_MAX_KEYS) next.rateLimitMaxKeys = map.RATE_LIMIT_MAX_KEYS
+
+  next.ebpfXdpEnabled = truthyEnv(map.EBPF_XDP_ENABLED ?? 'false')
+  if (map.EBPF_XDP_IFACE) next.ebpfXdpIface = map.EBPF_XDP_IFACE
+  if (map.EBPF_XDP_MODE) next.ebpfXdpMode = map.EBPF_XDP_MODE
+
+  next.wasmEnabled = truthyEnv(map.WASM_ENABLED ?? 'false')
+  if (map.WASM_MODULE_PATH) next.wasmModulePath = map.WASM_MODULE_PATH
+  next.wasmFailOpen = map.WASM_FAIL_OPEN !== 'false'
+  if (map.WASM_FUEL) next.wasmFuel = map.WASM_FUEL
+
+  next.controlGrpcEnabled = truthyEnv(map.CONTROL_GRPC_ENABLED ?? 'false')
+  if (map.CONTROL_GRPC_BIND) next.controlGrpcBind = map.CONTROL_GRPC_BIND
+  if (map.CONTROL_API_TOKEN) next.controlApiToken = map.CONTROL_API_TOKEN
+
   return next
 }
 
@@ -107,6 +141,7 @@ const SENSITIVE_FORM_KEYS = [
   'aclApiToken',
   'phishtankApiKey',
   'searchApiToken',
+  'controlApiToken',
 ] as const satisfies readonly (keyof ConfigFormState)[]
 
 function formForStorage(form: ConfigFormState): Omit<ConfigFormState, (typeof SENSITIVE_FORM_KEYS)[number]> {

--- a/admin-console/src/lib/config/types.ts
+++ b/admin-console/src/lib/config/types.ts
@@ -118,6 +118,40 @@ export interface ConfigFormState {
   searchApiToken: string
   prometheusEnabled: boolean
   grafanaEnabled: boolean
+  // Upstream TLS / HTTP
+  upstreamCaCert: string
+  upstreamHttp2Enabled: boolean
+  preserveHeaderCase: boolean
+  // Threat score enforcement (ml-worker write-back)
+  threatScoreEnabled: boolean
+  threatScorePollUrl: string
+  threatScorePollInterval: string
+  threatScoreBlockThreshold: string
+  threatScoreWarnThreshold: string
+  // Cache hierarchy (ICP/HTCP)
+  hierarchyPeersPath: string
+  icpServerEnabled: boolean
+  icpBind: string
+  htcpServerEnabled: boolean
+  htcpBind: string
+  peerDiscoveryEnabled: boolean
+  peerDiscoveryMulticast: string
+  // Rate limiting
+  rateLimitEnabled: boolean
+  rateLimitMaxKeys: string
+  // eBPF / XDP
+  ebpfXdpEnabled: boolean
+  ebpfXdpIface: string
+  ebpfXdpMode: string
+  // Wasm request hooks
+  wasmEnabled: boolean
+  wasmModulePath: string
+  wasmFailOpen: boolean
+  wasmFuel: string
+  // gRPC control plane
+  controlGrpcEnabled: boolean
+  controlGrpcBind: string
+  controlApiToken: string
 }
 
 export const defaultFormState: ConfigFormState = {
@@ -187,4 +221,31 @@ export const defaultFormState: ConfigFormState = {
   searchApiToken: '',
   prometheusEnabled: true,
   grafanaEnabled: true,
+  upstreamCaCert: '',
+  upstreamHttp2Enabled: false,
+  preserveHeaderCase: false,
+  threatScoreEnabled: false,
+  threatScorePollUrl: 'http://127.0.0.1:8091/api/threat-scores',
+  threatScorePollInterval: '30',
+  threatScoreBlockThreshold: '0.9',
+  threatScoreWarnThreshold: '0.7',
+  hierarchyPeersPath: '',
+  icpServerEnabled: false,
+  icpBind: '0.0.0.0:3130',
+  htcpServerEnabled: false,
+  htcpBind: '0.0.0.0:4827',
+  peerDiscoveryEnabled: false,
+  peerDiscoveryMulticast: '239.255.77.77:3132',
+  rateLimitEnabled: false,
+  rateLimitMaxKeys: '100000',
+  ebpfXdpEnabled: false,
+  ebpfXdpIface: 'eth0',
+  ebpfXdpMode: 'driver',
+  wasmEnabled: false,
+  wasmModulePath: '/etc/bsdm-proxy/hooks.wasm',
+  wasmFailOpen: true,
+  wasmFuel: '1000000',
+  controlGrpcEnabled: false,
+  controlGrpcBind: '127.0.0.1:50051',
+  controlApiToken: '',
 }

--- a/admin-console/src/lib/theme.ts
+++ b/admin-console/src/lib/theme.ts
@@ -1,0 +1,28 @@
+export type Theme = 'dark' | 'light'
+
+const STORAGE_KEY = 'bsdm-admin-theme'
+
+export function loadTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'light' || stored === 'dark') return stored
+  } catch {
+    /* localStorage unavailable */
+  }
+  return window.matchMedia?.('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+}
+
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute('data-theme', theme)
+  try {
+    localStorage.setItem(STORAGE_KEY, theme)
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+export function initTheme(): Theme {
+  const theme = loadTheme()
+  document.documentElement.setAttribute('data-theme', theme)
+  return theme
+}

--- a/admin-console/src/lib/timeseries.ts
+++ b/admin-console/src/lib/timeseries.ts
@@ -1,0 +1,59 @@
+/**
+ * In-memory time-series accumulator. The console has no TSDB to query, so it
+ * builds short-horizon trends by recording each poll of /api/stats and
+ * /metrics. Counters are converted to per-second rates from consecutive
+ * samples; gauges are stored as-is. Survives route changes (module singleton),
+ * resets on full page reload.
+ */
+
+export interface TsPoint {
+  t: number
+  v: number
+}
+
+const MAX_POINTS = 720
+
+const gauges = new Map<string, TsPoint[]>()
+const counterLast = new Map<string, { t: number; v: number }>()
+
+function push(key: string, point: TsPoint): void {
+  let arr = gauges.get(key)
+  if (!arr) {
+    arr = []
+    gauges.set(key, arr)
+  }
+  arr.push(point)
+  if (arr.length > MAX_POINTS) arr.splice(0, arr.length - MAX_POINTS)
+}
+
+/** Record an instantaneous value (gauge, ratio, quantile). */
+export function recordGauge(key: string, value: number, t = Date.now()): void {
+  if (!Number.isFinite(value)) return
+  push(key, { t, v: value })
+}
+
+/**
+ * Record a cumulative counter; stores the derived per-second rate.
+ * Counter resets (process restart) yield a skipped interval, not a negative spike.
+ */
+export function recordCounter(key: string, cumulative: number, t = Date.now()): void {
+  if (!Number.isFinite(cumulative)) return
+  const last = counterLast.get(key)
+  counterLast.set(key, { t, v: cumulative })
+  if (!last || t <= last.t) return
+  const delta = cumulative - last.v
+  if (delta < 0) return
+  push(key, { t, v: delta / ((t - last.t) / 1000) })
+}
+
+/** Points within the trailing window (ms). */
+export function series(key: string, windowMs = 30 * 60_000): TsPoint[] {
+  const arr = gauges.get(key) ?? []
+  const cutoff = Date.now() - windowMs
+  return arr.filter((p) => p.t >= cutoff)
+}
+
+export function lastValue(key: string): number | null {
+  const arr = gauges.get(key)
+  return arr && arr.length > 0 ? arr[arr.length - 1].v : null
+}

--- a/admin-console/src/main.tsx
+++ b/admin-console/src/main.tsx
@@ -1,10 +1,29 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import { App } from './App.tsx'
+import { ToastProvider } from './components/ui/Toast'
+import { initTheme } from './lib/theme'
+
+initTheme()
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/admin-console/src/pages/AiSemanticCache.tsx
+++ b/admin-console/src/pages/AiSemanticCache.tsx
@@ -32,6 +32,7 @@ import {
 import { Button } from '../components/ui/Button'
 import { Modal } from '../components/ui/Modal'
 import { FormField } from '../components/ui/Form'
+import { PreviewBanner } from '../components/ui/DataState'
 
 export function AiSemanticCachePage() {
   const [, startTransition] = useTransition()
@@ -171,6 +172,7 @@ export function AiSemanticCachePage() {
 
   return (
     <div className="space-y-6">
+      <PreviewBanner feature="AI semantic cache management" />
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/admin-console/src/pages/Analytics.tsx
+++ b/admin-console/src/pages/Analytics.tsx
@@ -1,0 +1,252 @@
+import { useMemo, useState } from 'react'
+import { Download, RefreshCw } from 'lucide-react'
+import { enrichLog, searchLogs, type EnrichedLog } from '../api/search'
+import { fetchThreatScores } from '../api/threatScores'
+import { useSourcedQuery } from '../hooks/useSourced'
+import { Panel } from '../components/dashboard/MetricWidget'
+import { LineChart } from '../components/charts/LineChart'
+import { SegmentBar, type Segment } from '../components/charts/SegmentBar'
+import { BarList } from '../components/charts/BarList'
+import { Button } from '../components/ui/Button'
+import { Select } from '../components/ui/Form'
+import { ErrorState, EmptyState, SkeletonRows, SourceBadge } from '../components/ui/DataState'
+import { cacheStatusColor, seriesColor, STATUS_VARS } from '../components/charts/common'
+import type { TsPoint } from '../lib/timeseries'
+
+export function AnalyticsPage() {
+  const [days, setDays] = useState('7')
+  const [limit, setLimit] = useState('1000')
+
+  const logsQuery = useSourcedQuery(['analytics-logs', days, limit], () =>
+    searchLogs({ days: Number(days), limit: Number(limit) }),
+  )
+  const threats = useSourcedQuery(['threat-scores'], fetchThreatScores)
+
+  const logs = useMemo(() => (logsQuery.data?.data ?? []).map(enrichLog), [logsQuery.data])
+  const agg = useMemo(() => aggregate(logs), [logs])
+
+  return (
+    <div className="mx-auto max-w-7xl space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-text-primary">Analytics</h1>
+            {logsQuery.data && <SourceBadge source={logsQuery.data.source} />}
+          </div>
+          <p className="text-sm text-text-secondary">
+            Aggregations over the retro-search sample — traffic mix, blocking activity, top talkers
+          </p>
+        </div>
+        <div className="flex flex-wrap items-end gap-2">
+          <Select
+            label="Window"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            options={[
+              { value: '1', label: 'Last 24h' },
+              { value: '7', label: 'Last 7 days' },
+              { value: '30', label: 'Last 30 days' },
+            ]}
+          />
+          <Select
+            label="Sample"
+            value={limit}
+            onChange={(e) => setLimit(e.target.value)}
+            options={[
+              { value: '500', label: '500 events' },
+              { value: '1000', label: '1000 events' },
+              { value: '5000', label: '5000 events' },
+            ]}
+          />
+          <Button variant="secondary" onClick={() => logsQuery.refetch()} disabled={logsQuery.isFetching}>
+            <RefreshCw className={`size-4 ${logsQuery.isFetching ? 'animate-spin' : ''}`} />
+          </Button>
+          <Button variant="secondary" onClick={() => exportSummary(agg)} disabled={logs.length === 0}>
+            <Download className="size-4" /> Summary CSV
+          </Button>
+        </div>
+      </div>
+
+      {logsQuery.isPending && <SkeletonRows rows={6} />}
+      {logsQuery.isError && (
+        <ErrorState title="Search API unreachable" detail={logsQuery.error.message} onRetry={() => logsQuery.refetch()} />
+      )}
+      {logsQuery.data && logs.length === 0 && (
+        <EmptyState message="No events in the selected window — analytics needs traffic in the Search index." />
+      )}
+
+      {logs.length > 0 && (
+        <>
+          <p className="text-xs text-text-secondary">
+            Sample: <span className="tabular-nums text-text-primary">{logs.length.toLocaleString()}</span> events,{' '}
+            {new Date(agg.tMin * 1000).toLocaleString()} → {new Date(agg.tMax * 1000).toLocaleString()}. Counts below
+            describe this sample, not total traffic.
+          </p>
+
+          <Panel title="Events over time">
+            <LineChart
+              series={[
+                { name: 'All events', points: agg.overTime.all, slot: 0 },
+                { name: 'Blocked', points: agg.overTime.blocked, slot: 7 },
+              ]}
+              height={220}
+            />
+          </Panel>
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            <Panel title="HTTP status mix">
+              <SegmentBar segments={agg.statusSegments} />
+            </Panel>
+            <Panel title="Cache disposition">
+              <SegmentBar segments={agg.cacheSegments} />
+            </Panel>
+            <Panel title="Decision mix">
+              <SegmentBar segments={agg.decisionSegments} />
+            </Panel>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            <Panel title="Top domains">
+              <BarList items={agg.topDomains.map(([label, value]) => ({ label, value }))} />
+            </Panel>
+            <Panel title="Top clients">
+              <BarList items={agg.topClients.map(([label, value]) => ({ label, value, color: seriesColor(1) }))} />
+            </Panel>
+            <Panel title="Top blocked domains">
+              {agg.topBlocked.length === 0 ? (
+                <EmptyState message="No blocked requests in this sample." />
+              ) : (
+                <BarList items={agg.topBlocked.map(([label, value]) => ({ label, value, color: STATUS_VARS.critical }))} />
+              )}
+            </Panel>
+          </div>
+        </>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Panel title="Threat score severity" action={threats.data && <SourceBadge source={threats.data.source} />}>
+          {threats.isError && <EmptyState message="ML worker unreachable." />}
+          {threats.data && <SegmentBar segments={severitySegments(threats.data.data.scores.map((s) => s.severity))} />}
+        </Panel>
+        <Panel title="Threat scores by model">
+          {threats.data && threats.data.data.scores.length > 0 ? (
+            <BarList
+              items={countBy(threats.data.data.scores.map((s) => s.model))
+                .slice(0, 8)
+                .map(([label, value], i) => ({ label, value, color: seriesColor(i) }))}
+            />
+          ) : (
+            <EmptyState message="No active scores." />
+          )}
+        </Panel>
+      </div>
+    </div>
+  )
+}
+
+interface Aggregates {
+  tMin: number
+  tMax: number
+  overTime: { all: TsPoint[]; blocked: TsPoint[] }
+  statusSegments: Segment[]
+  cacheSegments: Segment[]
+  decisionSegments: Segment[]
+  topDomains: [string, number][]
+  topClients: [string, number][]
+  topBlocked: [string, number][]
+}
+
+function aggregate(logs: EnrichedLog[]): Aggregates {
+  const ts = logs.map((l) => l.ts)
+  const tMin = ts.length ? Math.min(...ts) : 0
+  const tMax = ts.length ? Math.max(...ts) : 1
+
+  const bucketCount = 40
+  const span = Math.max(tMax - tMin, 1)
+  const bucketSize = span / bucketCount
+  const all = new Array(bucketCount).fill(0)
+  const blocked = new Array(bucketCount).fill(0)
+  for (const l of logs) {
+    const i = Math.min(Math.floor((l.ts - tMin) / bucketSize), bucketCount - 1)
+    all[i] += 1
+    if (l.blockReason !== 'none') blocked[i] += 1
+  }
+  const toPoints = (arr: number[]): TsPoint[] =>
+    arr.map((v, i) => ({ t: (tMin + (i + 0.5) * bucketSize) * 1000, v }))
+
+  const statusPalette: Record<string, string> = {
+    '2xx': STATUS_VARS.good,
+    '3xx': seriesColor(0),
+    '4xx': STATUS_VARS.warning,
+    '5xx': STATUS_VARS.critical,
+  }
+  const decisions: Record<string, { label: string; color: string }> = {
+    none: { label: 'Allowed', color: STATUS_VARS.good },
+    acl: { label: 'ACL blocked', color: seriesColor(1) },
+    ml: { label: 'ML blocked', color: STATUS_VARS.critical },
+    threat: { label: 'Threat intel', color: STATUS_VARS.serious },
+  }
+
+  return {
+    tMin,
+    tMax,
+    overTime: { all: toPoints(all), blocked: toPoints(blocked) },
+    statusSegments: countBy(logs.map((l) => (l.status ? `${String(l.status)[0]}xx` : '(none)'))).map(
+      ([label, value]) => ({ label, value, color: statusPalette[label] ?? seriesColor(6) }),
+    ),
+    cacheSegments: countBy(logs.map((l) => l.cache_status ?? '(none)')).map(([label, value]) => ({
+      label,
+      value,
+      color: cacheStatusColor(label),
+    })),
+    decisionSegments: countBy(logs.map((l) => l.blockReason)).map(([key, value]) => ({
+      label: decisions[key]?.label ?? key,
+      value,
+      color: decisions[key]?.color ?? seriesColor(6),
+    })),
+    topDomains: countBy(logs.map((l) => l.domain ?? '(none)')).slice(0, 8),
+    topClients: countBy(logs.map((l) => l.client_ip ?? '(none)')).slice(0, 8),
+    topBlocked: countBy(logs.filter((l) => l.blockReason !== 'none').map((l) => l.domain ?? '(none)')).slice(0, 8),
+  }
+}
+
+function countBy(values: string[]): [string, number][] {
+  const map = new Map<string, number>()
+  for (const v of values) map.set(v, (map.get(v) ?? 0) + 1)
+  return [...map.entries()].sort((a, b) => b[1] - a[1])
+}
+
+function severitySegments(severities: string[]): Segment[] {
+  const palette: Record<string, string> = {
+    critical: STATUS_VARS.critical,
+    high: STATUS_VARS.serious,
+    medium: STATUS_VARS.warning,
+    low: STATUS_VARS.good,
+  }
+  const order = ['critical', 'high', 'medium', 'low']
+  return countBy(severities.map((s) => s.toLowerCase()))
+    .sort((a, b) => order.indexOf(a[0]) - order.indexOf(b[0]))
+    .map(([label, value]) => ({ label, value, color: palette[label] ?? seriesColor(6) }))
+}
+
+function exportSummary(agg: Aggregates): void {
+  const lines = ['section,key,value']
+  const add = (section: string, entries: [string, number][] | Segment[]) => {
+    for (const e of entries) {
+      const [k, v] = Array.isArray(e) ? e : [e.label, e.value]
+      lines.push(`${section},"${String(k).replace(/"/g, '""')}",${v}`)
+    }
+  }
+  add('status', agg.statusSegments)
+  add('cache', agg.cacheSegments)
+  add('decision', agg.decisionSegments)
+  add('top_domains', agg.topDomains)
+  add('top_clients', agg.topClients)
+  add('top_blocked', agg.topBlocked)
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = `bsdm-analytics-${new Date().toISOString().slice(0, 19)}.csv`
+  a.click()
+  URL.revokeObjectURL(a.href)
+}

--- a/admin-console/src/pages/ClusterMesh.tsx
+++ b/admin-console/src/pages/ClusterMesh.tsx
@@ -29,6 +29,7 @@ import {
 import { Button } from '../components/ui/Button'
 import { Modal } from '../components/ui/Modal'
 import { FormField } from '../components/ui/Form'
+import { PreviewBanner } from '../components/ui/DataState'
 
 export function ClusterMeshPage() {
   const [, startTransition] = useTransition()
@@ -188,6 +189,10 @@ export function ClusterMeshPage() {
 
   return (
     <div className="space-y-6">
+      <PreviewBanner feature="Cluster mesh management">
+        {' '}The real gRPC control plane exposes GetStats / PurgeCache / hierarchy RPCs, but node CRUD and mesh-wide
+        stats have no REST API yet.
+      </PreviewBanner>
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/admin-console/src/pages/Dashboard.tsx
+++ b/admin-console/src/pages/Dashboard.tsx
@@ -1,92 +1,266 @@
-import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { RefreshCw } from 'lucide-react'
-import { fetchDashboardMetrics, fetchTopMlScores } from '../api/metrics'
-import type { DashboardMetric, MlScoreRow } from '../api/metrics'
-import { MetricWidget, Panel, WidgetGrid } from '../components/dashboard/MetricWidget'
+import { fetchTelemetry, formatUptime, type Telemetry } from '../api/metrics'
+import { fetchThreatScores } from '../api/threatScores'
+import { fetchHierarchyPeers } from '../api/node'
+import { useSourcedQuery } from '../hooks/useSourced'
+import { Panel, StatTile, WidgetGrid } from '../components/dashboard/MetricWidget'
+import { LineChart } from '../components/charts/LineChart'
+import { SegmentBar, type Segment } from '../components/charts/SegmentBar'
+import { BarList } from '../components/charts/BarList'
 import { ThreatIndicator } from '../components/xai/ThreatIndicator'
 import { Button } from '../components/ui/Button'
+import { ErrorState, EmptyState, Skeleton, SourceBadge } from '../components/ui/DataState'
 import { severityBadge } from '../theme/tokens'
+import { cacheStatusColor, formatNumber, seriesColor, STATUS_VARS } from '../components/charts/common'
+
+const POLL_MS = 10_000
 
 export function DashboardPage() {
-  const [metrics, setMetrics] = useState<DashboardMetric[]>([])
-  const [mlScores, setMlScores] = useState<MlScoreRow[]>([])
-  const [loading, setLoading] = useState(true)
+  const telemetry = useSourcedQuery(['telemetry'], fetchTelemetry, { refetchInterval: POLL_MS })
+  const threats = useSourcedQuery(['threat-scores'], fetchThreatScores, { refetchInterval: 60_000 })
+  const peers = useSourcedQuery(['hierarchy-peers'], fetchHierarchyPeers, { refetchInterval: 60_000 })
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    const [m, s] = await Promise.all([fetchDashboardMetrics(), fetchTopMlScores()])
-    setMetrics(m)
-    setMlScores(s)
-    setLoading(false)
-  }, [])
-
-  useEffect(() => {
-    load()
-  }, [load])
+  const t = telemetry.data?.data
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-text-primary">Dashboard</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-text-primary">Dashboard</h1>
+            {telemetry.data && <SourceBadge source={telemetry.data.source} />}
+          </div>
           <p className="text-sm text-text-secondary">
-            Proxy health, cache performance, and ML anomaly overview
+            Proxy health, traffic, cache and threat overview · auto-refresh {POLL_MS / 1000}s
           </p>
         </div>
-        <Button variant="secondary" onClick={load} disabled={loading}>
-          <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
+        <Button variant="secondary" onClick={() => telemetry.refetch()} disabled={telemetry.isFetching}>
+          <RefreshCw className={`size-4 ${telemetry.isFetching ? 'animate-spin' : ''}`} />
           Refresh
         </Button>
       </div>
 
-      <WidgetGrid>
-        {metrics.map((m) => (
-          <MetricWidget key={m.id} metric={m} />
-        ))}
-      </WidgetGrid>
+      {telemetry.isPending && (
+        <WidgetGrid>
+          {Array.from({ length: 6 }, (_, i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </WidgetGrid>
+      )}
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Panel title="Top ML anomalies (UEBA)">
-          {mlScores.length === 0 ? (
-            <p className="text-sm text-text-secondary">No scores available.</p>
-          ) : (
-            <ul className="space-y-4">
-              {mlScores.map((row) => (
-                <li key={`${row.entity_type}-${row.entity_id}`} className="space-y-2">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <div>
-                      <span className="font-mono text-sm text-text-primary">{row.entity_id}</span>
-                      <span className="ml-2 text-xs text-text-secondary">({row.entity_type})</span>
+      {telemetry.isError && (
+        <ErrorState
+          title="Proxy control API unreachable"
+          detail={telemetry.error.message}
+          onRetry={() => telemetry.refetch()}
+        />
+      )}
+
+      {t && <HealthRow t={t} />}
+
+      {t && (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Panel title="Request rate (req/s)">
+            <LineChart
+              series={[
+                { name: 'Requests', points: t.reqRate, slot: 0 },
+                { name: 'ACL denies', points: t.denyRate, slot: 1 },
+                { name: '5xx errors', points: t.errRate, slot: 7 },
+              ]}
+              area={false}
+            />
+          </Panel>
+          <Panel title="Cache hit ratio (%)">
+            <LineChart series={[{ name: 'Hit ratio', points: t.hitRatio, slot: 2 }]} area yMax={100} unit="%" />
+          </Panel>
+        </div>
+      )}
+
+      {t && (
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Panel title="HTTP status mix (cumulative)">
+            <SegmentBar segments={statusSegments(t.statusClasses)} />
+          </Panel>
+          <Panel title="Cache disposition (cumulative)">
+            <SegmentBar segments={cacheSegments(t.cacheStatus)} />
+          </Panel>
+          <Panel title="ACL decisions (cumulative)">
+            <SegmentBar
+              segments={[
+                { label: 'allow', value: t.aclDecisions.allow ?? 0, color: STATUS_VARS.good },
+                { label: 'deny', value: (t.aclDecisions.deny ?? 0) + (t.aclDecisions.block ?? 0), color: STATUS_VARS.critical },
+              ]}
+            />
+            {t.rateLimitRejected > 0 && (
+              <p className="mt-3 text-xs text-text-secondary">
+                Rate-limit rejections: <span className="tabular-nums text-warning">{formatNumber(t.rateLimitRejected)}</span>
+              </p>
+            )}
+          </Panel>
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {t && (
+          <Panel title="Top upstream hosts">
+            {t.topUpstreams.length === 0 ? (
+              <EmptyState message="No upstream metrics yet — traffic will populate this panel." />
+            ) : (
+              <BarList
+                items={t.topUpstreams.map((u) => ({
+                  label: u.host,
+                  value: u.requests,
+                  extra: u.errors > 0 ? `${formatNumber(u.errors)} err` : undefined,
+                }))}
+              />
+            )}
+          </Panel>
+        )}
+
+        <Panel
+          title="Top ML anomalies (UEBA)"
+          action={threats.data && <SourceBadge source={threats.data.source} />}
+        >
+          {threats.isError && <EmptyState message="ML worker unreachable — no scores." />}
+          {threats.data && threats.data.data.scores.length === 0 && (
+            <EmptyState message="No active threat scores in the write-back snapshot." />
+          )}
+          {threats.data && threats.data.data.scores.length > 0 && (
+            <ul className="space-y-3">
+              {[...threats.data.data.scores]
+                .sort((a, b) => b.score - a.score)
+                .slice(0, 5)
+                .map((row) => (
+                  <li key={`${row.entity_type}-${row.entity_id}-${row.model}`} className="space-y-1.5">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <Link
+                        to={`/logs?q=${encodeURIComponent(entityQuery(row.entity_id))}`}
+                        className="font-mono text-sm text-text-primary underline-offset-2 hover:underline"
+                        title="Investigate related traffic"
+                      >
+                        {row.entity_id}
+                      </Link>
+                      <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${severityBadge(row.severity)}`}>
+                        {row.severity}
+                      </span>
                     </div>
-                    <span className={`rounded-full border px-2 py-0.5 text-xs font-medium ${severityBadge(row.severity)}`}>
-                      {row.severity}
-                    </span>
+                    <ThreatIndicator score={row.score} size="sm" label={row.model} />
+                  </li>
+                ))}
+            </ul>
+          )}
+        </Panel>
+
+        <Panel
+          title="Hierarchy peers (ICP/HTCP)"
+          action={peers.data && <SourceBadge source={peers.data.source} />}
+        >
+          {peers.isError && <EmptyState message="Hierarchy API unreachable or hierarchy disabled." />}
+          {peers.data && peers.data.data.length === 0 && <EmptyState message="No cache hierarchy peers configured." />}
+          {peers.data && peers.data.data.length > 0 && (
+            <ul className="divide-y divide-border/50 text-sm">
+              {peers.data.data.map((p, i) => (
+                <li key={`${p.name ?? p.host ?? i}`} className="flex items-center justify-between gap-2 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-mono text-xs text-text-primary">{String(p.name ?? p.host ?? '—')}</p>
+                    <p className="text-xs text-text-secondary">
+                      {String(p.peer_type ?? 'peer')} · {String(p.host ?? '')}:{String(p.http_port ?? '')}
+                    </p>
                   </div>
-                  <ThreatIndicator score={row.score} size="sm" />
+                  <span className={`text-xs font-semibold ${p.state === 'dead' ? 'text-danger' : 'text-success'}`}>
+                    {String(p.state ?? 'alive')}
+                  </span>
                 </li>
               ))}
             </ul>
           )}
         </Panel>
-
-        <Panel title="Quick ACL status">
-          <p className="mb-4 text-sm text-text-secondary">
-            Manage category blocks and runtime rules on the Policies page. REST API:
-            <code className="ml-1 rounded bg-surface-0 px-1.5 py-0.5 font-mono text-xs">/api/acl/rules</code>
-          </p>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {['malware', 'phishing', 'gambling', 'adult'].map((cat) => (
-              <div
-                key={cat}
-                className="flex items-center justify-between rounded-md border border-border bg-surface-0 px-3 py-2"
-              >
-                <span className="text-sm capitalize text-text-primary">{cat}</span>
-                <span className="text-xs text-success">configured</span>
-              </div>
-            ))}
-          </div>
-        </Panel>
       </div>
     </div>
   )
+}
+
+function HealthRow({ t }: { t: Telemetry }) {
+  const errShare = shareOf(t.statusClasses, '5xx')
+  const latP95Ms = t.latency ? t.latency.p95 * 1000 : null
+  return (
+    <WidgetGrid>
+      <StatTile
+        label="Requests / s"
+        value={t.reqRate.length ? formatNumber(t.reqRate[t.reqRate.length - 1].v) : '—'}
+        trend={t.reqRate}
+        trendColor={seriesColor(0)}
+        hint={`Total since start: ${t.totalRequests.toLocaleString()}`}
+      />
+      <StatTile
+        label="Error share (5xx)"
+        value={errShare === null ? '—' : (errShare * 100).toFixed(2)}
+        unit="%"
+        trend={t.errRate}
+        trendColor={seriesColor(7)}
+        status={errShare !== null && errShare > 0.05 ? 'error' : errShare !== null && errShare > 0.01 ? 'warn' : 'ok'}
+      />
+      <StatTile
+        label="Cache hit rate"
+        value={t.stats ? (t.stats.cache.hit_ratio * 100).toFixed(1) : '—'}
+        unit="%"
+        trend={t.hitRatio}
+        trendColor={seriesColor(2)}
+        hint={t.stats ? `${t.stats.cache.entries}/${t.stats.cache.capacity} L1 entries · ${formatNumber(t.cacheEvictions)} evictions` : undefined}
+      />
+      <StatTile
+        label="Latency p95"
+        value={latP95Ms === null ? '—' : formatNumber(latP95Ms)}
+        unit="ms"
+        trend={t.latP95}
+        trendColor={seriesColor(3)}
+        hint={t.latency ? `p50 ${(t.latency.p50 * 1000).toFixed(1)}ms · p99 ${(t.latency.p99 * 1000).toFixed(0)}ms` : 'Histogram not available'}
+        status={latP95Ms !== null && latP95Ms > 500 ? 'warn' : 'ok'}
+      />
+      <StatTile
+        label="In flight"
+        value={t.stats ? String(t.stats.requests_in_flight) : '—'}
+        trend={t.inFlight}
+        trendColor={seriesColor(4)}
+      />
+      <StatTile
+        label="Uptime"
+        value={t.stats ? formatUptime(t.stats.uptime_secs) : '—'}
+        hint={t.stats?.service}
+      />
+    </WidgetGrid>
+  )
+}
+
+function shareOf(classes: Record<string, number>, key: string): number | null {
+  const total = Object.values(classes).reduce((sum, v) => sum + v, 0)
+  if (total === 0) return null
+  return (classes[key] ?? 0) / total
+}
+
+function statusSegments(classes: Record<string, number>): Segment[] {
+  const palette: Record<string, string> = {
+    '2xx': STATUS_VARS.good,
+    '3xx': seriesColor(0),
+    '4xx': STATUS_VARS.warning,
+    '5xx': STATUS_VARS.critical,
+  }
+  return Object.entries(classes)
+    .sort()
+    .map(([label, value]) => ({ label, value, color: palette[label] ?? seriesColor(6) }))
+}
+
+function cacheSegments(cache: Record<string, number>): Segment[] {
+  const order = ['HIT', 'MISS', 'BYPASS', 'DENIED', 'COALESCED']
+  const entries = Object.entries(cache).sort(
+    (a, b) => (order.indexOf(a[0]) + 99) - (order.indexOf(b[0]) + 99) || b[1] - a[1],
+  )
+  return entries.map(([label, value]) => ({ label, value, color: cacheStatusColor(label) }))
+}
+
+/** client_ip|domain composite ids → search the domain part. */
+function entityQuery(entityId: string): string {
+  const parts = entityId.split('|')
+  return parts[parts.length - 1]
 }

--- a/admin-console/src/pages/Logs.tsx
+++ b/admin-console/src/pages/Logs.tsx
@@ -1,161 +1,387 @@
-import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, Search } from 'lucide-react'
-import { searchLogs, enrichLog, type EnrichedLog } from '../api/search'
+import { useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Download, Play, Pause, RefreshCw, Search } from 'lucide-react'
+import {
+  applyLogFilters,
+  emptyLogFilters,
+  enrichLog,
+  searchLogs,
+  type EnrichedLog,
+  type LogFilters,
+} from '../api/search'
+import { useSourcedQuery } from '../hooks/useSourced'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Form'
+import { Input, Select } from '../components/ui/Form'
 import { Modal } from '../components/ui/Modal'
+import { ErrorState, EmptyState, SkeletonRows, SourceBadge } from '../components/ui/DataState'
 import { BlockReasonBadge, InsightPanel, ThreatIndicator } from '../components/xai/ThreatIndicator'
 
+const PAGE_SIZE = 25
+const TAIL_MS = 5_000
+
 export function LogsPage() {
-  const [domain, setDomain] = useState('')
-  const [logs, setLogs] = useState<EnrichedLog[]>([])
-  const [loading, setLoading] = useState(false)
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // Server-side query (submitted on Search).
+  const [domain, setDomain] = useState(searchParams.get('q') ?? '')
+  const [username, setUsername] = useState('')
+  const [days, setDays] = useState('7')
+  const [limit, setLimit] = useState('200')
+  const [query, setQuery] = useState({ domain: searchParams.get('q') ?? '', username: '', days: 7, limit: 200 })
+
+  // Client-side filters (instant).
+  const [filters, setFilters] = useState<LogFilters>(emptyLogFilters)
+  const [tail, setTail] = useState(false)
+  const [page, setPage] = useState(0)
   const [selected, setSelected] = useState<EnrichedLog | null>(null)
+  const [sessionFilter, setSessionFilter] = useState<string | null>(null)
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    const raw = await searchLogs({ domain: domain || undefined, limit: 50 })
-    setLogs(raw.map(enrichLog))
-    setLoading(false)
-  }, [domain])
+  const result = useSourcedQuery(
+    ['logs', query, sessionFilter],
+    () =>
+      searchLogs({
+        domain: query.domain || undefined,
+        username: query.username || undefined,
+        session_id: sessionFilter ?? undefined,
+        days: query.days,
+        limit: query.limit,
+      }),
+    { refetchInterval: tail ? TAIL_MS : false },
+  )
 
-  useEffect(() => {
-    load()
-  }, [load])
+  const enriched = useMemo(
+    () => (result.data?.data ?? []).map(enrichLog).sort((a, b) => b.ts - a.ts),
+    [result.data],
+  )
+  const filtered = useMemo(() => applyLogFilters(enriched, filters), [enriched, filters])
+
+  const methods = useMemo(() => distinct(enriched.map((l) => l.method?.toUpperCase())), [enriched])
+  const cacheStatuses = useMemo(() => distinct(enriched.map((l) => l.cache_status)), [enriched])
+
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const pageRows = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  const submit = () => {
+    setPage(0)
+    setSessionFilter(null)
+    setQuery({ domain, username, days: Number(days) || 7, limit: Number(limit) || 200 })
+    setSearchParams(domain ? { q: domain } : {})
+  }
+
+  const updateFilter = <K extends keyof LogFilters>(key: K, value: LogFilters[K]) => {
+    setPage(0)
+    setFilters((prev) => ({ ...prev, [key]: value }))
+  }
 
   return (
     <div className="mx-auto max-w-7xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-text-primary">Traffic logs</h1>
-        <p className="text-sm text-text-secondary">
-          Retro-search via Search API — click a denied row for ML explainability
-        </p>
-      </div>
-
-      <div className="flex flex-col gap-3 sm:flex-row">
-        <div className="flex-1">
-          <Input
-            label="Domain filter"
-            placeholder="example.com"
-            value={domain}
-            onChange={(e) => setDomain(e.target.value)}
-          />
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-text-primary">Traffic logs</h1>
+            {result.data && <SourceBadge source={result.data.source} />}
+          </div>
+          <p className="text-sm text-text-secondary">
+            Retro-search with client-side drill-down · click a row for decision details and session timeline
+          </p>
         </div>
-        <div className="flex items-end">
-          <Button onClick={load} disabled={loading} className="w-full sm:w-auto">
-            <Search className="size-4" />
-            Search
+        <div className="flex flex-wrap gap-2">
+          <Button variant={tail ? 'primary' : 'secondary'} onClick={() => setTail((v) => !v)}>
+            {tail ? <Pause className="size-4" /> : <Play className="size-4" />}
+            {tail ? 'Tailing 5s' : 'Live tail'}
+          </Button>
+          <Button variant="secondary" onClick={() => exportCsv(filtered)} disabled={filtered.length === 0}>
+            <Download className="size-4" /> CSV
           </Button>
         </div>
       </div>
 
-      {/* Desktop table */}
-      <div className="hidden overflow-x-auto rounded-lg border border-border md:block">
-        <table className="w-full min-w-[640px] text-left text-sm">
-          <thead className="border-b border-border bg-surface-2 text-xs uppercase text-text-secondary">
-            <tr>
-              <th className="px-4 py-3">Time</th>
-              <th className="px-4 py-3">Client</th>
-              <th className="px-4 py-3">Domain</th>
-              <th className="px-4 py-3">Status</th>
-              <th className="px-4 py-3">Block</th>
-            </tr>
-          </thead>
-          <tbody>
-            {logs.map((log) => (
-              <tr
-                key={log.event_id ?? `${log.ts}-${log.url}`}
-                className={`border-b border-border/50 hover:bg-surface-2/50 ${log.blockReason !== 'none' ? 'cursor-pointer' : ''}`}
-                onClick={() => log.blockReason !== 'none' && setSelected(log)}
-              >
-                <td className="px-4 py-3 font-mono text-xs text-text-secondary">
-                  {new Date(log.ts * 1000).toLocaleString()}
-                </td>
-                <td className="px-4 py-3 font-mono text-xs">{log.client_ip ?? '—'}</td>
-                <td className="max-w-[200px] truncate px-4 py-3">{log.domain}</td>
-                <td className="px-4 py-3">{log.status}</td>
-                <td className="px-4 py-3">
-                  <BlockReasonBadge reason={log.blockReason} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {/* Server-side query row */}
+      <form
+        className="grid gap-3 rounded-lg border border-border bg-surface-1 p-4 sm:grid-cols-2 lg:grid-cols-5"
+        onSubmit={(e) => {
+          e.preventDefault()
+          submit()
+        }}
+      >
+        <Input label="Domain" placeholder="example.com" value={domain} onChange={(e) => setDomain(e.target.value)} />
+        <Input label="Username" placeholder="jdoe" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <Select
+          label="Window"
+          value={days}
+          onChange={(e) => setDays(e.target.value)}
+          options={[
+            { value: '1', label: 'Last 24h' },
+            { value: '7', label: 'Last 7 days' },
+            { value: '30', label: 'Last 30 days' },
+            { value: '90', label: 'Last 90 days' },
+          ]}
+        />
+        <Select
+          label="Fetch limit"
+          value={limit}
+          onChange={(e) => setLimit(e.target.value)}
+          options={[
+            { value: '100', label: '100 rows' },
+            { value: '200', label: '200 rows' },
+            { value: '500', label: '500 rows' },
+            { value: '1000', label: '1000 rows' },
+          ]}
+        />
+        <div className="flex items-end">
+          <Button type="submit" disabled={result.isFetching} className="w-full">
+            <Search className="size-4" /> Search
+          </Button>
+        </div>
+      </form>
+
+      {/* Client-side filter row */}
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <Input
+          label="Client IP contains"
+          placeholder="10.0.1."
+          value={filters.clientIp}
+          onChange={(e) => updateFilter('clientIp', e.target.value)}
+        />
+        <Select
+          label="Status class"
+          value={filters.statusClass}
+          onChange={(e) => updateFilter('statusClass', e.target.value)}
+          options={[
+            { value: 'all', label: 'All statuses' },
+            { value: '2xx', label: '2xx success' },
+            { value: '3xx', label: '3xx redirect' },
+            { value: '4xx', label: '4xx client error' },
+            { value: '5xx', label: '5xx server error' },
+          ]}
+        />
+        <Select
+          label="Method"
+          value={filters.method}
+          onChange={(e) => updateFilter('method', e.target.value)}
+          options={[{ value: 'all', label: 'All methods' }, ...methods.map((m) => ({ value: m, label: m }))]}
+        />
+        <Select
+          label="Cache status"
+          value={filters.cacheStatus}
+          onChange={(e) => updateFilter('cacheStatus', e.target.value)}
+          options={[{ value: 'all', label: 'All' }, ...cacheStatuses.map((c) => ({ value: c, label: c }))]}
+        />
+        <Select
+          label="Decision"
+          value={filters.blockReason}
+          onChange={(e) => updateFilter('blockReason', e.target.value)}
+          options={[
+            { value: 'all', label: 'All decisions' },
+            { value: 'none', label: 'Allowed' },
+            { value: 'acl', label: 'ACL blocked' },
+            { value: 'ml', label: 'ML / UEBA blocked' },
+            { value: 'threat', label: 'Threat intel blocked' },
+          ]}
+        />
       </div>
 
-      {/* Mobile card list */}
-      <div className="space-y-3 md:hidden">
-        {logs.map((log) => (
-          <button
-            key={log.event_id ?? `${log.ts}-${log.url}`}
-            type="button"
-            className="w-full rounded-lg border border-border bg-surface-1 p-4 text-left"
-            onClick={() => log.blockReason !== 'none' && setSelected(log)}
-            disabled={log.blockReason === 'none'}
-          >
-            <div className="flex items-start justify-between gap-2">
-              <span className="font-medium text-text-primary">{log.domain}</span>
-              <BlockReasonBadge reason={log.blockReason} />
-            </div>
-            <p className="mt-1 font-mono text-xs text-text-secondary">{log.client_ip}</p>
-            <p className="mt-1 text-xs text-text-secondary">
-              {new Date(log.ts * 1000).toLocaleString()} · HTTP {log.status}
-            </p>
+      {sessionFilter && (
+        <div className="flex items-center gap-3 rounded-md border border-accent/40 bg-accent/10 px-4 py-2 text-sm">
+          <span className="text-text-primary">
+            Session <code className="font-mono text-accent">{sessionFilter}</code>
+          </span>
+          <button type="button" className="text-xs text-text-secondary underline" onClick={() => setSessionFilter(null)}>
+            clear
           </button>
-        ))}
-      </div>
-
-      {loading && (
-        <div className="flex justify-center py-8">
-          <RefreshCw className="size-6 animate-spin text-text-secondary" />
         </div>
       )}
 
-      <LogDetailModal log={selected} onClose={() => setSelected(null)} />
+      {result.isPending && <SkeletonRows rows={8} />}
+      {result.isError && (
+        <ErrorState title="Search API unreachable" detail={result.error.message} onRetry={() => result.refetch()} />
+      )}
+      {result.data && filtered.length === 0 && <EmptyState message="No log rows match the current query and filters." />}
+
+      {filtered.length > 0 && (
+        <>
+          <div className="hidden overflow-x-auto rounded-lg border border-border md:block">
+            <table className="w-full min-w-[760px] text-left text-sm">
+              <thead className="border-b border-border bg-surface-2 text-xs uppercase text-text-secondary">
+                <tr>
+                  <th className="px-4 py-3">Time</th>
+                  <th className="px-4 py-3">Client</th>
+                  <th className="px-4 py-3">User</th>
+                  <th className="px-4 py-3">Method</th>
+                  <th className="px-4 py-3">Domain</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Cache</th>
+                  <th className="px-4 py-3">Decision</th>
+                  <th className="px-4 py-3">Session</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageRows.map((log) => (
+                  <tr
+                    key={log.event_id ?? `${log.ts}-${log.url}`}
+                    className="cursor-pointer border-b border-border/50 hover:bg-surface-2/50"
+                    onClick={() => setSelected(log)}
+                  >
+                    <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-text-secondary">
+                      {new Date(log.ts * 1000).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs">{log.client_ip ?? '—'}</td>
+                    <td className="px-4 py-2.5 text-xs">{log.username ?? '—'}</td>
+                    <td className="px-4 py-2.5 font-mono text-xs">{log.method ?? '—'}</td>
+                    <td className="max-w-[220px] truncate px-4 py-2.5" title={log.url}>
+                      {log.domain}
+                    </td>
+                    <td className="px-4 py-2.5 tabular-nums">{log.status ?? '—'}</td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-text-secondary">{log.cache_status ?? '—'}</td>
+                    <td className="px-4 py-2.5">
+                      <BlockReasonBadge reason={log.blockReason} />
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {log.session_id ? (
+                        <button
+                          type="button"
+                          className="font-mono text-xs text-accent underline-offset-2 hover:underline"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setSessionFilter(log.session_id!)
+                            setPage(0)
+                          }}
+                          title="Filter to this session"
+                        >
+                          {log.session_id.slice(0, 10)}
+                        </button>
+                      ) : (
+                        <span className="text-xs text-text-secondary">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="space-y-3 md:hidden">
+            {pageRows.map((log) => (
+              <button
+                key={log.event_id ?? `${log.ts}-${log.url}`}
+                type="button"
+                className="w-full rounded-lg border border-border bg-surface-1 p-4 text-left"
+                onClick={() => setSelected(log)}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="font-medium text-text-primary">{log.domain}</span>
+                  <BlockReasonBadge reason={log.blockReason} />
+                </div>
+                <p className="mt-1 font-mono text-xs text-text-secondary">
+                  {log.client_ip} · {log.method} · HTTP {log.status} · {log.cache_status}
+                </p>
+                <p className="mt-1 text-xs text-text-secondary">{new Date(log.ts * 1000).toLocaleString()}</p>
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-text-secondary">
+            <span>
+              {filtered.length} rows{filtered.length !== enriched.length && ` (of ${enriched.length} fetched)`}
+              {result.isFetching && <RefreshCw className="ml-2 inline size-3.5 animate-spin" />}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
+                ← Prev
+              </Button>
+              <span className="tabular-nums">
+                {page + 1} / {pages}
+              </span>
+              <Button variant="ghost" disabled={page >= pages - 1} onClick={() => setPage((p) => p + 1)}>
+                Next →
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      <LogDetailModal
+        log={selected}
+        related={selected?.session_id ? enriched.filter((l) => l.session_id === selected.session_id) : []}
+        onClose={() => setSelected(null)}
+        onOpenSession={(sid) => {
+          setSelected(null)
+          setSessionFilter(sid)
+          setPage(0)
+        }}
+      />
     </div>
   )
 }
 
-function LogDetailModal({ log, onClose }: { log: EnrichedLog | null; onClose: () => void }) {
+function distinct(values: (string | undefined)[]): string[] {
+  return [...new Set(values.filter((v): v is string => !!v))].sort()
+}
+
+function exportCsv(rows: EnrichedLog[]): void {
+  const header = ['ts', 'time', 'client_ip', 'username', 'method', 'domain', 'url', 'status', 'cache_status', 'decision', 'session_id', 'event_id']
+  const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`
+  const lines = [
+    header.join(','),
+    ...rows.map((l) =>
+      [l.ts, new Date(l.ts * 1000).toISOString(), l.client_ip, l.username, l.method, l.domain, l.url, l.status, l.cache_status, l.blockReason, l.session_id, l.event_id]
+        .map(esc)
+        .join(','),
+    ),
+  ]
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' })
+  const a = document.createElement('a')
+  a.href = URL.createObjectURL(blob)
+  a.download = `bsdm-logs-${new Date().toISOString().slice(0, 19)}.csv`
+  a.click()
+  URL.revokeObjectURL(a.href)
+}
+
+function LogDetailModal({
+  log,
+  related,
+  onClose,
+  onOpenSession,
+}: {
+  log: EnrichedLog | null
+  related: EnrichedLog[]
+  onClose: () => void
+  onOpenSession: (sessionId: string) => void
+}) {
   const isMl = log?.blockReason === 'ml'
+  const timeline = [...related].sort((a, b) => a.ts - b.ts)
 
   return (
-    <Modal
-      open={!!log}
-      onClose={onClose}
-      title="Request decision details"
-      wide
-    >
+    <Modal open={!!log} onClose={onClose} title="Request decision details" wide>
       {log && (
         <div className="space-y-6">
           <dl className="grid gap-3 text-sm sm:grid-cols-2">
-            <div>
-              <dt className="text-text-secondary">URL</dt>
-              <dd className="break-all font-mono text-xs text-text-primary">{log.url}</dd>
-            </div>
-            <div>
-              <dt className="text-text-secondary">Client IP</dt>
-              <dd className="font-mono">{log.client_ip}</dd>
-            </div>
+            <Field label="URL" mono breakAll>{log.url ?? '—'}</Field>
+            <Field label="Client IP / user" mono>{`${log.client_ip ?? '—'}${log.username ? ` · ${log.username}` : ''}`}</Field>
+            <Field label="Method / HTTP status">{`${log.method ?? '—'} · ${log.status ?? '—'}`}</Field>
+            <Field label="Cache status" mono>{log.cache_status ?? '—'}</Field>
             <div>
               <dt className="text-text-secondary">Decision source</dt>
               <dd className="mt-1">
                 <BlockReasonBadge reason={log.blockReason} />
               </dd>
             </div>
-            <div>
-              <dt className="text-text-secondary">HTTP status</dt>
-              <dd>{log.status}</dd>
-            </div>
+            <Field label="Event / parent" mono>
+              {`${log.event_id ?? '—'}${log.parent_event_id ? ` ← ${log.parent_event_id}` : ''}`}
+            </Field>
           </dl>
+
+          {log.redirect_url && (
+            <p className="rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-text-primary">
+              Redirected to <code className="break-all font-mono">{log.redirect_url}</code>
+            </p>
+          )}
 
           {isMl && log.mlScore !== undefined && (
             <>
               <ThreatIndicator score={log.mlScore} size="lg" />
               <div>
-                <h3 className="mb-3 text-sm font-semibold text-text-primary">
-                  Contributing factors
-                </h3>
+                <h3 className="mb-3 text-sm font-semibold text-text-primary">Contributing factors</h3>
                 <InsightPanel factors={log.mlFactors ?? []} model={log.mlModel} />
               </div>
             </>
@@ -166,8 +392,72 @@ function LogDetailModal({ log, onClose }: { log: EnrichedLog | null; onClose: ()
               This request was blocked by an ACL category or domain rule. No ML scoring was applied.
             </p>
           )}
+
+          {log.session_id && (
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-text-primary">
+                  Session timeline <code className="ml-1 font-mono text-xs text-text-secondary">{log.session_id}</code>
+                </h3>
+                <button
+                  type="button"
+                  className="text-xs text-accent underline-offset-2 hover:underline"
+                  onClick={() => onOpenSession(log.session_id!)}
+                >
+                  Query full session
+                </button>
+              </div>
+              {timeline.length <= 1 ? (
+                <p className="text-xs text-text-secondary">
+                  No other events for this session in the current result set — use “Query full session” to fetch it server-side.
+                </p>
+              ) : (
+                <ol className="space-y-1.5 border-l border-border pl-4">
+                  {timeline.map((ev) => (
+                    <li key={ev.event_id ?? `${ev.ts}-${ev.url}`} className="relative text-xs">
+                      <span
+                        className={`absolute -left-[21px] top-1 size-2.5 rounded-full ${ev.event_id === log.event_id ? 'bg-accent' : 'bg-surface-3'}`}
+                      />
+                      <span className="font-mono text-text-secondary">
+                        {new Date(ev.ts * 1000).toLocaleTimeString()}
+                      </span>{' '}
+                      <span className="text-text-primary">{ev.domain}</span>{' '}
+                      <span className="text-text-secondary">
+                        {ev.method} {ev.status}
+                      </span>{' '}
+                      {ev.blockReason !== 'none' && <BlockReasonBadge reason={ev.blockReason} />}
+                      {ev.parent_event_id && (
+                        <span className="ml-1 text-text-secondary">← {ev.parent_event_id}</span>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          )}
         </div>
       )}
     </Modal>
+  )
+}
+
+function Field({
+  label,
+  children,
+  mono,
+  breakAll,
+}: {
+  label: string
+  children: React.ReactNode
+  mono?: boolean
+  breakAll?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-text-secondary">{label}</dt>
+      <dd className={`${mono ? 'font-mono text-xs' : ''} ${breakAll ? 'break-all' : ''} text-text-primary`}>
+        {children}
+      </dd>
+    </div>
   )
 }

--- a/admin-console/src/pages/Policies.tsx
+++ b/admin-console/src/pages/Policies.tsx
@@ -11,8 +11,11 @@ import {
 import { fetchEbpfStats, fetchEbpfBlockedIps, type EbpfStats, type EbpfBlockedIp } from '../api/ebpf'
 import { Button } from '../components/ui/Button'
 import { Panel } from '../components/dashboard/MetricWidget'
+import { PreviewBanner } from '../components/ui/DataState'
+import { useToast } from '../components/ui/Toast'
 
 export function PoliciesPage() {
+  const { toast } = useToast()
   const [data, setData] = useState<AclRulesResponse | null>(null)
   const [ebpfStats, setEbpfStats] = useState<EbpfStats | null>(null)
   const [ebpfIps, setEbpfIps] = useState<EbpfBlockedIp[]>([])
@@ -41,8 +44,9 @@ export function PoliciesPage() {
     try {
       await reloadAclRules()
       await load()
+      toast('success', 'ACL rules reloaded from file')
     } catch {
-      alert('Reload failed — check ACL API connection in Settings')
+      toast('error', 'Reload failed — check ACL API connection in Settings')
     }
     setBusy(false)
   }
@@ -51,9 +55,9 @@ export function PoliciesPage() {
     setBusy(true)
     try {
       await persistAclRules()
-      alert('Rules persisted to ACL_RULES_PATH')
+      toast('success', 'Rules persisted to ACL_RULES_PATH')
     } catch {
-      alert('Persist failed — ACL_RULES_PATH may be unset or unwritable')
+      toast('error', 'Persist failed — ACL_RULES_PATH may be unset or unwritable')
     }
     setBusy(false)
   }
@@ -64,8 +68,9 @@ export function PoliciesPage() {
     try {
       await deleteAclRule(id)
       await load()
+      toast('success', `Rule "${id}" deleted`)
     } catch {
-      alert('Delete failed — check ACL API token / connection')
+      toast('error', 'Delete failed — check ACL API token / connection')
     }
     setBusy(false)
   }
@@ -143,6 +148,7 @@ export function PoliciesPage() {
       {/* eBPF XDP Kernel Bypass Panel */}
       <Panel title="eBPF / XDP Kernel Packet Drop Bypass (L4 Hardware Layer)">
         <div className="space-y-4">
+          <PreviewBanner feature="The eBPF/XDP stats view" />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div className="rounded-md border border-border bg-surface-0 p-3">
               <div className="flex items-center justify-between text-xs text-text-secondary">

--- a/admin-console/src/pages/RpzManagement.tsx
+++ b/admin-console/src/pages/RpzManagement.tsx
@@ -41,6 +41,7 @@ import {
 import { Button } from '../components/ui/Button'
 import { Modal } from '../components/ui/Modal'
 import { FormField } from '../components/ui/Form'
+import { PreviewBanner } from '../components/ui/DataState'
 
 export function RpzManagementPage() {
   const [, startTransition] = useTransition()
@@ -274,6 +275,11 @@ export function RpzManagementPage() {
       logBlocks: cfgLogBlocks,
       wildcardMatching: cfgWildcard,
       upstreamDns: sinkholeConfig?.upstreamDns || ['1.1.1.1'],
+      dohEnabled: sinkholeConfig?.dohEnabled ?? false,
+      dohBind: sinkholeConfig?.dohBind ?? '0.0.0.0:443',
+      dohPath: sinkholeConfig?.dohPath ?? '/dns-query',
+      dotEnabled: sinkholeConfig?.dotEnabled ?? false,
+      dotBind: sinkholeConfig?.dotBind ?? '0.0.0.0:853',
     })
     setSinkholeConfig(updated)
     setConfigModalOpen(false)
@@ -290,6 +296,7 @@ export function RpzManagementPage() {
 
   return (
     <div className="space-y-6">
+      <PreviewBanner feature="RPZ feed management" />
       {/* Page Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/admin-console/src/pages/Settings.tsx
+++ b/admin-console/src/pages/Settings.tsx
@@ -1,30 +1,52 @@
 import { useCallback, useState } from 'react'
-import { Download, Eye, Upload } from 'lucide-react'
+import { Download, Eye, FlaskConical, Upload } from 'lucide-react'
 import type { ConfigFormState } from '../lib/config/types'
 import { defaultFormState } from '../lib/config/types'
 import { cacheMetadataEstimate } from '../lib/config/collect'
 import { formatEnv, generateAclRules, generateDockerCompose, downloadFile } from '../lib/config/export'
 import { importEnvFile, loadSavedForm, saveFormState } from '../lib/config/import'
 import { loadApiSettings, saveApiSettings, type ApiSettings } from '../api/settings'
+import { isDemoMode, setDemoMode } from '../api/source'
+import { fetchProxyStats, formatUptime } from '../api/metrics'
+import { fetchUpstreamTls } from '../api/node'
+import { useSourcedQuery } from '../hooks/useSourced'
+import { useQuery } from '@tanstack/react-query'
 import { Button } from '../components/ui/Button'
 import { Checkbox, FormGrid, FormSection, Input, Select } from '../components/ui/Form'
 import { CodePreview, CopyButton, Modal } from '../components/ui/Modal'
+import { Panel } from '../components/dashboard/MetricWidget'
+import { useToast } from '../components/ui/Toast'
 
-type SettingsTab = 'general' | 'cache' | 'auth' | 'acl' | 'api'
+type SettingsTab =
+  | 'general'
+  | 'cache'
+  | 'auth'
+  | 'filtering'
+  | 'threat'
+  | 'network'
+  | 'security'
+  | 'events'
+  | 'api'
 
 const tabs: { id: SettingsTab; label: string }[] = [
   { id: 'general', label: 'General' },
   { id: 'cache', label: 'Cache' },
   { id: 'auth', label: 'Auth' },
-  { id: 'acl', label: 'ACL' },
-  { id: 'api', label: 'API' },
+  { id: 'filtering', label: 'Filtering' },
+  { id: 'threat', label: 'Threat / ML' },
+  { id: 'network', label: 'Hierarchy / TLS' },
+  { id: 'security', label: 'Rate limit / eBPF / Wasm' },
+  { id: 'events', label: 'Events / Storage' },
+  { id: 'api', label: 'Console API' },
 ]
 
 export function SettingsPage() {
+  const { toast } = useToast()
   const [form, setForm] = useState<ConfigFormState>(() => loadSavedForm())
   const [apiSettings, setApiSettings] = useState<ApiSettings>(() => loadApiSettings())
   const [tab, setTab] = useState<SettingsTab>('general')
   const [preview, setPreview] = useState<{ title: string; content: string } | null>(null)
+  const [demoEnabled, setDemoEnabled] = useState(isDemoMode)
 
   const update = useCallback(<K extends keyof ConfigFormState>(key: K, value: ConfigFormState[K]) => {
     setForm((prev) => {
@@ -50,20 +72,22 @@ export function SettingsPage() {
       const next = importEnvFile(String(reader.result ?? ''), form)
       setForm(next)
       saveFormState(next)
-      alert(`Imported configuration`)
+      toast('success', `Imported configuration from ${file.name}`)
     }
     reader.readAsText(file)
     e.target.value = ''
   }
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6">
+    <div className="mx-auto max-w-5xl space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-text-primary">Settings</h1>
         <p className="text-sm text-text-secondary">
-          Proxy configuration generator (migrated from web-config)
+          Configuration generator (.env / compose / ACL) and console API endpoints
         </p>
       </div>
+
+      <LiveNodePanel />
 
       <div className="flex gap-1 overflow-x-auto border-b border-border pb-px">
         {tabs.map((t) => (
@@ -71,7 +95,7 @@ export function SettingsPage() {
             key={t.id}
             type="button"
             onClick={() => setTab(t.id)}
-            className={`touch-target shrink-0 rounded-t-md px-4 py-2 text-sm font-medium transition-colors ${
+            className={`touch-target shrink-0 rounded-t-md px-3 py-2 text-sm font-medium transition-colors ${
               tab === t.id
                 ? 'border-b-2 border-accent text-accent'
                 : 'text-text-secondary hover:text-text-primary'
@@ -86,8 +110,23 @@ export function SettingsPage() {
         {tab === 'general' && <GeneralTab form={form} update={update} />}
         {tab === 'cache' && <CacheTab form={form} update={update} />}
         {tab === 'auth' && <AuthTab form={form} update={update} />}
-        {tab === 'acl' && <AclTab form={form} update={update} />}
-        {tab === 'api' && <ApiTab settings={apiSettings} update={updateApi} />}
+        {tab === 'filtering' && <FilteringTab form={form} update={update} />}
+        {tab === 'threat' && <ThreatTab form={form} update={update} />}
+        {tab === 'network' && <NetworkTab form={form} update={update} />}
+        {tab === 'security' && <SecurityTab form={form} update={update} />}
+        {tab === 'events' && <EventsTab form={form} update={update} />}
+        {tab === 'api' && (
+          <ApiTab
+            settings={apiSettings}
+            update={updateApi}
+            demoEnabled={demoEnabled}
+            onDemoChange={(v) => {
+              setDemoEnabled(v)
+              setDemoMode(v)
+              toast('info', v ? 'Demo mode ON — unreachable APIs now render sample data marked “Demo”.' : 'Demo mode OFF — failures show real error states.')
+            }}
+          />
+        )}
       </div>
 
       <div className="flex flex-wrap gap-2">
@@ -104,7 +143,10 @@ export function SettingsPage() {
           variant="secondary"
           onClick={() => {
             const rules = generateAclRules(form)
-            if (!rules) return alert('Enable ACL first')
+            if (!rules) {
+              toast('warning', 'Enable ACL on the Filtering tab first')
+              return
+            }
             downloadFile('acl-rules.json', JSON.stringify(rules, null, 2) + '\n')
           }}
         >
@@ -114,7 +156,14 @@ export function SettingsPage() {
           <Upload className="size-4" /> Import .env
           <input type="file" accept=".env,text/plain" className="hidden" onChange={handleImport} />
         </label>
-        <Button variant="ghost" onClick={() => { setForm(defaultFormState); saveFormState(defaultFormState) }}>
+        <Button
+          variant="ghost"
+          onClick={() => {
+            setForm(defaultFormState)
+            saveFormState(defaultFormState)
+            toast('info', 'Form reset to defaults')
+          }}
+        >
           Reset defaults
         </Button>
       </div>
@@ -132,32 +181,89 @@ export function SettingsPage() {
   )
 }
 
-type UpdateFn = <K extends keyof ConfigFormState>(key: K, value: ConfigFormState[K]) => void
+/** What this node is actually running with right now (real control-plane endpoints). */
+function LiveNodePanel() {
+  const stats = useQuery({ queryKey: ['settings-stats'], queryFn: fetchProxyStats, refetchInterval: 30_000 })
+  const tls = useSourcedQuery(['upstream-tls'], fetchUpstreamTls)
+  const s = stats.data
 
-function GeneralTab({ form, update }: { form: ConfigFormState; update: UpdateFn }) {
+  return (
+    <Panel title="Live node state (read from the running proxy)">
+      {!s && (
+        <p className="text-sm text-text-secondary">
+          Control API unreachable — the generator below still works offline, but values shown here would confirm what
+          the node actually runs with.
+        </p>
+      )}
+      {s && (
+        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+          <div>
+            <dt className="text-xs text-text-secondary">Service</dt>
+            <dd className="font-mono text-xs text-text-primary">{s.service}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-text-secondary">Uptime</dt>
+            <dd className="text-text-primary">{formatUptime(s.uptime_secs)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs text-text-secondary">L1 cache</dt>
+            <dd className="tabular-nums text-text-primary">
+              {s.cache.entries.toLocaleString()}/{s.cache.capacity.toLocaleString()} · {s.cache.shards} shards
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-text-secondary">Upstream TLS</dt>
+            <dd className="truncate font-mono text-xs text-text-primary" title={tls.data ? JSON.stringify(tls.data.data) : ''}>
+              {tls.data ? summarizeTls(tls.data.data) : tls.isError ? 'unavailable' : '…'}
+            </dd>
+          </div>
+        </dl>
+      )}
+    </Panel>
+  )
+}
+
+function summarizeTls(tls: Record<string, unknown>): string {
+  const entries = Object.entries(tls).slice(0, 3)
+  if (entries.length === 0) return 'default'
+  return entries.map(([k, v]) => `${k}=${String(v)}`).join(' · ')
+}
+
+type UpdateFn = <K extends keyof ConfigFormState>(key: K, value: ConfigFormState[K]) => void
+interface TabProps {
+  form: ConfigFormState
+  update: UpdateFn
+}
+
+function GeneralTab({ form, update }: TabProps) {
   return (
     <FormSection title="General">
       <FormGrid>
         <Input label="HTTP proxy port" type="number" value={form.httpPort} onChange={(e) => update('httpPort', e.target.value)} />
         <Input label="Metrics / ACL API port" type="number" value={form.metricsPort} onChange={(e) => update('metricsPort', e.target.value)} />
       </FormGrid>
-      <Select
-        label="RUST_LOG"
-        value={form.logLevel}
-        onChange={(e) => update('logLevel', e.target.value)}
-        options={[
-          { value: 'warn', label: 'warn' },
-          { value: 'info,bsdm_proxy=info', label: 'info,bsdm_proxy=info' },
-          { value: 'info,bsdm_proxy=debug', label: 'info,bsdm_proxy=debug' },
-          { value: 'debug', label: 'debug' },
-        ]}
-      />
+      <FormGrid>
+        <Select
+          label="RUST_LOG"
+          value={form.logLevel}
+          onChange={(e) => update('logLevel', e.target.value)}
+          options={[
+            { value: 'warn', label: 'warn' },
+            { value: 'info,bsdm_proxy=info', label: 'info,bsdm_proxy=info' },
+            { value: 'info,bsdm_proxy=debug', label: 'info,bsdm_proxy=debug' },
+            { value: 'debug', label: 'debug' },
+          ]}
+        />
+        <Input label="Worker count" type="number" value={form.workerCount} onChange={(e) => update('workerCount', e.target.value)} hint="0 = number of CPU cores" />
+      </FormGrid>
       <Checkbox label="MITM_ENABLED (HTTPS interception)" checked={form.mitmEnabled} onChange={(v) => update('mitmEnabled', v)} hint="Requires /certs/ca.key and ca.crt" />
+      <Checkbox label="PERF_FAST_CACHE_HIT" checked={form.perfFastCacheHit} onChange={(v) => update('perfFastCacheHit', v)} hint="Skip per-hit bookkeeping on the hot path" />
+      <Checkbox label="STREAMING_MISS_ENABLED" checked={form.streamingMissEnabled} onChange={(v) => update('streamingMissEnabled', v)} />
     </FormSection>
   )
 }
 
-function CacheTab({ form, update }: { form: ConfigFormState; update: UpdateFn }) {
+function CacheTab({ form, update }: TabProps) {
   return (
     <div className="space-y-6">
       <FormSection title="L1 cache">
@@ -166,6 +272,15 @@ function CacheTab({ form, update }: { form: ConfigFormState; update: UpdateFn })
           <Input label="CACHE_TTL_SECONDS" type="number" value={form.cacheTtl} onChange={(e) => update('cacheTtl', e.target.value)} />
           <Input label="CACHE_SHARDS" type="number" value={form.cacheShards} onChange={(e) => update('cacheShards', e.target.value)} />
         </FormGrid>
+        <FormGrid>
+          <Input label="Max cache body (MB)" type="number" value={form.maxBodySizeMb} onChange={(e) => update('maxBodySizeMb', e.target.value)} />
+          <Input label="Spill threshold (KB)" type="number" value={form.spillThresholdKb} onChange={(e) => update('spillThresholdKb', e.target.value)} />
+        </FormGrid>
+        <Checkbox label="CACHE_HONOR_CACHE_CONTROL" checked={form.cacheHonorCacheControl} onChange={(v) => update('cacheHonorCacheControl', v)} />
+        <Checkbox label="NEGATIVE_CACHE_ENABLED" checked={form.negativeCacheEnabled} onChange={(v) => update('negativeCacheEnabled', v)} />
+        {form.negativeCacheEnabled && (
+          <Input label="NEGATIVE_CACHE_TTL_SECONDS" type="number" value={form.negativeCacheTtl} onChange={(e) => update('negativeCacheTtl', e.target.value)} />
+        )}
       </FormSection>
       <FormSection title="Redis L2">
         <Checkbox label="REDIS_L2_ENABLED" checked={form.redisL2Enabled} onChange={(v) => update('redisL2Enabled', v)} />
@@ -180,26 +295,44 @@ function CacheTab({ form, update }: { form: ConfigFormState; update: UpdateFn })
   )
 }
 
-function AuthTab({ form, update }: { form: ConfigFormState; update: UpdateFn }) {
+function AuthTab({ form, update }: TabProps) {
   return (
     <div className="space-y-4">
       <Checkbox label="AUTH_ENABLED" checked={form.authEnabled} onChange={(v) => update('authEnabled', v)} />
       {form.authEnabled && (
         <>
-          <Select
-            label="AUTH_BACKEND"
-            value={form.authBackend}
-            onChange={(e) => update('authBackend', e.target.value)}
-            options={[
-              { value: 'basic', label: 'basic' },
-              { value: 'ldap', label: 'ldap' },
-              { value: 'ntlm', label: 'ntlm' },
-            ]}
-          />
+          <FormGrid>
+            <Select
+              label="AUTH_BACKEND"
+              value={form.authBackend}
+              onChange={(e) => update('authBackend', e.target.value)}
+              options={[
+                { value: 'basic', label: 'basic' },
+                { value: 'ldap', label: 'ldap' },
+                { value: 'ntlm', label: 'ntlm' },
+              ]}
+            />
+            <Input label="AUTH_CACHE_TTL" type="number" value={form.authCacheTtl} onChange={(e) => update('authCacheTtl', e.target.value)} />
+          </FormGrid>
+          <Input label="AUTH_REALM" value={form.authRealm} onChange={(e) => update('authRealm', e.target.value)} />
           {form.authBackend === 'ldap' && (
+            <>
+              <FormGrid>
+                <Input label="LDAP_SERVERS" value={form.ldapServers} onChange={(e) => update('ldapServers', e.target.value)} />
+                <Input label="LDAP_BASE_DN" value={form.ldapBaseDn} onChange={(e) => update('ldapBaseDn', e.target.value)} />
+              </FormGrid>
+              <FormGrid>
+                <Input label="LDAP_BIND_DN" value={form.ldapBindDn} onChange={(e) => update('ldapBindDn', e.target.value)} />
+                <Input label="LDAP_BIND_PASSWORD" type="password" value={form.ldapBindPassword} onChange={(e) => update('ldapBindPassword', e.target.value)} hint="Session-only, never persisted" />
+              </FormGrid>
+              <Input label="LDAP_USER_FILTER" value={form.ldapUserFilter} onChange={(e) => update('ldapUserFilter', e.target.value)} />
+              <Checkbox label="LDAP_USE_TLS" checked={form.ldapUseTls} onChange={(v) => update('ldapUseTls', v)} />
+            </>
+          )}
+          {form.authBackend === 'ntlm' && (
             <FormGrid>
-              <Input label="LDAP_SERVERS" value={form.ldapServers} onChange={(e) => update('ldapServers', e.target.value)} />
-              <Input label="LDAP_BASE_DN" value={form.ldapBaseDn} onChange={(e) => update('ldapBaseDn', e.target.value)} />
+              <Input label="NTLM_DOMAIN" value={form.ntlmDomain} onChange={(e) => update('ntlmDomain', e.target.value)} />
+              <Input label="NTLM_WORKSTATION" value={form.ntlmWorkstation} onChange={(e) => update('ntlmWorkstation', e.target.value)} />
             </FormGrid>
           )}
         </>
@@ -208,49 +341,231 @@ function AuthTab({ form, update }: { form: ConfigFormState; update: UpdateFn }) 
   )
 }
 
-function AclTab({ form, update }: { form: ConfigFormState; update: UpdateFn }) {
+function FilteringTab({ form, update }: TabProps) {
   return (
-    <div className="space-y-4">
-      <Checkbox label="ACL_ENABLED" checked={form.aclEnabled} onChange={(v) => update('aclEnabled', v)} />
-      {form.aclEnabled && (
-        <>
-          <Select
-            label="ACL_DEFAULT_ACTION"
-            value={form.aclDefaultAction}
-            onChange={(e) => update('aclDefaultAction', e.target.value)}
-            options={[
-              { value: 'allow', label: 'allow' },
-              { value: 'deny', label: 'deny' },
-            ]}
-          />
-          <Input label="ACL_API_TOKEN" type="password" value={form.aclApiToken} onChange={(e) => update('aclApiToken', e.target.value)} />
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-text-primary">Quick category rules</p>
-            <Checkbox label="Block malware" checked={form.aclBlockMalware} onChange={(v) => update('aclBlockMalware', v)} />
-            <Checkbox label="Block phishing" checked={form.aclBlockPhishing} onChange={(v) => update('aclBlockPhishing', v)} />
-            <Checkbox label="Block gambling" checked={form.aclBlockGambling} onChange={(v) => update('aclBlockGambling', v)} />
-            <Checkbox label="Block adult" checked={form.aclBlockAdult} onChange={(v) => update('aclBlockAdult', v)} />
-          </div>
-        </>
-      )}
+    <div className="space-y-6">
+      <FormSection title="ACL">
+        <Checkbox label="ACL_ENABLED" checked={form.aclEnabled} onChange={(v) => update('aclEnabled', v)} />
+        {form.aclEnabled && (
+          <>
+            <FormGrid>
+              <Select
+                label="ACL_DEFAULT_ACTION"
+                value={form.aclDefaultAction}
+                onChange={(e) => update('aclDefaultAction', e.target.value)}
+                options={[
+                  { value: 'allow', label: 'allow' },
+                  { value: 'deny', label: 'deny' },
+                ]}
+              />
+              <Input label="ACL_API_TOKEN" type="password" value={form.aclApiToken} onChange={(e) => update('aclApiToken', e.target.value)} hint="Session-only, never persisted" />
+            </FormGrid>
+            <FormGrid>
+              <Input label="ACL_RULES_PATH" value={form.aclRulesPath} onChange={(e) => update('aclRulesPath', e.target.value)} />
+              <Input label="ACL_RELOAD_INTERVAL" type="number" value={form.aclReloadInterval} onChange={(e) => update('aclReloadInterval', e.target.value)} />
+            </FormGrid>
+            <Checkbox label="ACL_AUTO_RELOAD" checked={form.aclAutoReload} onChange={(v) => update('aclAutoReload', v)} />
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-text-primary">Quick category rules</p>
+              <Checkbox label="Block malware" checked={form.aclBlockMalware} onChange={(v) => update('aclBlockMalware', v)} />
+              <Checkbox label="Block phishing" checked={form.aclBlockPhishing} onChange={(v) => update('aclBlockPhishing', v)} />
+              <Checkbox label="Block gambling" checked={form.aclBlockGambling} onChange={(v) => update('aclBlockGambling', v)} />
+              <Checkbox label="Block adult" checked={form.aclBlockAdult} onChange={(v) => update('aclBlockAdult', v)} />
+            </div>
+          </>
+        )}
+      </FormSection>
+      <FormSection title="Categorization sources">
+        <Checkbox label="CATEGORIZATION_ENABLED" checked={form.categorizationEnabled} onChange={(v) => update('categorizationEnabled', v)} />
+        {form.categorizationEnabled && (
+          <>
+            <Input label="CATEGORIZATION_CACHE_TTL" type="number" value={form.categorizationCacheTtl} onChange={(e) => update('categorizationCacheTtl', e.target.value)} />
+            <Checkbox label="UT1 blacklists" checked={form.ut1Enabled} onChange={(v) => update('ut1Enabled', v)} />
+            {form.ut1Enabled && <Input label="UT1_PATH" value={form.ut1Path} onChange={(e) => update('ut1Path', e.target.value)} />}
+            <Checkbox label="URLhaus online lookups" checked={form.urlhausEnabled} onChange={(v) => update('urlhausEnabled', v)} />
+            <Checkbox label="PhishTank online lookups" checked={form.phishtankEnabled} onChange={(v) => update('phishtankEnabled', v)} />
+            {form.phishtankEnabled && (
+              <Input label="PHISHTANK_API_KEY" type="password" value={form.phishtankApiKey} onChange={(e) => update('phishtankApiKey', e.target.value)} hint="Session-only, never persisted" />
+            )}
+            <Checkbox label="Custom category DB" checked={form.customDbEnabled} onChange={(v) => update('customDbEnabled', v)} />
+            {form.customDbEnabled && <Input label="CUSTOM_DB_PATH" value={form.customDbPath} onChange={(e) => update('customDbPath', e.target.value)} />}
+          </>
+        )}
+      </FormSection>
     </div>
   )
 }
 
-function ApiTab({ settings, update }: { settings: ApiSettings; update: <K extends keyof ApiSettings>(key: K, value: ApiSettings[K]) => void }) {
+function ThreatTab({ form, update }: TabProps) {
   return (
-    <FormSection title="API endpoints">
-      <p className="text-sm text-text-secondary">
-        Leave blank to use Vite dev proxy paths. Set full base URLs in production.
-      </p>
-      <Input label="Search API base URL" placeholder="http://127.0.0.1:8080" value={settings.searchBaseUrl} onChange={(e) => update('searchBaseUrl', e.target.value)} />
-      <Input label="ACL API base URL" placeholder="http://127.0.0.1:9090" value={settings.aclBaseUrl} onChange={(e) => update('aclBaseUrl', e.target.value)} />
-      <Input label="Metrics base URL" placeholder="http://127.0.0.1:9090" value={settings.metricsBaseUrl} onChange={(e) => update('metricsBaseUrl', e.target.value)} />
-      <Input label="ML worker base URL" placeholder="http://127.0.0.1:8091" value={settings.mlBaseUrl} onChange={(e) => update('mlBaseUrl', e.target.value)} />
-      <FormGrid>
-        <Input label="Search API token" type="password" value={settings.searchToken} onChange={(e) => update('searchToken', e.target.value)} />
-        <Input label="ACL API token" type="password" value={settings.aclToken} onChange={(e) => update('aclToken', e.target.value)} />
-      </FormGrid>
+    <FormSection title="Threat score enforcement (ml-worker write-back)">
+      <Checkbox
+        label="THREAT_SCORE_ENABLED"
+        checked={form.threatScoreEnabled}
+        onChange={(v) => update('threatScoreEnabled', v)}
+        hint="Proxy polls the ml-worker snapshot and enforces thresholds on the request path (O(1) in-memory lookup)"
+      />
+      {form.threatScoreEnabled && (
+        <>
+          <Input label="THREAT_SCORE_POLL_URL" value={form.threatScorePollUrl} onChange={(e) => update('threatScorePollUrl', e.target.value)} />
+          <FormGrid>
+            <Input label="Poll interval (s)" type="number" value={form.threatScorePollInterval} onChange={(e) => update('threatScorePollInterval', e.target.value)} />
+            <Input label="Block threshold (0–1)" value={form.threatScoreBlockThreshold} onChange={(e) => update('threatScoreBlockThreshold', e.target.value)} />
+          </FormGrid>
+          <Input label="Warn threshold (0–1)" value={form.threatScoreWarnThreshold} onChange={(e) => update('threatScoreWarnThreshold', e.target.value)} hint="Scores ≥ warn are logged/enriched; ≥ block are denied" />
+        </>
+      )}
     </FormSection>
+  )
+}
+
+function NetworkTab({ form, update }: TabProps) {
+  return (
+    <div className="space-y-6">
+      <FormSection title="Cache hierarchy (ICP / HTCP)">
+        <Input label="HIERARCHY_PEERS_PATH" value={form.hierarchyPeersPath} onChange={(e) => update('hierarchyPeersPath', e.target.value)} hint="JSON file with parent/sibling peers; empty disables the hierarchy" />
+        <Checkbox label="ICP_SERVER_ENABLED" checked={form.icpServerEnabled} onChange={(v) => update('icpServerEnabled', v)} />
+        {form.icpServerEnabled && <Input label="ICP_BIND" value={form.icpBind} onChange={(e) => update('icpBind', e.target.value)} />}
+        <Checkbox label="HTCP_SERVER_ENABLED" checked={form.htcpServerEnabled} onChange={(v) => update('htcpServerEnabled', v)} />
+        {form.htcpServerEnabled && <Input label="HTCP_BIND" value={form.htcpBind} onChange={(e) => update('htcpBind', e.target.value)} />}
+        <Checkbox label="PEER_DISCOVERY_ENABLED (multicast)" checked={form.peerDiscoveryEnabled} onChange={(v) => update('peerDiscoveryEnabled', v)} />
+        {form.peerDiscoveryEnabled && (
+          <Input label="PEER_DISCOVERY_MULTICAST" value={form.peerDiscoveryMulticast} onChange={(e) => update('peerDiscoveryMulticast', e.target.value)} />
+        )}
+      </FormSection>
+      <FormSection title="Upstream TLS / HTTP">
+        <Input label="UPSTREAM_CA_CERT" value={form.upstreamCaCert} onChange={(e) => update('upstreamCaCert', e.target.value)} hint="Path to an extra CA bundle for upstream verification (corporate MITM chains)" />
+        <Checkbox label="UPSTREAM_HTTP2_ENABLED" checked={form.upstreamHttp2Enabled} onChange={(v) => update('upstreamHttp2Enabled', v)} />
+        <Checkbox label="HTTP_PRESERVE_HEADER_CASE" checked={form.preserveHeaderCase} onChange={(v) => update('preserveHeaderCase', v)} />
+      </FormSection>
+    </div>
+  )
+}
+
+function SecurityTab({ form, update }: TabProps) {
+  return (
+    <div className="space-y-6">
+      <FormSection title="Rate limiting">
+        <Checkbox label="RATE_LIMIT_ENABLED" checked={form.rateLimitEnabled} onChange={(v) => update('rateLimitEnabled', v)} />
+        {form.rateLimitEnabled && (
+          <Input label="RATE_LIMIT_MAX_KEYS" type="number" value={form.rateLimitMaxKeys} onChange={(e) => update('rateLimitMaxKeys', e.target.value)} />
+        )}
+      </FormSection>
+      <FormSection title="eBPF / XDP kernel drop">
+        <Checkbox label="EBPF_XDP_ENABLED" checked={form.ebpfXdpEnabled} onChange={(v) => update('ebpfXdpEnabled', v)} hint="Requires CAP_BPF and a supported NIC driver" />
+        {form.ebpfXdpEnabled && (
+          <FormGrid>
+            <Input label="EBPF_XDP_IFACE" value={form.ebpfXdpIface} onChange={(e) => update('ebpfXdpIface', e.target.value)} />
+            <Select
+              label="EBPF_XDP_MODE"
+              value={form.ebpfXdpMode}
+              onChange={(e) => update('ebpfXdpMode', e.target.value)}
+              options={[
+                { value: 'driver', label: 'driver (native)' },
+                { value: 'skb', label: 'skb (generic)' },
+                { value: 'hw', label: 'hw (offload)' },
+              ]}
+            />
+          </FormGrid>
+        )}
+      </FormSection>
+      <FormSection title="Wasm request hooks">
+        <Checkbox label="WASM_ENABLED" checked={form.wasmEnabled} onChange={(v) => update('wasmEnabled', v)} />
+        {form.wasmEnabled && (
+          <>
+            <Input label="WASM_MODULE_PATH" value={form.wasmModulePath} onChange={(e) => update('wasmModulePath', e.target.value)} />
+            <FormGrid>
+              <Input label="WASM_FUEL" type="number" value={form.wasmFuel} onChange={(e) => update('wasmFuel', e.target.value)} />
+              <div className="pt-6">
+                <Checkbox label="WASM_FAIL_OPEN" checked={form.wasmFailOpen} onChange={(v) => update('wasmFailOpen', v)} hint="Allow traffic if the module traps" />
+              </div>
+            </FormGrid>
+          </>
+        )}
+      </FormSection>
+      <FormSection title="gRPC control plane">
+        <Checkbox label="CONTROL_GRPC_ENABLED" checked={form.controlGrpcEnabled} onChange={(v) => update('controlGrpcEnabled', v)} />
+        {form.controlGrpcEnabled && (
+          <Input label="CONTROL_GRPC_BIND" value={form.controlGrpcBind} onChange={(e) => update('controlGrpcBind', e.target.value)} />
+        )}
+        <Input label="CONTROL_API_TOKEN" type="password" value={form.controlApiToken} onChange={(e) => update('controlApiToken', e.target.value)} hint="Protects /api/stats, /api/cache/purge, hierarchy and TLS endpoints. Session-only." />
+      </FormSection>
+    </div>
+  )
+}
+
+function EventsTab({ form, update }: TabProps) {
+  return (
+    <div className="space-y-6">
+      <FormSection title="Kafka event pipeline">
+        <FormGrid>
+          <Input label="KAFKA_BROKERS" value={form.kafkaBrokers} onChange={(e) => update('kafkaBrokers', e.target.value)} />
+          <Input label="KAFKA_TOPIC" value={form.kafkaTopic} onChange={(e) => update('kafkaTopic', e.target.value)} />
+        </FormGrid>
+        <FormGrid>
+          <Input label="KAFKA_SAMPLE_RATE" value={form.kafkaSampleRate} onChange={(e) => update('kafkaSampleRate', e.target.value)} hint="0 = log every request, N = 1-in-N sampling" />
+          <Input label="KAFKA_QUEUE_CAPACITY" type="number" value={form.kafkaQueueCapacity} onChange={(e) => update('kafkaQueueCapacity', e.target.value)} />
+        </FormGrid>
+        <FormGrid>
+          <Input label="KAFKA_ACKS" value={form.kafkaAcks} onChange={(e) => update('kafkaAcks', e.target.value)} />
+          <Input label="METRICS_SAMPLE_RATE" value={form.metricsSampleRate} onChange={(e) => update('metricsSampleRate', e.target.value)} />
+        </FormGrid>
+      </FormSection>
+      <FormSection title="ClickHouse (search index)">
+        <Input label="CLICKHOUSE_URL" value={form.clickhouseUrl} onChange={(e) => update('clickhouseUrl', e.target.value)} />
+        <FormGrid>
+          <Input label="CLICKHOUSE_DATABASE" value={form.clickhouseDatabase} onChange={(e) => update('clickhouseDatabase', e.target.value)} />
+          <Input label="CLICKHOUSE_TABLE" value={form.clickhouseTable} onChange={(e) => update('clickhouseTable', e.target.value)} />
+        </FormGrid>
+        <Input label="SEARCH_API_TOKEN" type="password" value={form.searchApiToken} onChange={(e) => update('searchApiToken', e.target.value)} hint="Session-only, never persisted" />
+      </FormSection>
+      <FormSection title="Observability stack (compose export)">
+        <Checkbox label="Include Prometheus" checked={form.prometheusEnabled} onChange={(v) => update('prometheusEnabled', v)} />
+        <Checkbox label="Include Grafana" checked={form.grafanaEnabled} onChange={(v) => update('grafanaEnabled', v)} />
+      </FormSection>
+    </div>
+  )
+}
+
+function ApiTab({
+  settings,
+  update,
+  demoEnabled,
+  onDemoChange,
+}: {
+  settings: ApiSettings
+  update: <K extends keyof ApiSettings>(key: K, value: ApiSettings[K]) => void
+  demoEnabled: boolean
+  onDemoChange: (v: boolean) => void
+}) {
+  return (
+    <div className="space-y-6">
+      <FormSection title="API endpoints">
+        <p className="text-sm text-text-secondary">
+          Leave blank to use Vite dev proxy paths. Set full base URLs in production.
+        </p>
+        <Input label="Search API base URL" placeholder="http://127.0.0.1:8080" value={settings.searchBaseUrl} onChange={(e) => update('searchBaseUrl', e.target.value)} />
+        <Input label="ACL API base URL" placeholder="http://127.0.0.1:9090" value={settings.aclBaseUrl} onChange={(e) => update('aclBaseUrl', e.target.value)} />
+        <Input label="Metrics base URL" placeholder="http://127.0.0.1:9090" value={settings.metricsBaseUrl} onChange={(e) => update('metricsBaseUrl', e.target.value)} />
+        <Input label="ML worker base URL" placeholder="http://127.0.0.1:8091" value={settings.mlBaseUrl} onChange={(e) => update('mlBaseUrl', e.target.value)} />
+        <FormGrid>
+          <Input label="Search API token" type="password" value={settings.searchToken} onChange={(e) => update('searchToken', e.target.value)} />
+          <Input label="ACL API token" type="password" value={settings.aclToken} onChange={(e) => update('aclToken', e.target.value)} />
+        </FormGrid>
+      </FormSection>
+      <FormSection title="Demo mode">
+        <div className="flex items-start gap-3 rounded-md border border-border bg-surface-0 p-4">
+          <FlaskConical className="mt-0.5 size-5 shrink-0 text-warning" />
+          <div className="flex-1">
+            <Checkbox
+              label="Serve sample data when APIs are unreachable"
+              checked={demoEnabled}
+              onChange={onDemoChange}
+              hint="Off (default): failures show error states — no fake numbers, ever. On: panels render illustrative data clearly marked with a “Demo” badge."
+            />
+          </div>
+        </div>
+      </FormSection>
+    </div>
   )
 }

--- a/admin-console/src/pages/ThreatScores.tsx
+++ b/admin-console/src/pages/ThreatScores.tsx
@@ -1,36 +1,25 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { RefreshCw } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { RefreshCw, Search } from 'lucide-react'
 import {
   factorsForThreatScore,
   fetchThreatScores,
   type ThreatScoreEntry,
 } from '../api/threatScores'
+import { useSourcedQuery } from '../hooks/useSourced'
 import { Button } from '../components/ui/Button'
 import { Panel } from '../components/dashboard/MetricWidget'
+import { ErrorState, SourceBadge } from '../components/ui/DataState'
 import { InsightPanel, ThreatIndicator } from '../components/xai/ThreatIndicator'
 import { Modal } from '../components/ui/Modal'
 import { severityBadge } from '../theme/tokens'
 
 export function ThreatScoresPage() {
-  const [snapshot, setSnapshot] = useState<{ generated_at?: string; scores: ThreatScoreEntry[] }>({
-    scores: [],
-  })
-  const [loading, setLoading] = useState(true)
+  const result = useSourcedQuery(['threat-scores'], fetchThreatScores, { refetchInterval: 60_000 })
+  const snapshot = result.data?.data ?? { scores: [] as ThreatScoreEntry[] }
+  const loading = result.isFetching
   const [selected, setSelected] = useState<ThreatScoreEntry | null>(null)
   const [modelFilter, setModelFilter] = useState<string>('all')
-
-  const load = useCallback(async () => {
-    setLoading(true)
-    const data = await fetchThreatScores()
-    setSnapshot(data)
-    setLoading(false)
-  }, [])
-
-  useEffect(() => {
-    load()
-    const id = window.setInterval(load, 60_000)
-    return () => window.clearInterval(id)
-  }, [load])
 
   const models = useMemo(() => {
     const set = new Set(snapshot.scores.map((s) => s.model))
@@ -49,21 +38,32 @@ export function ThreatScoresPage() {
     <div className="mx-auto max-w-7xl space-y-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-bold text-text-primary">Threat scores</h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-bold text-text-primary">Threat scores</h1>
+            {result.data && <SourceBadge source={result.data.source} />}
+          </div>
           <p className="text-sm text-text-secondary">
             M5.5 write-back snapshot from ml-worker — proxy polls this async (O(1) hot path)
           </p>
-          {snapshot.generated_at && (
+          {'generated_at' in snapshot && snapshot.generated_at && (
             <p className="mt-1 font-mono text-xs text-text-secondary">
               Generated {new Date(snapshot.generated_at).toLocaleString()}
             </p>
           )}
         </div>
-        <Button variant="secondary" onClick={load} disabled={loading}>
+        <Button variant="secondary" onClick={() => result.refetch()} disabled={loading}>
           <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
           Refresh
         </Button>
       </div>
+
+      {result.isError && (
+        <ErrorState
+          title="ML worker unreachable"
+          detail={result.error.message}
+          onRetry={() => result.refetch()}
+        />
+      )}
 
       <div className="flex flex-wrap gap-2">
         {models.map((m) => (
@@ -183,6 +183,12 @@ function ScoreDetailModal({
         </div>
         <ThreatIndicator score={entry.score} size="lg" />
         <InsightPanel factors={factors} model={entry.model} />
+        <Link
+          to={`/logs?q=${encodeURIComponent(entry.entity_id.split('|').pop() ?? entry.entity_id)}`}
+          className="inline-flex items-center gap-2 rounded-md border border-accent/40 bg-accent/10 px-3 py-2 text-sm font-medium text-accent hover:bg-accent/20"
+        >
+          <Search className="size-4" /> Investigate related traffic
+        </Link>
         <p className="text-xs text-text-secondary">
           Scored {entry.scored_at} · expires {entry.expires_at}. Proxy enriches{' '}
           <code className="rounded bg-surface-0 px-1 font-mono">threat_sources</code> when{' '}

--- a/admin-console/src/pages/WasmPlugins.tsx
+++ b/admin-console/src/pages/WasmPlugins.tsx
@@ -35,6 +35,7 @@ import {
 import { Button } from '../components/ui/Button'
 import { Modal } from '../components/ui/Modal'
 import { FormField } from '../components/ui/Form'
+import { PreviewBanner } from '../components/ui/DataState'
 
 export function WasmPluginsPage() {
   const [, startTransition] = useTransition()
@@ -207,6 +208,7 @@ export function WasmPluginsPage() {
 
   return (
     <div className="space-y-6">
+      <PreviewBanner feature="Wasm plugin management" />
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>

--- a/dns-sinkhole/src/config.rs
+++ b/dns-sinkhole/src/config.rs
@@ -76,7 +76,8 @@ impl Config {
             .unwrap_or_else(|_| "0.0.0.0:8443".into())
             .parse()
             .map_err(|e| format!("DNS_SINKHOLE_DOH_BIND: {e}"))?;
-        let doh_path = std::env::var("DNS_SINKHOLE_DOH_PATH").unwrap_or_else(|_| "/dns-query".into());
+        let doh_path =
+            std::env::var("DNS_SINKHOLE_DOH_PATH").unwrap_or_else(|_| "/dns-query".into());
 
         let dot_enabled = env_bool("DNS_SINKHOLE_DOT_ENABLED", true);
         let dot_bind = std::env::var("DNS_SINKHOLE_DOT_BIND")
@@ -84,8 +85,12 @@ impl Config {
             .parse()
             .map_err(|e| format!("DNS_SINKHOLE_DOT_BIND: {e}"))?;
 
-        let tls_cert_path = std::env::var("DNS_SINKHOLE_TLS_CERT").ok().filter(|s| !s.is_empty());
-        let tls_key_path = std::env::var("DNS_SINKHOLE_TLS_KEY").ok().filter(|s| !s.is_empty());
+        let tls_cert_path = std::env::var("DNS_SINKHOLE_TLS_CERT")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let tls_key_path = std::env::var("DNS_SINKHOLE_TLS_KEY")
+            .ok()
+            .filter(|s| !s.is_empty());
 
         Ok(Self {
             enabled,

--- a/dns-sinkhole/src/config.rs
+++ b/dns-sinkhole/src/config.rs
@@ -11,6 +11,11 @@ pub enum BlockAction {
     NxDomain,
 }
 
+// TODO: doh_enabled/doh_bind/doh_path/dot_enabled/dot_bind/tls_cert_path/tls_key_path
+// are parsed from env but main.rs never starts DoH/DoT listeners using them — the
+// DoH/DoT gateway feature is config-only today. Tracked separately; wiring up real
+// listeners is a larger change out of scope here.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct Config {
     pub enabled: bool,

--- a/dns-sinkhole/src/doh_dot.rs
+++ b/dns-sinkhole/src/doh_dot.rs
@@ -1,4 +1,8 @@
 //! DoH (DNS-over-HTTPS, RFC 8484) and DoT (DNS-over-TLS, RFC 7858) helpers.
+//!
+//! TODO: these codecs are not yet wired into any listener in main.rs — the
+//! DoH/DoT gateway is config-only today. Tracked separately.
+#![allow(dead_code)]
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -49,6 +49,7 @@ services:
     ports:
       - "1488:1488"
       - "9090:9090"
+      - "18080:18080"
     environment:
       - HTTP_PORT=1488
       - METRICS_PORT=9090
@@ -82,6 +83,25 @@ services:
       timeout: 5s
       retries: 5
       start_period: 5s
+
+  # Mock upstream for scripts/run-load-test.sh (load-test.yml CI workflow).
+  # Shares the proxy container's network namespace so a single loopback
+  # address (127.0.0.1:18080) is reachable both from the CI runner host
+  # (via the proxy service's published port) and from inside the proxy
+  # process itself when it forwards requests to the upstream.
+  mock-upstream:
+    image: python:3.12-slim
+    network_mode: "service:proxy"
+    depends_on:
+      proxy:
+        condition: service_started
+    volumes:
+      - ./scripts/mock-upstream-threaded.py:/mock-upstream.py:ro
+    environment:
+      - MOCK_HOST=0.0.0.0
+      - MOCK_PORT=18080
+    command: ["python3", "/mock-upstream.py"]
+    restart: unless-stopped
 
 networks:
   bsdm-lite:

--- a/proxy/src/ebpf.rs
+++ b/proxy/src/ebpf.rs
@@ -164,8 +164,16 @@ impl EbpfXdpManager {
 
         EbpfStats {
             active_blocked_ips: count,
-            packets_dropped_total: if dropped == 0 && count > 0 { 184250 } else { dropped },
-            bytes_dropped_total: if dropped == 0 && count > 0 { 117920000 } else { dropped * 64 },
+            packets_dropped_total: if dropped == 0 && count > 0 {
+                184250
+            } else {
+                dropped
+            },
+            bytes_dropped_total: if dropped == 0 && count > 0 {
+                117920000
+            } else {
+                dropped * 64
+            },
             kernel_latency_us: 0.45,
         }
     }

--- a/proxy/src/ebpf.rs
+++ b/proxy/src/ebpf.rs
@@ -9,20 +9,15 @@ use std::sync::{Arc, RwLock};
 use tracing::info;
 
 /// Runtime mode for eBPF XDP program attachment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum XdpMode {
     /// Generic / SKB mode (works on any netdev, driver independent)
+    #[default]
     Skb,
     /// Native driver mode (zero-copy hardware driver level)
     Driver,
     /// Hardware offload to SmartNIC
     Offload,
-}
-
-impl Default for XdpMode {
-    fn default() -> Self {
-        Self::Skb
-    }
 }
 
 impl XdpMode {

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -515,7 +515,7 @@ impl Metrics {
         }
         for cat in categories {
             self.categorization_blocked_total
-                .with_label_values(&[cat, action])
+                .with_label_values(&[cat.as_str(), action])
                 .inc();
         }
     }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -823,7 +823,7 @@ impl ProxyService {
                 warn!("Revalidation upstream error for {}: {}", url, e);
                 self.metrics
                     .upstream_errors_total
-                    .with_label_values(&[&domain, "revalidate"])
+                    .with_label_values(&[domain.as_str(), "revalidate"])
                     .inc();
                 return None;
             }
@@ -2094,7 +2094,7 @@ impl ProxyService {
                         }
                         self.metrics
                             .upstream_errors_total
-                            .with_label_values(&[&domain, "body_read"])
+                            .with_label_values(&[domain.as_str(), "body_read"])
                             .inc();
                         let mut resp = Response::new(full(Bytes::from_static(b"502 Bad Gateway")));
                         *resp.status_mut() = StatusCode::BAD_GATEWAY;
@@ -2215,7 +2215,7 @@ impl ProxyService {
                 }
                 self.metrics
                     .upstream_errors_total
-                    .with_label_values(&[&domain, "connection"])
+                    .with_label_values(&[domain.as_str(), "connection"])
                     .inc();
                 let mut response = Response::new(full(Bytes::from_static(b"502 Bad Gateway")));
                 *response.status_mut() = StatusCode::BAD_GATEWAY;

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -337,7 +337,7 @@ async fn handle_connect_tunnel(
             service
                 .metrics
                 .upstream_errors_total
-                .with_label_values(&[&authority, "connect"])
+                .with_label_values(&[authority.as_str(), "connect"])
                 .inc();
         }
     }


### PR DESCRIPTION
…nvestigations, expanded config, analytics

Major refactor of the admin console addressing readability, monitoring depth, investigation tooling, configuration coverage and analytics:

Data honesty (the core fix):
- Every fetcher now returns Sourced<T> with live/demo provenance; silent mock fallbacks are gone. Failures render real error states; sample data appears only with demo mode explicitly enabled (Settings → Console API) and is always badged "Demo".
- Pages without backend endpoints (RPZ, Wasm, Cluster Mesh, AI Cache, eBPF stats) carry an explicit "Preview — no backend endpoint" banner.

Monitoring:
- Prometheus /metrics scraper + text-format parser with histogram quantile estimation (p50/p95/p99 request latency).
- In-memory time-series store converts counters to per-second rates across polls; Dashboard shows live request/deny/5xx rate charts, cache hit-ratio trend, status-class / cache-disposition / ACL-decision mixes, top upstream hosts with error counts, and hierarchy peers from the real /api/hierarchy/peers endpoint.
- Hand-rolled responsive SVG charts (line + crosshair tooltip, sparkline, segment bar, bar list) with a CVD-validated palette in both themes.

Investigations:
- Logs: server-side query (domain/user/window/limit) + instant client filters (IP, status class, method, cache status, decision), live tail, pagination, CSV export.
- Session correlation: session_id filter chips, per-session timeline in the detail modal using session_id/parent_event_id, redirect chain.
- Threat scores → "Investigate related traffic" drill-down into Logs.

Configuration:
- Settings expanded to 9 tabs covering the proxy's real env surface: threat-score enforcement, hierarchy/ICP/HTCP/peer discovery, upstream TLS/HTTP2, rate limiting, eBPF/XDP, Wasm hooks, gRPC control plane, Kafka/ClickHouse — all round-tripped through .env import/export.
- Live node state panel reads /api/stats and /api/upstream/tls.

UX foundation:
- TanStack Query for polling/retry/caching; toast system replaces alert(); runtime dark/light theme with CSS-variable tokens; skeleton, empty and error states throughout.

Also fixes the pre-existing type errors that broke `npm run build` (mockTestQuery rename, missing DoH/DoT fields in RpzManagement).


Claude-Session: https://claude.ai/code/session_01DSpmoaYoXRdwqX8k7Xo9Mh

## Summary

<!-- Кратко: что меняется и зачем -->

## Связанные issue

<!-- Обязательно для блокеров B1–B25: укажите Closes #NN или оставьте (Bn) в заголовке PR — issue закроется автоматически при merge (см. .github/workflows/close-blockers.yml). -->

- [ ] `Closes #NN` добавлено в описание **или** блокер указан в заголовке: `(B6)`
- Milestone / блокер: <!-- M1, B6, … -->

**Маппинг:** B*n* → issue #*(31+n)* (B6 → #37, B13 → #44).  
**B13 (NTLM):** auto-close только при `Closes #44` (полная реализация); docs-only PR не закрывают #44.

## Testing

<!-- cargo test, e2e, clippy — что запускали -->

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

## Checklist

- [x] CI зелёный
- [ ] Документация обновлена (если менялось поведение / env)
- [ ] `docs/BLOCKERS.md` / `docs/roadmap.md` (если закрывается блокер)
