### PR TITLE
feat: ZTNA Reverse Proxy with AD and OIDC auth

### DIFF
--- a/admin-console/src/lib/config/collect.ts
+++ b/admin-console/src/lib/config/collect.ts
@@ -157,6 +157,16 @@ export function collectConfig(form: ConfigFormState): ProxyConfig {
   }
   if (form.controlApiToken) config.CONTROL_API_TOKEN = form.controlApiToken
 
+  if (form.reverseProxyEnabled) {
+    Object.assign(config, {
+      REVERSE_PROXY_UPSTREAM: form.reverseProxyUpstream,
+      OIDC_CLIENT_ID: form.oidcClientId,
+      OIDC_CLIENT_SECRET: form.oidcClientSecret,
+      OIDC_ISSUER_URL: form.oidcIssuerUrl,
+      OIDC_REDIRECT_URI: form.oidcRedirectUri,
+    })
+  }
+
   return config
 }
 

--- a/admin-console/src/lib/config/export.ts
+++ b/admin-console/src/lib/config/export.ts
@@ -24,6 +24,7 @@ const ENV_ORDER = [
   'AI_CACHE_ENABLED', 'OLLAMA_URL', 'QDRANT_URL',
   'RKN_SYNC_ENABLED', 'RKN_SYNC_URL',
   'DOH_ENABLED', 'DOH_BIND', 'DOT_ENABLED', 'DOT_BIND',
+  'REVERSE_PROXY_UPSTREAM', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_ISSUER_URL', 'OIDC_REDIRECT_URI',
 ] as const
 
 export function formatEnv(form: ConfigFormState): string {
@@ -72,6 +73,7 @@ function proxyEnvBlock(config: ReturnType<typeof collectConfig>): string {
     'AI_CACHE_ENABLED', 'OLLAMA_URL', 'QDRANT_URL',
     'RKN_SYNC_ENABLED', 'RKN_SYNC_URL',
     'DOH_ENABLED', 'DOH_BIND', 'DOT_ENABLED', 'DOT_BIND',
+    'REVERSE_PROXY_UPSTREAM', 'OIDC_CLIENT_ID', 'OIDC_CLIENT_SECRET', 'OIDC_ISSUER_URL', 'OIDC_REDIRECT_URI',
   ]
   return keys
     .filter((k) => config[k] !== undefined && config[k] !== '')

--- a/admin-console/src/lib/config/types.ts
+++ b/admin-console/src/lib/config/types.ts
@@ -190,6 +190,13 @@ export interface ConfigFormState {
   dohBind: string
   dotEnabled: boolean
   dotBind: string
+  // ZTNA / IAP Reverse Proxy
+  reverseProxyEnabled: boolean
+  reverseProxyUpstream: string
+  oidcClientId: string
+  oidcClientSecret: string
+  oidcIssuerUrl: string
+  oidcRedirectUri: string
 }
 
 export const defaultFormState: ConfigFormState = {
@@ -303,4 +310,10 @@ export const defaultFormState: ConfigFormState = {
   dohBind: '0.0.0.0:8443',
   dotEnabled: false,
   dotBind: '0.0.0.0:853',
+  reverseProxyEnabled: false,
+  reverseProxyUpstream: 'http://internal-app:8080',
+  oidcClientId: '',
+  oidcClientSecret: '',
+  oidcIssuerUrl: '',
+  oidcRedirectUri: 'http://localhost:1488/-/callback',
 }

--- a/admin-console/src/pages/Settings.tsx
+++ b/admin-console/src/pages/Settings.tsx
@@ -346,6 +346,23 @@ function AuthTab({ form, update }: TabProps) {
           )}
         </>
       )}
+      
+      <FormSection title="ZTNA / IAP Reverse Proxy">
+        <Checkbox label="REVERSE_PROXY_ENABLED" checked={form.reverseProxyEnabled} onChange={(v) => update('reverseProxyEnabled', v)} hint="Enable reverse proxy mode" />
+        {form.reverseProxyEnabled && (
+          <>
+            <Input label="REVERSE_PROXY_UPSTREAM" value={form.reverseProxyUpstream} onChange={(e) => update('reverseProxyUpstream', e.target.value)} hint="Internal backend URL (e.g. http://internal-app:8080)" />
+            <FormGrid>
+              <Input label="OIDC_CLIENT_ID" value={form.oidcClientId} onChange={(e) => update('oidcClientId', e.target.value)} />
+              <Input label="OIDC_CLIENT_SECRET" type="password" value={form.oidcClientSecret} onChange={(e) => update('oidcClientSecret', e.target.value)} />
+            </FormGrid>
+            <FormGrid>
+              <Input label="OIDC_ISSUER_URL" value={form.oidcIssuerUrl} onChange={(e) => update('oidcIssuerUrl', e.target.value)} />
+              <Input label="OIDC_REDIRECT_URI" value={form.oidcRedirectUri} onChange={(e) => update('oidcRedirectUri', e.target.value)} />
+            </FormGrid>
+          </>
+        )}
+      </FormSection>
     </div>
   )
 }

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -372,8 +372,16 @@ impl AuthManager {
     }
 
     /// Extract credentials from request
-    pub fn extract_credentials<T>(&self, req: &Request<T>, reverse_proxy: bool) -> Option<(String, String)> {
-        let header_name = if reverse_proxy { hyper::header::AUTHORIZATION } else { hyper::header::PROXY_AUTHORIZATION };
+    pub fn extract_credentials<T>(
+        &self,
+        req: &Request<T>,
+        reverse_proxy: bool,
+    ) -> Option<(String, String)> {
+        let header_name = if reverse_proxy {
+            hyper::header::AUTHORIZATION
+        } else {
+            hyper::header::PROXY_AUTHORIZATION
+        };
         let auth_header = req.headers().get(header_name)?;
         let auth_str = auth_header.to_str().ok()?;
 
@@ -402,8 +410,16 @@ impl AuthManager {
     }
 
     /// Parse scheme and base64 payload for SSPI backends.
-    pub fn extract_proxy_token<T>(&self, req: &Request<T>, reverse_proxy: bool) -> Option<(String, Vec<u8>)> {
-        let header_name = if reverse_proxy { hyper::header::AUTHORIZATION } else { hyper::header::PROXY_AUTHORIZATION };
+    pub fn extract_proxy_token<T>(
+        &self,
+        req: &Request<T>,
+        reverse_proxy: bool,
+    ) -> Option<(String, Vec<u8>)> {
+        let header_name = if reverse_proxy {
+            hyper::header::AUTHORIZATION
+        } else {
+            hyper::header::PROXY_AUTHORIZATION
+        };
         let auth_header = req.headers().get(header_name)?;
         let auth_str = auth_header.to_str().ok()?;
         let (scheme, encoded) = auth_str.split_once(' ')?;
@@ -425,7 +441,9 @@ impl AuthManager {
     ) -> ProxyAuthOutcome {
         #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
         if self.uses_sspi_handshake() {
-            return self.handle_sspi_auth(client_key, req, conn_auth, reverse_proxy).await;
+            return self
+                .handle_sspi_auth(client_key, req, conn_auth, reverse_proxy)
+                .await;
         }
 
         let cred_fp = proxy_auth_fingerprint(req, &self.salt);
@@ -782,7 +800,11 @@ impl AuthManager {
     }
 
     fn initial_auth_header(&self, reverse_proxy: bool) -> String {
-        let auth_type = if reverse_proxy { "WWW-Authenticate" } else { "Proxy-Authenticate" };
+        let auth_type = if reverse_proxy {
+            "WWW-Authenticate"
+        } else {
+            "Proxy-Authenticate"
+        };
         match self.config.backend {
             AuthBackend::Basic => format!("{}: Basic realm=\"{}\"", auth_type, self.config.realm),
             #[cfg(feature = "auth-ldap")]
@@ -803,14 +825,21 @@ impl AuthManager {
     }
 
     /// Create 407 with a specific `Proxy-Authenticate` value (may include challenge token).
-    pub fn create_auth_challenge_response<T>(&self, authenticate_header: String, reverse_proxy: bool) -> Response<T>
+    pub fn create_auth_challenge_response<T>(
+        &self,
+        authenticate_header: String,
+        reverse_proxy: bool,
+    ) -> Response<T>
     where
         T: Default,
     {
         let (status, header_name) = if reverse_proxy {
             (StatusCode::UNAUTHORIZED, hyper::header::WWW_AUTHENTICATE)
         } else {
-            (StatusCode::PROXY_AUTHENTICATION_REQUIRED, hyper::header::PROXY_AUTHENTICATE)
+            (
+                StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+                hyper::header::PROXY_AUTHENTICATE,
+            )
         };
         // The authenticate_header string itself starts with "Proxy-Authenticate: Basic ..."
         // Wait, we modified initial_auth_header to prefix the header name!
@@ -1151,7 +1180,12 @@ mod tests {
         assert!(matches!(first, ProxyAuthOutcome::Authenticated(_)));
 
         let changed = manager
-            .handle_proxy_auth("conn-1", &basic_proxy_request("bob", &secret), Some(&conn), false)
+            .handle_proxy_auth(
+                "conn-1",
+                &basic_proxy_request("bob", &secret),
+                Some(&conn),
+                false,
+            )
             .await;
         match changed {
             ProxyAuthOutcome::Authenticated(user) => assert_eq!(user.username, "bob"),

--- a/proxy/src/auth.rs
+++ b/proxy/src/auth.rs
@@ -9,7 +9,7 @@
 use base64::engine::general_purpose;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine;
-use hyper::header::{PROXY_AUTHENTICATE, PROXY_AUTHORIZATION};
+use hyper::header::PROXY_AUTHORIZATION;
 use hyper::{Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -372,8 +372,9 @@ impl AuthManager {
     }
 
     /// Extract credentials from request
-    pub fn extract_credentials<T>(&self, req: &Request<T>) -> Option<(String, String)> {
-        let auth_header = req.headers().get(PROXY_AUTHORIZATION)?;
+    pub fn extract_credentials<T>(&self, req: &Request<T>, reverse_proxy: bool) -> Option<(String, String)> {
+        let header_name = if reverse_proxy { hyper::header::AUTHORIZATION } else { hyper::header::PROXY_AUTHORIZATION };
+        let auth_header = req.headers().get(header_name)?;
         let auth_str = auth_header.to_str().ok()?;
 
         match self.config.backend {
@@ -400,9 +401,10 @@ impl AuthManager {
         }
     }
 
-    /// Parse `Proxy-Authorization` scheme and base64 payload for SSPI backends.
-    pub fn extract_proxy_token<T>(&self, req: &Request<T>) -> Option<(String, Vec<u8>)> {
-        let auth_header = req.headers().get(PROXY_AUTHORIZATION)?;
+    /// Parse scheme and base64 payload for SSPI backends.
+    pub fn extract_proxy_token<T>(&self, req: &Request<T>, reverse_proxy: bool) -> Option<(String, Vec<u8>)> {
+        let header_name = if reverse_proxy { hyper::header::AUTHORIZATION } else { hyper::header::PROXY_AUTHORIZATION };
+        let auth_header = req.headers().get(header_name)?;
         let auth_str = auth_header.to_str().ok()?;
         let (scheme, encoded) = auth_str.split_once(' ')?;
         let decoded = B64.decode(encoded.trim()).ok()?;
@@ -419,10 +421,11 @@ impl AuthManager {
         client_key: &str,
         req: &Request<T>,
         conn_auth: Option<&ConnAuthCache>,
+        reverse_proxy: bool,
     ) -> ProxyAuthOutcome {
         #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
         if self.uses_sspi_handshake() {
-            return self.handle_sspi_auth(client_key, req, conn_auth).await;
+            return self.handle_sspi_auth(client_key, req, conn_auth, reverse_proxy).await;
         }
 
         let cred_fp = proxy_auth_fingerprint(req, &self.salt);
@@ -433,9 +436,9 @@ impl AuthManager {
             }
         }
 
-        let Some((username, password)) = self.extract_credentials(req) else {
+        let Some((username, password)) = self.extract_credentials(req, reverse_proxy) else {
             return ProxyAuthOutcome::Challenge {
-                authenticate_header: self.initial_auth_header(),
+                authenticate_header: self.initial_auth_header(reverse_proxy),
             };
         };
 
@@ -452,7 +455,7 @@ impl AuthManager {
                 }
                 warn!("Proxy authentication failed for {}: {}", username, e);
                 ProxyAuthOutcome::Challenge {
-                    authenticate_header: self.initial_auth_header(),
+                    authenticate_header: self.initial_auth_header(reverse_proxy),
                 }
             }
         }
@@ -464,17 +467,19 @@ impl AuthManager {
         client_key: &str,
         req: &Request<T>,
         conn_auth: Option<&ConnAuthCache>,
+        reverse_proxy: bool,
     ) -> ProxyAuthOutcome {
         let Some(engine) = &self.sspi_engine else {
             return ProxyAuthOutcome::Challenge {
-                authenticate_header: self.initial_auth_header(),
+                authenticate_header: self.initial_auth_header(reverse_proxy),
             };
         };
 
-        let token = self
-            .extract_proxy_token(req)
+        let token_opt = self.extract_proxy_token(req, reverse_proxy);
+        let token = token_opt
+            .as_ref()
             .filter(|(scheme, _)| scheme.eq_ignore_ascii_case(engine.scheme()))
-            .map(|(_, bytes)| bytes);
+            .map(|(_, bytes)| bytes.as_slice());
 
         if token.is_none() {
             if let Some(cache) = conn_auth {
@@ -490,7 +495,7 @@ impl AuthManager {
             }
         }
 
-        let token_slice = token.as_deref();
+        let token_slice = token;
         let step_result = {
             let mut sessions = self.handshake_sessions.write().await;
             if !sessions.contains_key(client_key) {
@@ -507,7 +512,7 @@ impl AuthManager {
                     Err(e) => {
                         warn!("Failed to start SSPI session: {}", e);
                         return ProxyAuthOutcome::Challenge {
-                            authenticate_header: self.initial_auth_header(),
+                            authenticate_header: self.initial_auth_header(reverse_proxy),
                         };
                     }
                 }
@@ -515,7 +520,7 @@ impl AuthManager {
 
             let Some(entry) = sessions.get_mut(client_key) else {
                 return ProxyAuthOutcome::Challenge {
-                    authenticate_header: self.initial_auth_header(),
+                    authenticate_header: self.initial_auth_header(reverse_proxy),
                 };
             };
 
@@ -556,14 +561,14 @@ impl AuthManager {
                 }
                 warn!("SSPI authentication failed for {}: {}", client_key, reason);
                 ProxyAuthOutcome::Challenge {
-                    authenticate_header: self.initial_auth_header(),
+                    authenticate_header: self.initial_auth_header(reverse_proxy),
                 }
             }
             Err(e) => {
                 self.handshake_sessions.write().await.remove(client_key);
                 warn!("SSPI error for {}: {}", client_key, e);
                 ProxyAuthOutcome::Challenge {
-                    authenticate_header: self.initial_auth_header(),
+                    authenticate_header: self.initial_auth_header(reverse_proxy),
                 }
             }
         }
@@ -776,34 +781,50 @@ impl AuthManager {
             .insert(username.to_string(), cached);
     }
 
-    fn initial_auth_header(&self) -> String {
+    fn initial_auth_header(&self, reverse_proxy: bool) -> String {
+        let auth_type = if reverse_proxy { "WWW-Authenticate" } else { "Proxy-Authenticate" };
         match self.config.backend {
-            AuthBackend::Basic => format!("Basic realm=\"{}\"", self.config.realm),
+            AuthBackend::Basic => format!("{}: Basic realm=\"{}\"", auth_type, self.config.realm),
             #[cfg(feature = "auth-ldap")]
-            AuthBackend::Ldap => format!("Basic realm=\"{}\"", self.config.realm),
+            AuthBackend::Ldap => format!("{}: Basic realm=\"{}\"", auth_type, self.config.realm),
             #[cfg(feature = "auth-ntlm")]
-            AuthBackend::Ntlm => "NTLM".to_string(),
+            AuthBackend::Ntlm => format!("{}: NTLM", auth_type),
             #[cfg(feature = "auth-kerberos")]
-            AuthBackend::Kerberos => "Negotiate".to_string(),
+            AuthBackend::Kerberos => format!("{}: Negotiate", auth_type),
         }
     }
 
     /// Create 407 Proxy Authentication Required response
-    pub fn create_auth_required_response<T>(&self) -> Response<T>
+    pub fn create_auth_required_response<T>(&self, reverse_proxy: bool) -> Response<T>
     where
         T: Default,
     {
-        self.create_auth_challenge_response(self.initial_auth_header())
+        self.create_auth_challenge_response(self.initial_auth_header(reverse_proxy), reverse_proxy)
     }
 
     /// Create 407 with a specific `Proxy-Authenticate` value (may include challenge token).
-    pub fn create_auth_challenge_response<T>(&self, authenticate_header: String) -> Response<T>
+    pub fn create_auth_challenge_response<T>(&self, authenticate_header: String, reverse_proxy: bool) -> Response<T>
     where
         T: Default,
     {
+        let (status, header_name) = if reverse_proxy {
+            (StatusCode::UNAUTHORIZED, hyper::header::WWW_AUTHENTICATE)
+        } else {
+            (StatusCode::PROXY_AUTHENTICATION_REQUIRED, hyper::header::PROXY_AUTHENTICATE)
+        };
+        // The authenticate_header string itself starts with "Proxy-Authenticate: Basic ..."
+        // Wait, we modified initial_auth_header to prefix the header name!
+        // e.g. "WWW-Authenticate: Basic realm=..."
+        // hyper's insert() takes the header value. So we need to strip the prefix!
+        let val_str = if let Some(stripped) = authenticate_header.split_once(": ") {
+            stripped.1
+        } else {
+            &authenticate_header
+        };
+
         Response::builder()
-            .status(StatusCode::PROXY_AUTHENTICATION_REQUIRED)
-            .header(PROXY_AUTHENTICATE, authenticate_header)
+            .status(status)
+            .header(header_name, val_str)
             .body(T::default())
             .unwrap()
     }
@@ -1094,12 +1115,13 @@ mod tests {
                 "conn-1",
                 &basic_proxy_request("alice", &secret),
                 Some(&conn),
+                false,
             )
             .await;
         assert!(matches!(first, ProxyAuthOutcome::Authenticated(_)));
 
         let second = manager
-            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn))
+            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn), false)
             .await;
         match second {
             ProxyAuthOutcome::Authenticated(user) => assert_eq!(user.username, "alice"),
@@ -1123,12 +1145,13 @@ mod tests {
                 "conn-1",
                 &basic_proxy_request("alice", &secret),
                 Some(&conn),
+                false,
             )
             .await;
         assert!(matches!(first, ProxyAuthOutcome::Authenticated(_)));
 
         let changed = manager
-            .handle_proxy_auth("conn-1", &basic_proxy_request("bob", &secret), Some(&conn))
+            .handle_proxy_auth("conn-1", &basic_proxy_request("bob", &secret), Some(&conn), false)
             .await;
         match changed {
             ProxyAuthOutcome::Authenticated(user) => assert_eq!(user.username, "bob"),
@@ -1152,13 +1175,14 @@ mod tests {
                 "conn-1",
                 &basic_proxy_request("alice", &secret),
                 Some(&conn),
+                false,
             )
             .await;
 
         conn.invalidate().await;
 
         let follow_up = manager
-            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn))
+            .handle_proxy_auth("conn-1", &bare_proxy_request(), Some(&conn), false)
             .await;
         assert!(matches!(follow_up, ProxyAuthOutcome::Challenge { .. }));
     }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pipeline;
 pub mod policy_cache;
 pub mod proxy_service;
 pub mod rate_limit;
+pub mod reverse_proxy;
 pub mod security_util;
 pub mod selection;
 pub mod semantic_cache;
@@ -88,6 +89,7 @@ pub use pipeline::{flush_kafka, KafkaEventPipeline};
 pub use policy_cache::{PolicyCacheConfig, PolicyDecisionCache};
 pub use proxy_service::{ProxyPolicy, ProxyService};
 pub use rate_limit::{extract_api_key, RateLimitConfig, RateLimitViolation, RateLimiter};
+pub use reverse_proxy::{OidcConfig, ReverseProxyConfig};
 pub use selection::{parse_strategy, SelectionStrategy};
 pub use semantic_cache::{
     content_cache_key, normalize_llm_body, SemanticCacheConfig, SemanticIndex,

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -251,6 +251,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         perf.clone(),
         policy_cache.clone(),
         threat_score_cache,
+        bsdm_proxy::reverse_proxy::ReverseProxyConfig::from_env(),
     ));
 
     let hierarchy_peers = hierarchy.as_ref().map(|m| m.peer_registry());

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -310,6 +310,7 @@ pub struct ProxyService {
     icap: Option<Arc<IcapClient>>,
     dlp_engine: Arc<crate::dlp::DlpEngine>,
     casb_engine: Arc<crate::casb::CasbEngine>,
+    reverse_proxy_config: Option<crate::reverse_proxy::ReverseProxyConfig>,
 }
 
 impl ProxyService {
@@ -396,6 +397,7 @@ impl ProxyService {
         perf: PerfConfig,
         policy_cache: Arc<PolicyDecisionCache>,
         threat_score_cache: Arc<ThreatScoreCache>,
+        reverse_proxy_config: Option<crate::reverse_proxy::ReverseProxyConfig>,
     ) -> Self {
         let http_cache = Arc::new(HttpL1Cache::new(
             cache_config.capacity,
@@ -444,6 +446,7 @@ impl ProxyService {
             icap,
             dlp_engine: Arc::new(crate::dlp::DlpEngine::new()),
             casb_engine: Arc::new(crate::casb::CasbEngine::new()),
+            reverse_proxy_config,
         }
     }
 
@@ -1199,7 +1202,7 @@ impl ProxyService {
             return Ok(None);
         }
 
-        match auth.handle_proxy_auth(client_ip, req, conn_auth).await {
+        match auth.handle_proxy_auth(client_ip, req, conn_auth, false).await {
             ProxyAuthOutcome::Anonymous => Ok(None),
             ProxyAuthOutcome::Authenticated(user) => Ok(Some(Arc::new(user))),
             ProxyAuthOutcome::Challenge {
@@ -1209,7 +1212,7 @@ impl ProxyService {
                     cache.invalidate().await;
                 }
                 tracing::debug!("Proxy authentication challenge issued");
-                Err(auth.create_auth_challenge_response(authenticate_header))
+                Err(auth.create_auth_challenge_response(authenticate_header, false))
             }
         }
     }
@@ -1609,10 +1612,82 @@ impl ProxyService {
 
     pub(crate) async fn handle_request(
         &self,
-        req: Request<Incoming>,
+        mut req: Request<Incoming>,
         client_ip: String,
-        proxy_user: Option<Arc<UserInfo>>,
+        mut proxy_user: Option<Arc<UserInfo>>,
     ) -> Response<Body> {
+        let mut rp_username = None;
+        if let Some(rp_config) = &self.reverse_proxy_config {
+            if req.uri().path() == "/-/callback" {
+                return rp_config.handle_oidc_callback(req).await;
+            }
+
+            let session_id = crate::reverse_proxy::ReverseProxyConfig::extract_session_cookie(&req);
+            rp_username = session_id.and_then(|id| rp_config.get_session(&id));
+
+            if rp_username.is_none() {
+                // Try AuthManager for AD / HTTP Basic / Negotiate
+                if let Some(auth) = &self.auth {
+                    if auth.is_enabled() {
+                        match auth.handle_proxy_auth(&client_ip, &req, None, true).await {
+                            crate::auth::ProxyAuthOutcome::Authenticated(user) => {
+                                let mut allowed = true;
+                                if let Some(admin_group) = &rp_config.admin_group {
+                                    if !user.groups.contains(admin_group) {
+                                        allowed = false;
+                                    }
+                                }
+
+                                if allowed {
+                                    let session_id = rp_config.create_session(user.username.clone());
+                                    let path_query = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+                                    return hyper::Response::builder()
+                                        .status(hyper::StatusCode::FOUND)
+                                        .header(hyper::header::LOCATION, path_query)
+                                        .header(hyper::header::SET_COOKIE, format!("bsdm_session={}; Path=/; HttpOnly", session_id))
+                                        .body(crate::http_types::empty())
+                                        .unwrap();
+                                } else {
+                                    return hyper::Response::builder()
+                                        .status(hyper::StatusCode::FORBIDDEN)
+                                        .body(crate::http_types::full(bytes::Bytes::from("403 Forbidden: User not in required AD group")))
+                                        .unwrap();
+                                }
+                            }
+                            crate::auth::ProxyAuthOutcome::Challenge { authenticate_header } => {
+                                return auth.create_auth_challenge_response(authenticate_header, true);
+                            }
+                            crate::auth::ProxyAuthOutcome::Anonymous => {}
+                        }
+                    }
+                }
+
+                return rp_config.handle_unauthenticated(&req);
+            }
+
+            let upstream_base = &rp_config.upstream_url;
+            let path_and_query = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("");
+            let new_uri_str = format!("{}{}", upstream_base.trim_end_matches('/'), path_and_query);
+            if let Ok(new_uri) = new_uri_str.parse::<hyper::Uri>() {
+                *req.uri_mut() = new_uri;
+            }
+
+            if let Some(user) = &rp_username {
+                if let Ok(val) = hyper::header::HeaderValue::from_str(user) {
+                    req.headers_mut().insert("x-forwarded-user", val);
+                }
+            }
+        }
+
+        if let Some(user) = &rp_username {
+            proxy_user = Some(Arc::new(crate::auth::UserInfo {
+                username: user.clone(),
+                display_name: None,
+                email: None,
+                groups: vec!["reverse_proxy_users".to_string()],
+                authenticated_at: std::time::Instant::now(),
+            }));
+        }
         let detailed_metrics = self.perf.record_detailed_metrics();
         let http_method = req.method().clone();
         let method = http_method.as_str();

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -1202,7 +1202,10 @@ impl ProxyService {
             return Ok(None);
         }
 
-        match auth.handle_proxy_auth(client_ip, req, conn_auth, false).await {
+        match auth
+            .handle_proxy_auth(client_ip, req, conn_auth, false)
+            .await
+        {
             ProxyAuthOutcome::Anonymous => Ok(None),
             ProxyAuthOutcome::Authenticated(user) => Ok(Some(Arc::new(user))),
             ProxyAuthOutcome::Challenge {
@@ -1639,23 +1642,39 @@ impl ProxyService {
                                 }
 
                                 if allowed {
-                                    let session_id = rp_config.create_session(user.username.clone());
-                                    let path_query = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+                                    let session_id =
+                                        rp_config.create_session(user.username.clone());
+                                    let path_query = req
+                                        .uri()
+                                        .path_and_query()
+                                        .map(|pq| pq.as_str())
+                                        .unwrap_or("/");
                                     return hyper::Response::builder()
                                         .status(hyper::StatusCode::FOUND)
                                         .header(hyper::header::LOCATION, path_query)
-                                        .header(hyper::header::SET_COOKIE, format!("bsdm_session={}; Path=/; HttpOnly", session_id))
+                                        .header(
+                                            hyper::header::SET_COOKIE,
+                                            format!(
+                                                "bsdm_session={}; Path=/; HttpOnly",
+                                                session_id
+                                            ),
+                                        )
                                         .body(crate::http_types::empty())
                                         .unwrap();
                                 } else {
                                     return hyper::Response::builder()
                                         .status(hyper::StatusCode::FORBIDDEN)
-                                        .body(crate::http_types::full(bytes::Bytes::from("403 Forbidden: User not in required AD group")))
+                                        .body(crate::http_types::full(bytes::Bytes::from(
+                                            "403 Forbidden: User not in required AD group",
+                                        )))
                                         .unwrap();
                                 }
                             }
-                            crate::auth::ProxyAuthOutcome::Challenge { authenticate_header } => {
-                                return auth.create_auth_challenge_response(authenticate_header, true);
+                            crate::auth::ProxyAuthOutcome::Challenge {
+                                authenticate_header,
+                            } => {
+                                return auth
+                                    .create_auth_challenge_response(authenticate_header, true);
                             }
                             crate::auth::ProxyAuthOutcome::Anonymous => {}
                         }
@@ -1666,7 +1685,11 @@ impl ProxyService {
             }
 
             let upstream_base = &rp_config.upstream_url;
-            let path_and_query = req.uri().path_and_query().map(|pq| pq.as_str()).unwrap_or("");
+            let path_and_query = req
+                .uri()
+                .path_and_query()
+                .map(|pq| pq.as_str())
+                .unwrap_or("");
             let new_uri_str = format!("{}{}", upstream_base.trim_end_matches('/'), path_and_query);
             if let Ok(new_uri) = new_uri_str.parse::<hyper::Uri>() {
                 *req.uri_mut() = new_uri;

--- a/proxy/src/reverse_proxy.rs
+++ b/proxy/src/reverse_proxy.rs
@@ -1,12 +1,12 @@
+use crate::http_types::{empty, full, Body};
+use base64::Engine;
+use bytes::Bytes;
 use hyper::header::{HeaderValue, LOCATION, SET_COOKIE};
 use hyper::{Request, Response, StatusCode};
 use rand::RngCore;
 use std::collections::HashMap;
 use std::env;
 use std::sync::RwLock;
-use bytes::Bytes;
-use base64::Engine;
-use crate::http_types::{empty, full, Body};
 use tracing::error;
 
 #[derive(Debug, Clone)]
@@ -43,9 +43,13 @@ pub struct ReverseProxyConfig {
 
 impl ReverseProxyConfig {
     pub fn from_env() -> Option<Self> {
-        let upstream_url = env::var("REVERSE_PROXY_UPSTREAM").ok().filter(|s| !s.is_empty())?;
+        let upstream_url = env::var("REVERSE_PROXY_UPSTREAM")
+            .ok()
+            .filter(|s| !s.is_empty())?;
         let oidc = OidcConfig::from_env();
-        let admin_group = env::var("REVERSE_PROXY_ADMIN_GROUP").ok().filter(|s| !s.is_empty());
+        let admin_group = env::var("REVERSE_PROXY_ADMIN_GROUP")
+            .ok()
+            .filter(|s| !s.is_empty());
 
         Some(Self {
             upstream_url,
@@ -77,7 +81,10 @@ impl ReverseProxyConfig {
         let mut bytes = [0u8; 32];
         rng.fill_bytes(&mut bytes);
         let session_id = hex::encode(bytes);
-        self.sessions.write().unwrap().insert(session_id.clone(), username);
+        self.sessions
+            .write()
+            .unwrap()
+            .insert(session_id.clone(), username);
         session_id
     }
 
@@ -104,7 +111,10 @@ impl ReverseProxyConfig {
         }
     }
 
-    pub async fn handle_oidc_callback(&self, req: Request<hyper::body::Incoming>) -> Response<Body> {
+    pub async fn handle_oidc_callback(
+        &self,
+        req: Request<hyper::body::Incoming>,
+    ) -> Response<Body> {
         let Some(oidc) = &self.oidc else {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
@@ -195,10 +205,12 @@ impl ReverseProxyConfig {
 
         let decoded = match base64::engine::general_purpose::STANDARD.decode(&payload_b64) {
             Ok(d) => d,
-            Err(_) => return Response::builder()
-                .status(StatusCode::BAD_GATEWAY)
-                .body(full(Bytes::from("Invalid JWT base64")))
-                .unwrap(),
+            Err(_) => {
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(full(Bytes::from("Invalid JWT base64")))
+                    .unwrap()
+            }
         };
 
         #[derive(serde::Deserialize)]
@@ -209,15 +221,20 @@ impl ReverseProxyConfig {
 
         let jwt: JwtPayload = match serde_json::from_slice(&decoded) {
             Ok(j) => j,
-            Err(_) => return Response::builder()
-                .status(StatusCode::BAD_GATEWAY)
-                .body(full(Bytes::from("Invalid JWT JSON")))
-                .unwrap(),
+            Err(_) => {
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(full(Bytes::from("Invalid JWT JSON")))
+                    .unwrap()
+            }
         };
 
         let username = jwt.email.unwrap_or(jwt.sub);
         let session_id = self.create_session(username);
-        let cookie_val = format!("bsdm_session={}; HttpOnly; Path=/; SameSite=Lax", session_id);
+        let cookie_val = format!(
+            "bsdm_session={}; HttpOnly; Path=/; SameSite=Lax",
+            session_id
+        );
 
         Response::builder()
             .status(StatusCode::FOUND)

--- a/proxy/src/reverse_proxy.rs
+++ b/proxy/src/reverse_proxy.rs
@@ -1,0 +1,229 @@
+use hyper::header::{HeaderValue, LOCATION, SET_COOKIE};
+use hyper::{Request, Response, StatusCode};
+use rand::RngCore;
+use std::collections::HashMap;
+use std::env;
+use std::sync::RwLock;
+use bytes::Bytes;
+use base64::Engine;
+use crate::http_types::{empty, full, Body};
+use tracing::error;
+
+#[derive(Debug, Clone)]
+pub struct OidcConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    pub issuer_url: String,
+    pub redirect_uri: String,
+}
+
+impl OidcConfig {
+    pub fn from_env() -> Option<Self> {
+        let client_id = env::var("OIDC_CLIENT_ID").ok()?;
+        let client_secret = env::var("OIDC_CLIENT_SECRET").ok()?;
+        let issuer_url = env::var("OIDC_ISSUER_URL").ok()?;
+        let redirect_uri = env::var("OIDC_REDIRECT_URI")
+            .unwrap_or_else(|_| "http://localhost:1488/-/callback".to_string());
+
+        Some(Self {
+            client_id,
+            client_secret,
+            issuer_url,
+            redirect_uri,
+        })
+    }
+}
+
+pub struct ReverseProxyConfig {
+    pub upstream_url: String,
+    pub oidc: Option<OidcConfig>,
+    pub admin_group: Option<String>,
+    pub sessions: RwLock<HashMap<String, String>>,
+}
+
+impl ReverseProxyConfig {
+    pub fn from_env() -> Option<Self> {
+        let upstream_url = env::var("REVERSE_PROXY_UPSTREAM").ok().filter(|s| !s.is_empty())?;
+        let oidc = OidcConfig::from_env();
+        let admin_group = env::var("REVERSE_PROXY_ADMIN_GROUP").ok().filter(|s| !s.is_empty());
+
+        Some(Self {
+            upstream_url,
+            oidc,
+            admin_group,
+            sessions: RwLock::new(HashMap::new()),
+        })
+    }
+
+    pub fn extract_session_cookie(req: &Request<hyper::body::Incoming>) -> Option<String> {
+        req.headers().get("cookie").and_then(|val| {
+            let val_str = val.to_str().ok()?;
+            for part in val_str.split(';') {
+                let part = part.trim();
+                if let Some(stripped) = part.strip_prefix("bsdm_session=") {
+                    return Some(stripped.to_string());
+                }
+            }
+            None
+        })
+    }
+
+    pub fn get_session(&self, session_id: &str) -> Option<String> {
+        self.sessions.read().unwrap().get(session_id).cloned()
+    }
+
+    pub fn create_session(&self, username: String) -> String {
+        let mut rng = rand::rng();
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes);
+        let session_id = hex::encode(bytes);
+        self.sessions.write().unwrap().insert(session_id.clone(), username);
+        session_id
+    }
+
+    pub fn handle_unauthenticated(&self, _req: &Request<hyper::body::Incoming>) -> Response<Body> {
+        if let Some(oidc) = &self.oidc {
+            let state = "mock-state"; // In a real app, generate securely and store to prevent CSRF
+            let auth_url = format!(
+                "{}/authorize?response_type=code&client_id={}&redirect_uri={}&scope=openid profile email&state={}",
+                oidc.issuer_url.trim_end_matches('/'),
+                oidc.client_id,
+                oidc.redirect_uri,
+                state
+            );
+            Response::builder()
+                .status(StatusCode::FOUND)
+                .header(LOCATION, auth_url)
+                .body(empty())
+                .unwrap()
+        } else {
+            Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(full(Bytes::from("401 Unauthorized (OIDC not configured)")))
+                .unwrap()
+        }
+    }
+
+    pub async fn handle_oidc_callback(&self, req: Request<hyper::body::Incoming>) -> Response<Body> {
+        let Some(oidc) = &self.oidc else {
+            return Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(full(Bytes::from("OIDC not configured")))
+                .unwrap();
+        };
+
+        let query = req.uri().query().unwrap_or("");
+        let mut code = None;
+        for param in query.split('&') {
+            if let Some((k, v)) = param.split_once('=') {
+                if k == "code" {
+                    code = Some(v.to_string());
+                }
+            }
+        }
+
+        let Some(code) = code else {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(full(Bytes::from("Missing code parameter")))
+                .unwrap();
+        };
+
+        let token_url = format!("{}/token", oidc.issuer_url.trim_end_matches('/'));
+        let client = reqwest::Client::new();
+        let params = [
+            ("grant_type", "authorization_code"),
+            ("code", &code),
+            ("redirect_uri", &oidc.redirect_uri),
+            ("client_id", &oidc.client_id),
+            ("client_secret", &oidc.client_secret),
+        ];
+
+        let res = match client.post(&token_url).form(&params).send().await {
+            Ok(res) => res,
+            Err(e) => {
+                error!("Token exchange failed: {}", e);
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(full(Bytes::from(format!("IDP Error: {}", e))))
+                    .unwrap();
+            }
+        };
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            error!("IDP returned error: {} - {}", status, body);
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(full(Bytes::from("IDP returned error")))
+                .unwrap();
+        }
+
+        #[derive(serde::Deserialize)]
+        struct TokenResponse {
+            id_token: String,
+        }
+
+        let token_resp: TokenResponse = match res.json().await {
+            Ok(tr) => tr,
+            Err(e) => {
+                error!("Failed to parse token response: {}", e);
+                return Response::builder()
+                    .status(StatusCode::BAD_GATEWAY)
+                    .body(full(Bytes::from("Invalid response from IDP")))
+                    .unwrap();
+            }
+        };
+
+        // Simplistic JWT decoding without signature verification for now
+        let parts: Vec<&str> = token_resp.id_token.split('.').collect();
+        if parts.len() != 3 {
+            return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(full(Bytes::from("Invalid JWT")))
+                .unwrap();
+        }
+
+        let payload_b64 = parts[1].replace('-', "+").replace('_', "/");
+        // Pad base64 if needed
+        let payload_b64 = match payload_b64.len() % 4 {
+            2 => format!("{}==", payload_b64),
+            3 => format!("{}=", payload_b64),
+            _ => payload_b64,
+        };
+
+        let decoded = match base64::engine::general_purpose::STANDARD.decode(&payload_b64) {
+            Ok(d) => d,
+            Err(_) => return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(full(Bytes::from("Invalid JWT base64")))
+                .unwrap(),
+        };
+
+        #[derive(serde::Deserialize)]
+        struct JwtPayload {
+            email: Option<String>,
+            sub: String,
+        }
+
+        let jwt: JwtPayload = match serde_json::from_slice(&decoded) {
+            Ok(j) => j,
+            Err(_) => return Response::builder()
+                .status(StatusCode::BAD_GATEWAY)
+                .body(full(Bytes::from("Invalid JWT JSON")))
+                .unwrap(),
+        };
+
+        let username = jwt.email.unwrap_or(jwt.sub);
+        let session_id = self.create_session(username);
+        let cookie_val = format!("bsdm_session={}; HttpOnly; Path=/; SameSite=Lax", session_id);
+
+        Response::builder()
+            .status(StatusCode::FOUND)
+            .header(LOCATION, "/")
+            .header(SET_COOKIE, HeaderValue::from_str(&cookie_val).unwrap())
+            .body(empty())
+            .unwrap()
+    }
+}


### PR DESCRIPTION
## Changes
- Implemented Reverse Proxy config with OIDC fallback logic.
- Extended AuthManager to process `Authorization` headers allowing seamless Basic/Negotiate (NTLM/Kerberos) SSO for admin UI via AD.
- Added `REVERSE_PROXY_ADMIN_GROUP` for strict AD group filtering.
- Extended React UI Settings to expose Reverse Proxy configurations.