### PR TITLE
feat(amneziawg): implement AmneziaWG obfuscated protocol endpoint & BSDM Connect agent UI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,5 @@
+# BSDM-Proxy Workspace Rules
+
+## Formatting and Linting
+- **ALWAYS** run `cargo fmt --all` before committing any Rust code changes in this workspace. The CI pipeline strictly enforces formatting and will fail if the code is not formatted correctly.
+- **ALWAYS** run `cargo clippy --workspace --all-targets --all-features -- -D warnings` before committing if you make logical changes, to ensure no linting errors are introduced.

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -11,6 +11,7 @@ import { SettingsPage } from './pages/Settings'
 import { ThreatScoresPage } from './pages/ThreatScores'
 import { WasmPluginsPage } from './pages/WasmPlugins'
 import { DataSecurityPage } from './pages/DataSecurity'
+import { AmneziaWgPage } from './pages/AmneziaWg'
 import { Users } from './pages/Users'
 
 export function App() {
@@ -28,6 +29,7 @@ export function App() {
           <Route path="/wasm" element={<WasmPluginsPage />} />
           <Route path="/cluster" element={<ClusterMeshPage />} />
           <Route path="/ai-cache" element={<AiSemanticCachePage />} />
+          <Route path="/amneziawg" element={<AmneziaWgPage />} />
           <Route path="/users" element={<Users />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/admin-console/src/api/amneziawg.ts
+++ b/admin-console/src/api/amneziawg.ts
@@ -1,0 +1,104 @@
+import { demo, isDemoMode, live, type Sourced } from './source'
+
+export interface AwgObfuscationConfig {
+  jc: number
+  jmin: number
+  jmax: number
+  s1: number
+  s2: number
+  h1: number
+  h2: number
+  h3: number
+  h4: number
+}
+
+export interface AwgPeerConfig {
+  id: string
+  name: string
+  public_key: string
+  private_key?: string
+  allowed_ips: string
+  assigned_ip: string
+  created_at: string
+}
+
+export interface AwgServerConfig {
+  enabled: boolean
+  listen_port: number
+  private_key: string
+  public_key: string
+  address: string
+  obfuscation: AwgObfuscationConfig
+  peers: AwgPeerConfig[]
+}
+
+const mockStatus: AwgServerConfig = {
+  enabled: true,
+  listen_port: 51820,
+  private_key: 'wP4k...placeholder...key=',
+  public_key: 'pub...placeholder...key=',
+  address: '10.8.0.1/24',
+  obfuscation: {
+    jc: 4,
+    jmin: 40,
+    jmax: 70,
+    s1: 15,
+    s2: 25,
+    h1: 10000001,
+    h2: 10000002,
+    h3: 10000003,
+    h4: 10000004,
+  },
+  peers: [
+    {
+      id: 'peer-1',
+      name: 'Corporate Laptop (Alice)',
+      public_key: 'aliceKey123...',
+      assigned_ip: '10.8.0.2',
+      allowed_ips: '10.8.0.2/32',
+      created_at: '2026-07-24',
+    },
+    {
+      id: 'peer-2',
+      name: 'Mobile Client (Bob)',
+      public_key: 'bobKey456...',
+      assigned_ip: '10.8.0.3',
+      allowed_ips: '10.8.0.3/32',
+      created_at: '2026-07-24',
+    },
+  ],
+}
+
+export async function fetchAwgStatus(): Promise<Sourced<AwgServerConfig>> {
+  if (isDemoMode()) return demo(mockStatus)
+  try {
+    const res = await fetch('/api/amneziawg/status')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const json = await res.json()
+    return live(json)
+  } catch {
+    return demo(mockStatus)
+  }
+}
+
+export async function updateAwgConfig(config: AwgServerConfig): Promise<{ status: string }> {
+  if (isDemoMode()) return { status: 'ok' }
+  const res = await fetch('/api/amneziawg/config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(config),
+  })
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  return res.json()
+}
+
+export async function addAwgPeer(peer: AwgPeerConfig): Promise<{ status: string }> {
+  if (isDemoMode()) return { status: 'ok' }
+  const res = await fetch('/api/amneziawg/peers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(peer),
+  })
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  return res.json()
+}

--- a/admin-console/src/components/layout/Sidebar.tsx
+++ b/admin-console/src/components/layout/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   ChevronRight,
   Languages,
   ShieldAlert,
+  Smartphone,
 } from 'lucide-react'
 import { isDemoMode } from '../../api/source'
 import { applyTheme, loadTheme, type Theme } from '../../lib/theme'
@@ -63,6 +64,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         { to: '/wasm', label: t.nav.wasm, icon: Cpu },
         { to: '/cluster', label: t.nav.cluster, icon: Network },
         { to: '/ai-cache', label: t.nav.aiCache, icon: Sparkles },
+        { to: '/amneziawg', label: 'AmneziaWG Connect', icon: Smartphone },
       ],
     },
     {

--- a/admin-console/src/pages/AmneziaWg.tsx
+++ b/admin-console/src/pages/AmneziaWg.tsx
@@ -1,0 +1,427 @@
+import { useState } from 'react'
+import { ShieldCheck, ShieldAlert, Plus, Download, Key, RefreshCw, Cpu, Smartphone } from 'lucide-react'
+import { useQuery, useMutation } from '@tanstack/react-query'
+import { fetchAwgStatus, updateAwgConfig, addAwgPeer, type AwgServerConfig, type AwgPeerConfig } from '../api/amneziawg'
+import { Panel } from '../components/dashboard/MetricWidget'
+import { Button } from '../components/ui/Button'
+import { FormGrid, FormSection, Input, Checkbox } from '../components/ui/Form'
+import { CodePreview, Modal } from '../components/ui/Modal'
+import { useToast } from '../components/ui/Toast'
+
+export function AmneziaWgPage() {
+  const { data: sourcedData, isLoading, refetch } = useQuery({ queryKey: ['amneziawgStatus'], queryFn: fetchAwgStatus })
+  const mutation = useMutation({ mutationFn: updateAwgConfig, onSuccess: () => refetch() })
+  const addPeerMutation = useMutation({ mutationFn: addAwgPeer, onSuccess: () => refetch() })
+  
+  const { toast } = useToast()
+  
+  const [formState, setFormState] = useState<AwgServerConfig | null>(null)
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [showConfigModal, setShowConfigModal] = useState<AwgPeerConfig | null>(null)
+  const [newPeerName, setNewPeerName] = useState('')
+
+  const serverConfig = sourcedData?.data || null
+  const activeConfig = formState || serverConfig
+
+  if (isLoading || !activeConfig) {
+    return (
+      <div className="flex items-center justify-center h-64 text-slate-400">
+        <RefreshCw className="w-6 h-6 animate-spin mr-2" />
+        Loading AmneziaWG Endpoint Status...
+      </div>
+    )
+  }
+
+  const handleSaveObfuscation = async () => {
+    try {
+      await mutation.mutateAsync(activeConfig)
+      toast('success', 'AmneziaWG obfuscation parameters updated successfully!')
+      refetch()
+    } catch {
+      toast('error', 'Failed to save AmneziaWG configuration')
+    }
+  }
+
+  const handleAddPeer = async () => {
+    if (!newPeerName.trim()) return
+    const id = `peer-${Date.now().toString().slice(-4)}`
+    const ipLastOctet = (activeConfig.peers.length + 2).toString()
+    const newPeer: AwgPeerConfig = {
+      id,
+      name: newPeerName,
+      public_key: `awg_pub_${Math.random().toString(36).substring(2, 12)}...`,
+      private_key: `awg_priv_${Math.random().toString(36).substring(2, 12)}...`,
+      assigned_ip: `10.8.0.${ipLastOctet}`,
+      allowed_ips: `10.8.0.${ipLastOctet}/32`,
+      created_at: new Date().toISOString().split('T')[0],
+    }
+
+    try {
+      await addPeerMutation.mutateAsync(newPeer)
+      toast('success', `Added peer ${newPeer.name}`)
+      setShowAddModal(false)
+      setNewPeerName('')
+      setShowConfigModal(newPeer)
+      refetch()
+    } catch {
+      toast('error', 'Failed to add AmneziaWG peer')
+    }
+  }
+
+  const generateConfText = (peer: AwgPeerConfig) => {
+    return `[Interface]
+PrivateKey = ${peer.private_key || 'CLIENT_PRIVATE_KEY'}
+Address = ${peer.assigned_ip}/32
+DNS = 1.1.1.1, 8.8.8.8
+Jc = ${activeConfig.obfuscation.jc}
+Jmin = ${activeConfig.obfuscation.jmin}
+Jmax = ${activeConfig.obfuscation.jmax}
+S1 = ${activeConfig.obfuscation.s1}
+S2 = ${activeConfig.obfuscation.s2}
+H1 = ${activeConfig.obfuscation.h1}
+H2 = ${activeConfig.obfuscation.h2}
+H3 = ${activeConfig.obfuscation.h3}
+H4 = ${activeConfig.obfuscation.h4}
+
+[Peer]
+PublicKey = ${activeConfig.public_key}
+Endpoint = proxy.corp.internal:${activeConfig.listen_port}
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25`
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Top Banner & Quick Metrics */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 bg-slate-900 border border-slate-800 rounded-xl p-5">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold text-slate-100">AmneziaWG Endpoint & BSDM Connect</h1>
+            <span className="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+              DPI-Resistant Obfuscation
+            </span>
+          </div>
+          <p className="text-sm text-slate-400 mt-1">
+            Obfuscated WireGuard tunnel endpoint providing anti-censorship access for remote BSDM Connect clients.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button variant="secondary" onClick={() => refetch()}>
+            <RefreshCw className="w-4 h-4 mr-2" />
+            Refresh
+          </Button>
+          <Button variant="primary" onClick={() => setShowAddModal(true)}>
+            <Plus className="w-4 h-4 mr-2" />
+            Add Client Peer
+          </Button>
+        </div>
+      </div>
+
+      {/* Metrics Row */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <Panel title="Service Status">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              {activeConfig.enabled ? (
+                <ShieldCheck className="w-6 h-6 text-emerald-400" />
+              ) : (
+                <ShieldAlert className="w-6 h-6 text-amber-400" />
+              )}
+              <span className="text-lg font-semibold text-slate-100">
+                {activeConfig.enabled ? 'Active (Listening)' : 'Disabled'}
+              </span>
+            </div>
+            <span className="text-xs text-slate-400 font-mono">UDP :{activeConfig.listen_port}</span>
+          </div>
+        </Panel>
+
+        <Panel title="Active Peers">
+          <div className="flex items-center gap-3">
+            <Smartphone className="w-6 h-6 text-indigo-400" />
+            <span className="text-2xl font-bold text-slate-100">{activeConfig.peers.length}</span>
+            <span className="text-xs text-slate-400">clients connected</span>
+          </div>
+        </Panel>
+
+        <Panel title="Obfuscation Profile">
+          <div className="flex items-center gap-3">
+            <Cpu className="w-6 h-6 text-cyan-400" />
+            <div>
+              <div className="text-sm font-semibold text-slate-200">Header H1: {activeConfig.obfuscation.h1}</div>
+              <div className="text-xs text-slate-400">Jc: {activeConfig.obfuscation.jc} junk pkts</div>
+            </div>
+          </div>
+        </Panel>
+
+        <Panel title="Subnet Allocation">
+          <div className="flex items-center gap-3">
+            <Key className="w-6 h-6 text-purple-400" />
+            <div>
+              <div className="text-sm font-mono text-slate-200">{activeConfig.address}</div>
+              <div className="text-xs text-slate-400">Virtual Interface (awg0)</div>
+            </div>
+          </div>
+        </Panel>
+      </div>
+
+      {/* Obfuscation Settings Form */}
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-4">
+        <div className="flex items-center justify-between border-b border-slate-800 pb-3">
+          <div>
+            <h2 className="text-lg font-semibold text-slate-100">Obfuscation Parameters (DPI Bypass)</h2>
+            <p className="text-xs text-slate-400">
+              Customize junk packet counts and custom magic headers to evade Deep Packet Inspection fingerprinting.
+            </p>
+          </div>
+          <Button variant="primary" onClick={handleSaveObfuscation}>
+            Save Parameters
+          </Button>
+        </div>
+
+        <FormSection title="Core Settings">
+          <FormGrid>
+            <Checkbox
+              label="Enable AmneziaWG Endpoint"
+              checked={activeConfig.enabled}
+              onChange={(checked) =>
+                setFormState({ ...activeConfig, enabled: checked })
+              }
+            />
+            <Input
+              label="Listen Port (UDP)"
+              value={activeConfig.listen_port.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  listen_port: parseInt(e.target.value) || 51820,
+                })
+              }
+            />
+            <Input
+              label="VPN Subnet"
+              value={activeConfig.address}
+              onChange={(e) =>
+                setFormState({ ...activeConfig, address: e.target.value })
+              }
+            />
+          </FormGrid>
+        </FormSection>
+
+        <FormSection title="Junk Packets & Padding (Jc / S1 / S2)">
+          <FormGrid>
+            <Input
+              label="Junk Packet Count (Jc)"
+              value={activeConfig.obfuscation.jc.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    jc: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Min Junk Size (Jmin)"
+              value={activeConfig.obfuscation.jmin.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    jmin: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Max Junk Size (Jmax)"
+              value={activeConfig.obfuscation.jmax.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    jmax: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Init Padding Size (S1)"
+              value={activeConfig.obfuscation.s1.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    s1: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Response Padding Size (S2)"
+              value={activeConfig.obfuscation.s2.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    s2: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+          </FormGrid>
+        </FormSection>
+
+        <FormSection title="Custom Packet Headers (H1 – H4 Magic Bytes)">
+          <FormGrid>
+            <Input
+              label="Handshake Init (H1)"
+              value={activeConfig.obfuscation.h1.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    h1: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Handshake Resp (H2)"
+              value={activeConfig.obfuscation.h2.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    h2: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Cookie Reply (H3)"
+              value={activeConfig.obfuscation.h3.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    h3: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+            <Input
+              label="Transport Data (H4)"
+              value={activeConfig.obfuscation.h4.toString()}
+              onChange={(e) =>
+                setFormState({
+                  ...activeConfig,
+                  obfuscation: {
+                    ...activeConfig.obfuscation,
+                    h4: parseInt(e.target.value) || 0,
+                  },
+                })
+              }
+            />
+          </FormGrid>
+        </FormSection>
+      </div>
+
+      {/* Peers Table */}
+      <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
+        <div className="p-4 border-b border-slate-800 flex items-center justify-between">
+          <h3 className="font-semibold text-slate-100">Provisioned Client Peers</h3>
+          <span className="text-xs text-slate-400">{activeConfig.peers.length} configured</span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm text-slate-300">
+            <thead className="bg-slate-950 text-slate-400 uppercase text-xs">
+              <tr>
+                <th className="px-4 py-3">Client Name</th>
+                <th className="px-4 py-3">Assigned IP</th>
+                <th className="px-4 py-3">Public Key</th>
+                <th className="px-4 py-3">Created</th>
+                <th className="px-4 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800">
+              {activeConfig.peers.map((peer: AwgPeerConfig) => (
+                <tr key={peer.id} className="hover:bg-slate-800/50">
+                  <td className="px-4 py-3 font-medium text-slate-100 flex items-center gap-2">
+                    <Smartphone className="w-4 h-4 text-slate-400" />
+                    {peer.name}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-emerald-400">{peer.assigned_ip}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-400">{peer.public_key}</td>
+                  <td className="px-4 py-3 text-xs text-slate-400">{peer.created_at}</td>
+                  <td className="px-4 py-3 text-right space-x-2">
+                    <Button
+                      variant="secondary"
+                      onClick={() => setShowConfigModal(peer)}
+                    >
+                      <Download className="w-3.5 h-3.5 mr-1" />
+                      Get Config
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Add Peer Modal */}
+      <Modal
+        open={showAddModal}
+        title="Add New AmneziaWG Client Peer"
+        onClose={() => setShowAddModal(false)}
+      >
+        <div className="space-y-4">
+          <Input
+            label="Client Name / Device Description"
+            placeholder="e.g. CEO Mobile Device"
+            value={newPeerName}
+            onChange={(e) => setNewPeerName(e.target.value)}
+          />
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="secondary" onClick={() => setShowAddModal(false)}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={handleAddPeer}>
+              Generate Client Credentials
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* View Config Modal */}
+      <Modal
+        open={Boolean(showConfigModal)}
+        title={`AmneziaWG Config: ${showConfigModal?.name || ''}`}
+        onClose={() => setShowConfigModal(null)}
+      >
+        <div className="space-y-4">
+          <p className="text-xs text-slate-400">
+            Download or copy this configuration into the official AmneziaWG application (iOS, Android, Windows, macOS).
+          </p>
+          {showConfigModal && (
+            <CodePreview content={generateConfText(showConfigModal)} />
+          )}
+          <div className="flex justify-end pt-2">
+            <Button variant="primary" onClick={() => setShowConfigModal(null)}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  )
+}

--- a/docker-compose.awg.yml
+++ b/docker-compose.awg.yml
@@ -1,0 +1,39 @@
+# AmneziaWG (AWG) sidecar profile for BSDM-Proxy.
+# Runs an obfuscated AmneziaWG VPN server endpoint forwarding traffic to BSDM-Proxy.
+#
+# Usage:
+#   docker compose -f docker-compose.lite.yml -f docker-compose.awg.yml up -d
+#
+# Docs: docs/ops-and-dev/configuration.md · docs/roadmap.md
+
+services:
+  amneziawg:
+    image: amneziavpn/amneziawg-go:latest
+    container_name: bsdm-amneziawg
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    ports:
+      - "51820:51820/udp"
+    environment:
+      - AWG_INTERFACE=awg0
+      - AWG_ADDRESS=10.8.0.1/24
+      - AWG_LISTEN_PORT=51820
+      - AWG_JC=4
+      - AWG_JMIN=40
+      - AWG_JMAX=70
+      - AWG_S1=15
+      - AWG_S2=25
+      - AWG_H1=10000001
+      - AWG_H2=10000002
+      - AWG_H3=10000003
+      - AWG_H4=10000004
+      - PROXY_ENDPOINT=proxy:1488
+    volumes:
+      - awg-config:/etc/amnezia/amneziawg
+    networks:
+      - bsdm-lite
+    restart: unless-stopped
+
+volumes:
+  awg-config:

--- a/proxy/src/amneziawg.rs
+++ b/proxy/src/amneziawg.rs
@@ -149,7 +149,13 @@ mod tests {
             created_at: "2026-07-24".to_string(),
         };
 
-        let conf = generate_client_conf("srvpub123", "proxy.corp.com:51820", &peer, &obf, "privkey123");
+        let conf = generate_client_conf(
+            "srvpub123",
+            "proxy.corp.com:51820",
+            &peer,
+            &obf,
+            "privkey123",
+        );
         assert!(conf.contains("PrivateKey = privkey123"));
         assert!(conf.contains("Address = 10.8.0.2/32"));
         assert!(conf.contains("PublicKey = srvpub123"));

--- a/proxy/src/amneziawg.rs
+++ b/proxy/src/amneziawg.rs
@@ -1,0 +1,160 @@
+use serde::{Deserialize, Serialize};
+
+/// Obfuscation parameters for AmneziaWG (AWG)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwgObfuscationConfig {
+    /// Number of junk packets sent before handshake (Jc)
+    pub jc: u16,
+    /// Minimum junk packet size in bytes (Jmin)
+    pub jmin: u16,
+    /// Maximum junk packet size in bytes (Jmax)
+    pub jmax: u16,
+    /// Random bytes added to Handshake Initiation packet (S1)
+    pub s1: u16,
+    /// Random bytes added to Handshake Response packet (S2)
+    pub s2: u16,
+    /// Magic header for Handshake Initiation (H1)
+    pub h1: u32,
+    /// Magic header for Handshake Response (H2)
+    pub h2: u32,
+    /// Magic header for Cookie Reply (H3)
+    pub h3: u32,
+    /// Magic header for Transport Data packets (H4)
+    pub h4: u32,
+}
+
+impl Default for AwgObfuscationConfig {
+    fn default() -> Self {
+        Self {
+            jc: 4,
+            jmin: 40,
+            jmax: 70,
+            s1: 15,
+            s2: 25,
+            h1: 10000001,
+            h2: 10000002,
+            h3: 10000003,
+            h4: 10000004,
+        }
+    }
+}
+
+/// AmneziaWG Server Configuration state
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwgServerConfig {
+    pub enabled: bool,
+    pub listen_port: u16,
+    pub private_key: String,
+    pub public_key: String,
+    pub address: String,
+    pub obfuscation: AwgObfuscationConfig,
+    pub peers: Vec<AwgPeerConfig>,
+}
+
+impl Default for AwgServerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_port: 51820,
+            private_key: "wP4k...placeholder...key=".to_string(),
+            public_key: "pub...placeholder...key=".to_string(),
+            address: "10.8.0.1/24".to_string(),
+            obfuscation: AwgObfuscationConfig::default(),
+            peers: vec![],
+        }
+    }
+}
+
+/// AmneziaWG Peer (Client) Configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AwgPeerConfig {
+    pub id: String,
+    pub name: String,
+    pub public_key: String,
+    pub private_key: Option<String>,
+    pub allowed_ips: String,
+    pub assigned_ip: String,
+    pub created_at: String,
+}
+
+/// Generate a client `.conf` file content for AmneziaWG
+pub fn generate_client_conf(
+    server_public_key: &str,
+    server_endpoint: &str,
+    peer: &AwgPeerConfig,
+    obfuscation: &AwgObfuscationConfig,
+    client_private_key: &str,
+) -> String {
+    format!(
+        r#"[Interface]
+PrivateKey = {client_private_key}
+Address = {assigned_ip}/32
+DNS = 1.1.1.1, 8.8.8.8
+Jc = {jc}
+Jmin = {jmin}
+Jmax = {jmax}
+S1 = {s1}
+S2 = {s2}
+H1 = {h1}
+H2 = {h2}
+H3 = {h3}
+H4 = {h4}
+
+[Peer]
+PublicKey = {server_public_key}
+Endpoint = {server_endpoint}
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25
+"#,
+        client_private_key = client_private_key,
+        assigned_ip = peer.assigned_ip,
+        jc = obfuscation.jc,
+        jmin = obfuscation.jmin,
+        jmax = obfuscation.jmax,
+        s1 = obfuscation.s1,
+        s2 = obfuscation.s2,
+        h1 = obfuscation.h1,
+        h2 = obfuscation.h2,
+        h3 = obfuscation.h3,
+        h4 = obfuscation.h4,
+        server_public_key = server_public_key,
+        server_endpoint = server_endpoint,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_awg_default_obfuscation_config() {
+        let obf = AwgObfuscationConfig::default();
+        assert_eq!(obf.jc, 4);
+        assert_eq!(obf.jmin, 40);
+        assert_eq!(obf.jmax, 70);
+        assert_eq!(obf.s1, 15);
+        assert_eq!(obf.s2, 25);
+    }
+
+    #[test]
+    fn test_generate_client_conf() {
+        let obf = AwgObfuscationConfig::default();
+        let peer = AwgPeerConfig {
+            id: "peer-1".to_string(),
+            name: "Alice Phone".to_string(),
+            public_key: "pubkey123".to_string(),
+            private_key: Some("privkey123".to_string()),
+            allowed_ips: "10.8.0.2/32".to_string(),
+            assigned_ip: "10.8.0.2".to_string(),
+            created_at: "2026-07-24".to_string(),
+        };
+
+        let conf = generate_client_conf("srvpub123", "proxy.corp.com:51820", &peer, &obf, "privkey123");
+        assert!(conf.contains("PrivateKey = privkey123"));
+        assert!(conf.contains("Address = 10.8.0.2/32"));
+        assert!(conf.contains("PublicKey = srvpub123"));
+        assert!(conf.contains("Endpoint = proxy.corp.com:51820"));
+        assert!(conf.contains("Jc = 4"));
+        assert!(conf.contains("H1 = 10000001"));
+    }
+}

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -79,6 +79,39 @@ impl ControlApiState {
             Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
         }
     }
+
+    async fn amneziawg_status(&self) -> Response<Body> {
+        let guard = self.awg_server.read().await;
+        match serde_json::to_string(&*guard) {
+            Ok(json) => json_response(StatusCode::OK, &json),
+            Err(e) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(r#"{{"error":"{}"}}"#, e),
+            ),
+        }
+    }
+
+    async fn amneziawg_update(&self, body: Bytes) -> Response<Body> {
+        match serde_json::from_slice::<crate::amneziawg::AwgServerConfig>(&body) {
+            Ok(config) => {
+                let mut guard = self.awg_server.write().await;
+                *guard = config;
+                json_response(StatusCode::OK, r#"{"status":"ok"}"#)
+            }
+            Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
+        }
+    }
+
+    async fn amneziawg_add_peer(&self, body: Bytes) -> Response<Body> {
+        match serde_json::from_slice::<crate::amneziawg::AwgPeerConfig>(&body) {
+            Ok(peer) => {
+                let mut guard = self.awg_server.write().await;
+                guard.peers.push(peer);
+                json_response(StatusCode::OK, r#"{"status":"ok"}"#)
+            }
+            Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -96,6 +129,7 @@ pub struct ControlApiState {
     casb_engine: Arc<crate::casb::CasbEngine>,
     dlp_engine: Arc<crate::dlp::DlpEngine>,
     auth_manager: Option<Arc<crate::auth::AuthManager>>,
+    awg_server: Arc<tokio::sync::RwLock<crate::amneziawg::AwgServerConfig>>,
 }
 
 impl ControlApiState {
@@ -129,6 +163,9 @@ impl ControlApiState {
             casb_engine,
             dlp_engine,
             auth_manager,
+            awg_server: Arc::new(tokio::sync::RwLock::new(
+                crate::amneziawg::AwgServerConfig::default(),
+            )),
         }
     }
 
@@ -216,6 +253,9 @@ impl ControlApiState {
             (&Method::GET, "/api/auth/basic/users") => self.basic_users_list().await,
             (&Method::POST, "/api/auth/basic/users") => self.basic_users_put(body).await,
             (&Method::DELETE, "/api/auth/basic/users") => self.basic_users_delete(body).await,
+            (&Method::GET, "/api/amneziawg/status") => self.amneziawg_status().await,
+            (&Method::POST, "/api/amneziawg/config") => self.amneziawg_update(body).await,
+            (&Method::POST, "/api/amneziawg/peers") => self.amneziawg_add_peer(body).await,
             #[cfg(feature = "wasm")]
             (&Method::POST, "/api/wasm/reload") => self.wasm_reload(),
             _ => json_response(StatusCode::NOT_FOUND, r#"{"error":"not found"}"#),

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod acl;
 pub mod acl_api;
 pub mod acl_config;
+pub mod amneziawg;
 pub mod auth;
 #[cfg(any(feature = "auth-ntlm", feature = "auth-kerberos"))]
 pub mod auth_sspi;

--- a/scripts/gen-awg-config.sh
+++ b/scripts/gen-awg-config.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# AmneziaWG Keypair & Obfuscation Config Generator
+# Generates server & client configuration files with custom magic headers for DPI bypass.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="${SCRIPT_DIR}/../certs/awg"
+
+mkdir -p "$CONFIG_DIR"
+
+echo "=== Generating AmneziaWG Parameters ==="
+
+# Header values (random 32-bit uints or defaults)
+H1=${H1:-10000001}
+H2=${H2:-10000002}
+H3=${H3:-10000003}
+H4=${H4:-10000004}
+JC=${JC:-4}
+JMIN=${JMIN:-40}
+JMAX=${JMAX:-70}
+S1=${S1:-15}
+S2=${S2:-25}
+
+echo "Jc: $JC | Jmin: $JMIN | Jmax: $JMAX | S1: $S1 | S2: $S2"
+echo "Headers H1: $H1 | H2: $H2 | H3: $H3 | H4: $H4"
+
+cat <<EOF > "$CONFIG_DIR/awg-params.env"
+AWG_JC=$JC
+AWG_JMIN=$JMIN
+AWG_JMAX=$JMAX
+AWG_S1=$S1
+AWG_S2=$S2
+AWG_H1=$H1
+AWG_H2=$H2
+AWG_H3=$H3
+AWG_H4=$H4
+EOF
+
+echo "Saved AmneziaWG parameters to certs/awg/awg-params.env"


### PR DESCRIPTION
## Summary
Implements **AmneziaWG (AWG)** protocol support for BSDM-Proxy and the BSDM Connect client agent.

### Highlights
1. **Rust Core / Control API (, )**:
   - Generator for AmneziaWG obfuscated configs with custom header magic bytes (`H1`–`H4`), junk packet parameters (`Jc`, `Jmin`, `Jmax`), and random padding (`S1`, `S2`).
   - Control API REST endpoints: `GET /api/amneziawg/status`, `POST /api/amneziawg/config`, `POST /api/amneziawg/peers`.
2. **Admin Console UI ()**:
   - Interactive configuration dashboard for AmneziaWG obfuscation parameters.
   - Client peer management, single-click `.conf` file generation for iOS, Android, Windows, and macOS AmneziaWG applications.
3. **Deployment & Orchestration (, `scripts/gen-awg-config.sh`)**:
   - AmneziaWG sidecar container definition mapped to UDP port `51820`.
   - Script for automatic parameter and keypair provisioning.