### PR TITLE
feat(awg): AWG Control Plane Link & Sidecar Lifecycle

### DIFF
--- a/admin-console/src/api/amneziawg.ts
+++ b/admin-console/src/api/amneziawg.ts
@@ -20,6 +20,9 @@ export interface AwgPeerConfig {
   allowed_ips: string
   assigned_ip: string
   created_at: string
+  rx_bytes?: number
+  tx_bytes?: number
+  latest_handshake_secs?: number
 }
 
 export interface AwgServerConfig {
@@ -30,6 +33,8 @@ export interface AwgServerConfig {
   address: string
   obfuscation: AwgObfuscationConfig
   peers: AwgPeerConfig[]
+  last_reload_status?: string
+  last_reload_at?: number
 }
 
 const mockStatus: AwgServerConfig = {
@@ -38,6 +43,8 @@ const mockStatus: AwgServerConfig = {
   private_key: 'wP4k...placeholder...key=',
   public_key: 'pub...placeholder...key=',
   address: '10.8.0.1/24',
+  last_reload_status: 'Sidecar synced (awg0.conf updated)',
+  last_reload_at: 1721812900,
   obfuscation: {
     jc: 4,
     jmin: 40,
@@ -57,6 +64,9 @@ const mockStatus: AwgServerConfig = {
       assigned_ip: '10.8.0.2',
       allowed_ips: '10.8.0.2/32',
       created_at: '2026-07-24',
+      rx_bytes: 14258900,
+      tx_bytes: 84210000,
+      latest_handshake_secs: Math.floor(Date.now() / 1000) - 120,
     },
     {
       id: 'peer-2',
@@ -65,6 +75,9 @@ const mockStatus: AwgServerConfig = {
       assigned_ip: '10.8.0.3',
       allowed_ips: '10.8.0.3/32',
       created_at: '2026-07-24',
+      rx_bytes: 512000,
+      tx_bytes: 1024000,
+      latest_handshake_secs: Math.floor(Date.now() / 1000) - 3600,
     },
   ],
 }
@@ -81,8 +94,8 @@ export async function fetchAwgStatus(): Promise<Sourced<AwgServerConfig>> {
   }
 }
 
-export async function updateAwgConfig(config: AwgServerConfig): Promise<{ status: string }> {
-  if (isDemoMode()) return { status: 'ok' }
+export async function updateAwgConfig(config: AwgServerConfig): Promise<{ status: string; reload_status?: string }> {
+  if (isDemoMode()) return { status: 'ok', reload_status: 'Sidecar synced' }
   const res = await fetch('/api/amneziawg/config', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -92,12 +105,23 @@ export async function updateAwgConfig(config: AwgServerConfig): Promise<{ status
   return res.json()
 }
 
-export async function addAwgPeer(peer: AwgPeerConfig): Promise<{ status: string }> {
-  if (isDemoMode()) return { status: 'ok' }
+export async function addAwgPeer(peer: AwgPeerConfig): Promise<{ status: string; reload_status?: string }> {
+  if (isDemoMode()) return { status: 'ok', reload_status: 'Sidecar synced' }
   const res = await fetch('/api/amneziawg/peers', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(peer),
+  })
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  return res.json()
+}
+
+export async function deleteAwgPeer(id: string): Promise<{ status: string; reload_status?: string }> {
+  if (isDemoMode()) return { status: 'deleted', reload_status: 'Sidecar synced' }
+  const res = await fetch('/api/amneziawg/peers', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
   })
   if (!res.ok) throw new Error('HTTP ' + res.status)
   return res.json()

--- a/admin-console/src/pages/AmneziaWg.tsx
+++ b/admin-console/src/pages/AmneziaWg.tsx
@@ -1,17 +1,35 @@
 import { useState } from 'react'
-import { ShieldCheck, ShieldAlert, Plus, Download, Key, RefreshCw, Cpu, Smartphone } from 'lucide-react'
+import { ShieldCheck, ShieldAlert, Plus, Download, Key, RefreshCw, Cpu, Smartphone, Trash2, Activity } from 'lucide-react'
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { fetchAwgStatus, updateAwgConfig, addAwgPeer, type AwgServerConfig, type AwgPeerConfig } from '../api/amneziawg'
+import { fetchAwgStatus, updateAwgConfig, addAwgPeer, deleteAwgPeer, type AwgServerConfig, type AwgPeerConfig } from '../api/amneziawg'
 import { Panel } from '../components/dashboard/MetricWidget'
 import { Button } from '../components/ui/Button'
 import { FormGrid, FormSection, Input, Checkbox } from '../components/ui/Form'
 import { CodePreview, Modal } from '../components/ui/Modal'
 import { useToast } from '../components/ui/Toast'
 
+function formatBytes(bytes?: number): string {
+  if (!bytes || bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
+}
+
+function formatHandshake(secs?: number): string {
+  if (!secs || secs === 0) return 'Never'
+  const now = Math.floor(Date.now() / 1000)
+  const diff = now - secs
+  if (diff < 60) return `${diff}s ago`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  return `${Math.floor(diff / 3600)}h ago`
+}
+
 export function AmneziaWgPage() {
   const { data: sourcedData, isLoading, refetch } = useQuery({ queryKey: ['amneziawgStatus'], queryFn: fetchAwgStatus })
   const mutation = useMutation({ mutationFn: updateAwgConfig, onSuccess: () => refetch() })
   const addPeerMutation = useMutation({ mutationFn: addAwgPeer, onSuccess: () => refetch() })
+  const deletePeerMutation = useMutation({ mutationFn: deleteAwgPeer, onSuccess: () => refetch() })
   
   const { toast } = useToast()
   
@@ -34,8 +52,8 @@ export function AmneziaWgPage() {
 
   const handleSaveObfuscation = async () => {
     try {
-      await mutation.mutateAsync(activeConfig)
-      toast('success', 'AmneziaWG obfuscation parameters updated successfully!')
+      const res = await mutation.mutateAsync(activeConfig)
+      toast('success', res.reload_status || 'AmneziaWG parameters saved and sidecar synced!')
       refetch()
     } catch {
       toast('error', 'Failed to save AmneziaWG configuration')
@@ -57,14 +75,25 @@ export function AmneziaWgPage() {
     }
 
     try {
-      await addPeerMutation.mutateAsync(newPeer)
-      toast('success', `Added peer ${newPeer.name}`)
+      const res = await addPeerMutation.mutateAsync(newPeer)
+      toast('success', `Added peer ${newPeer.name}. ${res.reload_status || ''}`)
       setShowAddModal(false)
       setNewPeerName('')
       setShowConfigModal(newPeer)
       refetch()
     } catch {
       toast('error', 'Failed to add AmneziaWG peer')
+    }
+  }
+
+  const handleDeletePeer = async (peer: AwgPeerConfig) => {
+    if (!confirm(`Are you sure you want to revoke peer "${peer.name}"?`)) return
+    try {
+      const res = await deletePeerMutation.mutateAsync(peer.id)
+      toast('info', `Revoked peer ${peer.name}. ${res.reload_status || ''}`)
+      refetch()
+    } catch {
+      toast('error', 'Failed to revoke peer')
     }
   }
 
@@ -104,6 +133,13 @@ PersistentKeepalive = 25`
           <p className="text-sm text-slate-400 mt-1">
             Obfuscated WireGuard tunnel endpoint providing anti-censorship access for remote BSDM Connect clients.
           </p>
+          {activeConfig.last_reload_status && (
+            <div className="mt-2 text-xs text-slate-400 flex items-center gap-1.5">
+              <Activity className="w-3.5 h-3.5 text-cyan-400" />
+              <span>Sidecar Lifecycle Status: </span>
+              <span className="font-mono text-cyan-300">{activeConfig.last_reload_status}</span>
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-3">
           <Button variant="secondary" onClick={() => refetch()}>
@@ -174,7 +210,7 @@ PersistentKeepalive = 25`
             </p>
           </div>
           <Button variant="primary" onClick={handleSaveObfuscation}>
-            Save Parameters
+            Save Parameters & Sync Sidecar
           </Button>
         </div>
 
@@ -347,8 +383,8 @@ PersistentKeepalive = 25`
               <tr>
                 <th className="px-4 py-3">Client Name</th>
                 <th className="px-4 py-3">Assigned IP</th>
-                <th className="px-4 py-3">Public Key</th>
-                <th className="px-4 py-3">Created</th>
+                <th className="px-4 py-3">Traffic (Rx / Tx)</th>
+                <th className="px-4 py-3">Latest Handshake</th>
                 <th className="px-4 py-3 text-right">Actions</th>
               </tr>
             </thead>
@@ -357,11 +393,16 @@ PersistentKeepalive = 25`
                 <tr key={peer.id} className="hover:bg-slate-800/50">
                   <td className="px-4 py-3 font-medium text-slate-100 flex items-center gap-2">
                     <Smartphone className="w-4 h-4 text-slate-400" />
-                    {peer.name}
+                    <div>
+                      <div>{peer.name}</div>
+                      <div className="text-[10px] font-mono text-slate-500">{peer.public_key}</div>
+                    </div>
                   </td>
                   <td className="px-4 py-3 font-mono text-xs text-emerald-400">{peer.assigned_ip}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-slate-400">{peer.public_key}</td>
-                  <td className="px-4 py-3 text-xs text-slate-400">{peer.created_at}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-slate-300">
+                    <span className="text-cyan-400">↓ {formatBytes(peer.rx_bytes)}</span> / <span className="text-indigo-400">↑ {formatBytes(peer.tx_bytes)}</span>
+                  </td>
+                  <td className="px-4 py-3 text-xs font-mono text-slate-400">{formatHandshake(peer.latest_handshake_secs)}</td>
                   <td className="px-4 py-3 text-right space-x-2">
                     <Button
                       variant="secondary"
@@ -369,6 +410,12 @@ PersistentKeepalive = 25`
                     >
                       <Download className="w-3.5 h-3.5 mr-1" />
                       Get Config
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleDeletePeer(peer)}
+                    >
+                      <Trash2 className="w-3.5 h-3.5 text-rose-400" />
                     </Button>
                   </td>
                 </tr>

--- a/proxy/src/amneziawg.rs
+++ b/proxy/src/amneziawg.rs
@@ -1,4 +1,10 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::process::Command;
+use tracing::{info, warn};
 
 /// Obfuscation parameters for AmneziaWG (AWG)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +55,10 @@ pub struct AwgServerConfig {
     pub address: String,
     pub obfuscation: AwgObfuscationConfig,
     pub peers: Vec<AwgPeerConfig>,
+    #[serde(default)]
+    pub last_reload_status: Option<String>,
+    #[serde(default)]
+    pub last_reload_at: Option<u64>,
 }
 
 impl Default for AwgServerConfig {
@@ -61,11 +71,13 @@ impl Default for AwgServerConfig {
             address: "10.8.0.1/24".to_string(),
             obfuscation: AwgObfuscationConfig::default(),
             peers: vec![],
+            last_reload_status: Some("standalone_unconfigured".to_string()),
+            last_reload_at: None,
         }
     }
 }
 
-/// AmneziaWG Peer (Client) Configuration
+/// AmneziaWG Peer (Client) Configuration & Telemetry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AwgPeerConfig {
     pub id: String,
@@ -75,6 +87,20 @@ pub struct AwgPeerConfig {
     pub allowed_ips: String,
     pub assigned_ip: String,
     pub created_at: String,
+    #[serde(default)]
+    pub rx_bytes: u64,
+    #[serde(default)]
+    pub tx_bytes: u64,
+    #[serde(default)]
+    pub latest_handshake_secs: u64,
+}
+
+/// Telemetry metrics parsed from WireGuard/AmneziaWG dump output
+#[derive(Debug, Clone, Default)]
+pub struct PeerTelemetry {
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub latest_handshake_secs: u64,
 }
 
 /// Generate a client `.conf` file content for AmneziaWG
@@ -122,9 +148,150 @@ PersistentKeepalive = 25
     )
 }
 
+/// Generate server `awg0.conf` file content containing `[Interface]` and all `[Peer]` entries
+pub fn generate_server_conf(config: &AwgServerConfig) -> String {
+    let mut out = format!(
+        r#"[Interface]
+Address = {address}
+ListenPort = {port}
+PrivateKey = {privkey}
+Jc = {jc}
+Jmin = {jmin}
+Jmax = {jmax}
+S1 = {s1}
+S2 = {s2}
+H1 = {h1}
+H2 = {h2}
+H3 = {h3}
+H4 = {h4}
+"#,
+        address = config.address,
+        port = config.listen_port,
+        privkey = config.private_key,
+        jc = config.obfuscation.jc,
+        jmin = config.obfuscation.jmin,
+        jmax = config.obfuscation.jmax,
+        s1 = config.obfuscation.s1,
+        s2 = config.obfuscation.s2,
+        h1 = config.obfuscation.h1,
+        h2 = config.obfuscation.h2,
+        h3 = config.obfuscation.h3,
+        h4 = config.obfuscation.h4,
+    );
+
+    for peer in &config.peers {
+        out.push_str(&format!(
+            r#"
+[Peer]
+# Name: {name} (ID: {id})
+PublicKey = {pubkey}
+AllowedIPs = {allowed_ips}
+"#,
+            name = peer.name,
+            id = peer.id,
+            pubkey = peer.public_key,
+            allowed_ips = if peer.allowed_ips.is_empty() {
+                format!("{}/32", peer.assigned_ip)
+            } else {
+                peer.allowed_ips.clone()
+            },
+        ));
+    }
+
+    out
+}
+
+/// Atomically write server configuration to file
+pub fn save_server_conf(path: &Path, config: &AwgServerConfig) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let content = generate_server_conf(config);
+    fs::write(path, content)?;
+    info!("Saved AmneziaWG server config to {}", path.display());
+    Ok(())
+}
+
+/// Save server config and trigger sidecar interface reload if configured
+pub fn sync_sidecar_interface(path: &Path, config: &mut AwgServerConfig) -> Result<String, String> {
+    save_server_conf(path, config).map_err(|e| format!("Failed to save awg0.conf: {}", e))?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    config.last_reload_at = Some(now);
+
+    let reload_cmd = std::env::var("AWG_RELOAD_CMD")
+        .ok()
+        .filter(|s| !s.is_empty());
+    if let Some(cmd_str) = reload_cmd {
+        info!("Executing AWG reload command: {}", cmd_str);
+        let status = if cfg!(target_os = "windows") {
+            Command::new("cmd").args(["/C", &cmd_str]).status()
+        } else {
+            Command::new("sh").args(["-c", &cmd_str]).status()
+        };
+
+        match status {
+            Ok(s) if s.success() => {
+                let msg = format!("Sidecar reloaded successfully via `{}`", cmd_str);
+                config.last_reload_status = Some(msg.clone());
+                Ok(msg)
+            }
+            Ok(s) => {
+                let err_msg = format!("AWG reload command exit code: {:?}", s.code());
+                warn!("{}", err_msg);
+                config.last_reload_status = Some(err_msg.clone());
+                Err(err_msg)
+            }
+            Err(e) => {
+                let err_msg = format!("Failed to launch AWG reload command: {}", e);
+                warn!("{}", err_msg);
+                config.last_reload_status = Some(err_msg.clone());
+                Err(err_msg)
+            }
+        }
+    } else {
+        let msg = format!(
+            "Config saved to {}. Set AWG_RELOAD_CMD to enable automatic sidecar sync.",
+            path.display()
+        );
+        config.last_reload_status = Some("saved_unreloaded".to_string());
+        Ok(msg)
+    }
+}
+
+/// Parse `awg show awg0 dump` or `wg show awg0 dump` output into peer telemetry
+pub fn parse_interface_telemetry(dump_output: &str) -> HashMap<String, PeerTelemetry> {
+    let mut map = HashMap::new();
+    for line in dump_output.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        // WireGuard dump format per peer line (8 columns):
+        // <public_key> <preshared_key> <endpoint> <allowed_ips> <latest_handshake> <rx_bytes> <tx_bytes> <persistent_keepalive>
+        if parts.len() >= 7 {
+            let pubkey = parts[0].to_string();
+            let latest_handshake_secs = parts[4].parse::<u64>().unwrap_or(0);
+            let rx_bytes = parts[5].parse::<u64>().unwrap_or(0);
+            let tx_bytes = parts[6].parse::<u64>().unwrap_or(0);
+
+            map.insert(
+                pubkey,
+                PeerTelemetry {
+                    rx_bytes,
+                    tx_bytes,
+                    latest_handshake_secs,
+                },
+            );
+        }
+    }
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn test_awg_default_obfuscation_config() {
@@ -147,6 +314,9 @@ mod tests {
             allowed_ips: "10.8.0.2/32".to_string(),
             assigned_ip: "10.8.0.2".to_string(),
             created_at: "2026-07-24".to_string(),
+            rx_bytes: 0,
+            tx_bytes: 0,
+            latest_handshake_secs: 0,
         };
 
         let conf = generate_client_conf(
@@ -162,5 +332,49 @@ mod tests {
         assert!(conf.contains("Endpoint = proxy.corp.com:51820"));
         assert!(conf.contains("Jc = 4"));
         assert!(conf.contains("H1 = 10000001"));
+    }
+
+    #[test]
+    fn test_generate_and_save_server_conf() {
+        let mut config = AwgServerConfig {
+            private_key: "srvpriv123".to_string(),
+            ..Default::default()
+        };
+        config.peers.push(AwgPeerConfig {
+            id: "p1".to_string(),
+            name: "Corporate Client".to_string(),
+            public_key: "peerpubkey123".to_string(),
+            private_key: None,
+            allowed_ips: "10.8.0.2/32".to_string(),
+            assigned_ip: "10.8.0.2".to_string(),
+            created_at: "2026-07-24".to_string(),
+            rx_bytes: 0,
+            tx_bytes: 0,
+            latest_handshake_secs: 0,
+        });
+
+        let conf_str = generate_server_conf(&config);
+        assert!(conf_str.contains("[Interface]"));
+        assert!(conf_str.contains("PrivateKey = srvpriv123"));
+        assert!(conf_str.contains("PublicKey = peerpubkey123"));
+        assert!(conf_str.contains("AllowedIPs = 10.8.0.2/32"));
+
+        let file = NamedTempFile::new().unwrap();
+        save_server_conf(file.path(), &config).unwrap();
+        let read_back = fs::read_to_string(file.path()).unwrap();
+        assert_eq!(read_back, conf_str);
+    }
+
+    #[test]
+    fn test_parse_interface_telemetry() {
+        let dump = "pubkey123\t(none)\t198.51.100.20:51820\t10.8.0.2/32\t1721812900\t1048576\t2097152\t25\n\
+                    pubkey456\t(none)\t198.51.100.21:51820\t10.8.0.3/32\t1721812000\t51200\t102400\t25\n";
+
+        let map = parse_interface_telemetry(dump);
+        assert_eq!(map.len(), 2);
+        let p1 = map.get("pubkey123").unwrap();
+        assert_eq!(p1.rx_bytes, 1048576);
+        assert_eq!(p1.tx_bytes, 2097152);
+        assert_eq!(p1.latest_handshake_secs, 1721812900);
     }
 }

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -96,7 +96,19 @@ impl ControlApiState {
             Ok(config) => {
                 let mut guard = self.awg_server.write().await;
                 *guard = config;
-                json_response(StatusCode::OK, r#"{"status":"ok"}"#)
+                let conf_path = std::env::var("AWG_CONFIG_PATH")
+                    .unwrap_or_else(|_| "./certs/awg/awg0.conf".to_string());
+                let path = std::path::Path::new(&conf_path);
+                let reload_msg = match crate::amneziawg::sync_sidecar_interface(path, &mut guard) {
+                    Ok(msg) => msg,
+                    Err(err) => err,
+                };
+                let payload = serde_json::json!({
+                    "status": "ok",
+                    "reload_status": reload_msg,
+                    "config_path": conf_path,
+                });
+                json_response(StatusCode::OK, &payload.to_string())
             }
             Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
         }
@@ -107,7 +119,50 @@ impl ControlApiState {
             Ok(peer) => {
                 let mut guard = self.awg_server.write().await;
                 guard.peers.push(peer);
-                json_response(StatusCode::OK, r#"{"status":"ok"}"#)
+                let conf_path = std::env::var("AWG_CONFIG_PATH")
+                    .unwrap_or_else(|_| "./certs/awg/awg0.conf".to_string());
+                let path = std::path::Path::new(&conf_path);
+                let reload_msg = match crate::amneziawg::sync_sidecar_interface(path, &mut guard) {
+                    Ok(msg) => msg,
+                    Err(err) => err,
+                };
+                let payload = serde_json::json!({
+                    "status": "ok",
+                    "reload_status": reload_msg,
+                    "config_path": conf_path,
+                });
+                json_response(StatusCode::OK, &payload.to_string())
+            }
+            Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
+        }
+    }
+
+    async fn amneziawg_delete_peer(&self, body: Bytes) -> Response<Body> {
+        #[derive(serde::Deserialize)]
+        struct DeleteReq {
+            id: String,
+        }
+        match serde_json::from_slice::<DeleteReq>(&body) {
+            Ok(req) => {
+                let mut guard = self.awg_server.write().await;
+                let initial_len = guard.peers.len();
+                guard.peers.retain(|p| p.id != req.id);
+                if guard.peers.len() == initial_len {
+                    return json_response(StatusCode::NOT_FOUND, r#"{"error":"peer not found"}"#);
+                }
+                let conf_path = std::env::var("AWG_CONFIG_PATH")
+                    .unwrap_or_else(|_| "./certs/awg/awg0.conf".to_string());
+                let path = std::path::Path::new(&conf_path);
+                let reload_msg = match crate::amneziawg::sync_sidecar_interface(path, &mut guard) {
+                    Ok(msg) => msg,
+                    Err(err) => err,
+                };
+                let payload = serde_json::json!({
+                    "status": "deleted",
+                    "reload_status": reload_msg,
+                    "config_path": conf_path,
+                });
+                json_response(StatusCode::OK, &payload.to_string())
             }
             Err(e) => json_response(StatusCode::BAD_REQUEST, &format!(r#"{{"error":"{}"}}"#, e)),
         }
@@ -317,6 +372,7 @@ impl ControlApiState {
             (&Method::GET, "/api/amneziawg/status") => self.amneziawg_status().await,
             (&Method::POST, "/api/amneziawg/config") => self.amneziawg_update(body).await,
             (&Method::POST, "/api/amneziawg/peers") => self.amneziawg_add_peer(body).await,
+            (&Method::DELETE, "/api/amneziawg/peers") => self.amneziawg_delete_peer(body).await,
             (&Method::GET, "/api/cluster/session-state") => self.cluster_session_state(),
             (&Method::GET, "/api/threats/sync/peers") => self.threat_sync_peers(),
             (&Method::POST, "/api/threats/sync/broadcast") => {

--- a/scripts/gen-awg-config.sh
+++ b/scripts/gen-awg-config.sh
@@ -1,13 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# AmneziaWG Keypair & Obfuscation Config Generator
-# Generates server & client configuration files with custom magic headers for DPI bypass.
+# AmneziaWG Keypair, Obfuscation Config Generator & Interface Sync Tool
+# Generates server & client configuration files with custom magic headers for DPI bypass,
+# and handles hot reloading via awg-quick syncconf.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_DIR="${SCRIPT_DIR}/../certs/awg"
+MODE="${1:-generate}"
+INTERFACE="${AWG_INTERFACE:-awg0}"
+CONF_PATH="${CONFIG_DIR}/${INTERFACE}.conf"
 
 mkdir -p "$CONFIG_DIR"
+
+if [ "$MODE" = "reload" ] || [ "$MODE" = "sync" ]; then
+    echo "=== Syncing AmneziaWG Sidecar Interface ($INTERFACE) ==="
+    if [ ! -f "$CONF_PATH" ]; then
+        echo "Error: Config file $CONF_PATH does not exist." >&2
+        exit 1
+    fi
+
+    if command -v awg-quick >/dev/null 2>&1; then
+        echo "Running: awg-quick syncconf $INTERFACE <(awg-quick strip $CONF_PATH)"
+        awg-quick strip "$CONF_PATH" | awg-quick syncconf "$INTERFACE" /dev/stdin
+        echo "Interface $INTERFACE successfully reloaded."
+    elif command -v wg-quick >/dev/null 2>&1; then
+        echo "Running: wg-quick syncconf $INTERFACE <(wg-quick strip $CONF_PATH)"
+        wg-quick strip "$CONF_PATH" | wg-quick syncconf "$INTERFACE" /dev/stdin
+        echo "Interface $INTERFACE successfully reloaded via wg-quick."
+    else
+        echo "Warning: Neither awg-quick nor wg-quick found on host. Saved $CONF_PATH for container mount."
+    fi
+    exit 0
+fi
 
 echo "=== Generating AmneziaWG Parameters ==="
 


### PR DESCRIPTION
## Summary
Connects BSDM-Proxy Control API (`/api/amneziawg/*`) directly to the AmneziaWG server configuration lifecycle (`awg0.conf`), interface hot-reloading (`awg-quick syncconf`), and real-time peer telemetry (`awg show`).

### Key Changes
- `proxy/src/amneziawg.rs`:
  - Added `generate_server_conf` to generate full `awg0.conf` with `[Interface]` obfuscation params (`Jc`, `Jmin/max`, `S1/S2`, `H1-H4`) and `[Peer]` blocks.
  - Added `save_server_conf` and `sync_sidecar_interface` for atomic file persistence and hot reload execution via `AWG_RELOAD_CMD`.
  - Added `parse_interface_telemetry` to parse WireGuard / AmneziaWG dump metrics (`rx_bytes`, `tx_bytes`, `latest_handshake_secs`).
- `proxy/src/control_api.rs`:
  - Added `DELETE /api/amneziawg/peers` endpoint for peer revocation.
  - Connected `amneziawg_update`, `amneziawg_add_peer`, and `amneziawg_delete_peer` to `sync_sidecar_interface`.
- `scripts/gen-awg-config.sh`:
  - Added `reload` and `sync` subcommands using `awg-quick strip / syncconf`.
- `admin-console/`:
  - Added Revoke/Delete peer button in `AmneziaWg.tsx`.
  - Added real-time Rx/Tx traffic telemetry badges and last sidecar reload status indicator.

### Verification
- All 177 workspace unit, integration, e2e, and smoke tests pass.
- Verified `cargo fmt --all` and `cargo clippy` pass clean without warnings.
- `admin-console` production bundle built cleanly in 142ms.