### PR TITLE
ci: add actions:write permission for Docker Buildx GHA cache

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Fixes Docker Buildx cache export error (`ERROR: failed to solve: not_found`) by granting `actions: write` permission in `docker-publish.yml`.