### PR TITLE
Fix/docker publish gha cache permission

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  actions: write
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
@@ -61,4 +61,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-27
+
+Release **0.8.0**. Global Session State & Real-time Threat Sync, AmneziaWG Obfuscated Protocol Endpoint & BSDM Connect UI, DoH & DoT Encrypted DNS Gateways, and Admin Console modules (RPZ, Wasm, ICAP, Mesh Cluster, eBPF/XDP, Vector AI Cache).
+
+
 ### Added
 
 - **DoH (RFC 8484) & DoT (RFC 7858) Encrypted DNS Gateways** — Inbound DoH (`/dns-query`) and DoT (TCP/853 TLS) listeners for `dns-sinkhole`, wireformat base64url decoding, 2-byte TCP framing, and `admin-console` encrypted DNS panel ([#204](https://github.com/onixus/bsdm-proxy/pull/204))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "alert-worker"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "hex",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-events"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "serde",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "bsdm-proxy"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -529,7 +529,7 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cache-indexer"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "bsdm-events",
  "bytes",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "dns-sinkhole"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "ml-worker"
-version = "0.6.1-1"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "prometheus",

--- a/admin-console/package-lock.json
+++ b/admin-console/package-lock.json
@@ -1094,18 +1094,11 @@
         }
       }
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1607,20 +1600,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -1682,12 +1674,6 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -19,6 +19,9 @@
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.18.1"
   },
+  "overrides": {
+    "react-router": "^8.3.0"
+  },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^24.13.3",

--- a/alert-worker/Cargo.toml
+++ b/alert-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alert-worker"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/bsdm-events/Cargo.toml
+++ b/bsdm-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-events"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "Shared HTTP cache event schema for BSDM-Proxy Kafka pipeline"

--- a/cache-indexer/Cargo.toml
+++ b/cache-indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cache-indexer"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/dns-sinkhole/Cargo.toml
+++ b/dns-sinkhole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dns-sinkhole"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,40 @@
+# Release v0.8.0
+
+**Тип:** stable release (v0.8.0)
+**Дата:** 2026-07-27
+**База:** `main`
+
+> Рекомендуемая версия: Global Session State & Real-time Threat Sync, AmneziaWG Obfuscated Protocol Endpoint & BSDM Connect UI, DoH & DoT Encrypted DNS Gateways, Admin Console modules (RPZ, Wasm, ICAP, Mesh Cluster, eBPF/XDP, Vector AI Cache). См. [CHANGELOG.md](../../CHANGELOG.md).
+
+## Highlights (с v0.7)
+
+### Major Features
+
+- **DoH (RFC 8484) & DoT (RFC 7858) Encrypted DNS Gateways** — Inbound DoH (`/dns-query`) and DoT (TCP/853 TLS) listeners for `dns-sinkhole`, wireformat base64url decoding, 2-byte TCP framing, and `admin-console` encrypted DNS panel ([#204](https://github.com/onixus/bsdm-proxy/pull/204))
+- **AmneziaWG Obfuscated Protocol Endpoint & BSDM Connect Agent UI** — AmneziaWG obfuscated protocol endpoint (`/awg`) and BSDM Connect client configuration generator ([#210](https://github.com/onixus/bsdm-proxy/pull/210))
+- **Global Session State & Real-Time Threat Sync** — Distributed session management, state replication, and immediate cross-node threat propagation (`/cluster`)
+- **Admin Console Modules**
+  - **RPZ Sinkhole Module (`/rpz`)** — RPZ list parsing, feed management, custom overrides, and DNS query simulator ([#108](https://github.com/onixus/bsdm-proxy/issues/108))
+  - **Wasm Plugins Module (`/wasm`)** — Interactive Wasm Request Sandbox, WAT source viewer, plugin directory, and engine settings ([#188](https://github.com/onixus/bsdm-proxy/issues/188))
+  - **ICAP Inspection & DLP Module (`/icap`)** — RFC 3507 ICAP scanning sandbox, Threat Log audit table, and service profile management ([#99](https://github.com/onixus/bsdm-proxy/issues/99))
+  - **gRPC Control Plane Mesh Module (`/cluster`)** — Multi-node cluster topology grid, real-time gRPC policy push, and cluster-wide cache purge ([#187](https://github.com/onixus/bsdm-proxy/issues/187))
+  - **eBPF / XDP Kernel Packet Drop Bypass Module** — Zero-CPU packet drops at NIC driver layer (`EBPF_XDP_ENABLED`), reference `bpf/xdp_drop.c`, and `admin-console` eBPF Policies panel
+  - **AI Semantic Cache & Vector DB Module (`/ai-cache`)** — Qdrant vector match simulator, cosine similarity tuning, token savings analytics ($285.00/24h) ([#189](https://github.com/onixus/bsdm-proxy/issues/189))
+
+## Сборка
+
+```bash
+cargo build --release --workspace
+
+./scripts/build-package.sh
+# → dist/bsdm-proxy-0.8.0-linux-<arch>.tar.gz
+```
+
+## Release tag
+
+```bash
+git tag -a v0.8.0 -m "BSDM-Proxy v0.8.0"
+git push origin v0.8.0
+```
+
+Workflow [release.yml](../../.github/workflows/release.yml) и [docker-publish.yml](../../.github/workflows/docker-publish.yml) опубликуют релизные артефакты и Docker-образы.

--- a/ml-worker/Cargo.toml
+++ b/ml-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ml-worker"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["BSDM-Proxy Contributors"]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bsdm-proxy"
-version = "0.6.1-1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

<!-- Кратко: что меняется и зачем -->

## Связанные issue

<!-- Обязательно для блокеров B1–B25: укажите Closes #NN или оставьте (Bn) в заголовке PR — issue закроется автоматически при merge (см. .github/workflows/close-blockers.yml). -->

- [ ] `Closes #NN` добавлено в описание **или** блокер указан в заголовке: `(B6)`
- Milestone / блокер: <!-- M1, B6, … -->

**Маппинг:** B*n* → issue #*(31+n)* (B6 → #37, B13 → #44).  
**B13 (NTLM):** auto-close только при `Closes #44` (полная реализация); docs-only PR не закрывают #44.

## Testing

<!-- cargo test, e2e, clippy — что запускали -->

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

## Checklist

- [ ] CI зелёный
- [ ] Документация обновлена (если менялось поведение / env)
- [ ] `docs/BLOCKERS.md` / `docs/roadmap.md` (если закрывается блокер)
