### PR TITLE
Fix ClickHouse 24.12 compatibility

### DIFF
--- a/cache-indexer/src/clickhouse.rs
+++ b/cache-indexer/src/clickhouse.rs
@@ -71,7 +71,12 @@ impl ClickHouseWriter {
         params: &[(&str, String)],
     ) -> Result<String, Box<dyn std::error::Error>> {
         let base = self.config.url.trim_end_matches('/');
-        let mut req = self.client.post(base).query(&[("query", sql)]).body("");
+        let mut req = self
+            .client
+            .post(base)
+            .query(&[("query", sql)])
+            .header(reqwest::header::CONTENT_LENGTH, 0)
+            .body("");
         for (name, value) in params {
             req = req.query(&[(format!("param_{name}"), value.as_str())]);
         }

--- a/scripts/clickhouse/http_cache.sql
+++ b/scripts/clickhouse/http_cache.sql
@@ -30,8 +30,8 @@ CREATE TABLE IF NOT EXISTS bsdm.http_cache
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(ts)
-ORDER BY (domain, username, ts, event_id)
-TTL ts + INTERVAL 42 DAY
+ORDER BY (domain, ifNull(username, ''), ts, event_id)
+TTL toDateTime(ts) + INTERVAL 42 DAY
 SETTINGS index_granularity = 8192;
 
 -- M3: who accessed domain X (30 days)

--- a/scripts/clickhouse/ml_features.sql
+++ b/scripts/clickhouse/ml_features.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS bsdm.entity_features
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(window_start)
 ORDER BY (entity_type, entity_id, window_start)
-TTL window_start + INTERVAL 90 DAY
+TTL toDateTime(window_start) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192;
 
 -- Model / stub scores keyed to an entity window.
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS bsdm.ml_scores
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(scored_at)
 ORDER BY (entity_type, entity_id, scored_at)
-TTL scored_at + INTERVAL 90 DAY
+TTL toDateTime(scored_at) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192;
 
 -- M5.3 per-domain lexical phishing features (ml-worker phishing_lexical_v0).
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS bsdm.domain_phishing_features
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(window_start)
 ORDER BY (domain, window_start)
-TTL window_start + INTERVAL 90 DAY
+TTL toDateTime(window_start) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192;
 
 -- M5.4 client→domain C&C beacon features (ml-worker cc_beacon_v0).
@@ -98,7 +98,7 @@ CREATE TABLE IF NOT EXISTS bsdm.beacon_pair_features
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(window_start)
 ORDER BY (client_ip, domain, window_start)
-TTL window_start + INTERVAL 90 DAY
+TTL toDateTime(window_start) + INTERVAL 90 DAY
 SETTINGS index_granularity = 8192;
 
 -- M5.5 threat score write-back cache (ml-worker → proxy poll).
@@ -115,7 +115,7 @@ CREATE TABLE IF NOT EXISTS bsdm.threat_score_cache
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(scored_at)
 ORDER BY (entity_type, entity_id, scored_at)
-TTL expires_at
+TTL toDateTime(expires_at)
 SETTINGS index_granularity = 8192;
 
 -- Example: top phishing-scored domains (last 24h)

--- a/scripts/clickhouse/pilot_retention.sql
+++ b/scripts/clickhouse/pilot_retention.sql
@@ -2,16 +2,16 @@
 -- Mounted after the base DDL by docker-compose.pilot.yml on a fresh volume.
 
 ALTER TABLE bsdm.http_cache
-MODIFY TTL ts + INTERVAL 5 DAY;
+MODIFY TTL toDateTime(ts) + INTERVAL 5 DAY;
 
 ALTER TABLE bsdm.entity_features
-MODIFY TTL window_start + INTERVAL 5 DAY;
+MODIFY TTL toDateTime(window_start) + INTERVAL 5 DAY;
 
 ALTER TABLE bsdm.ml_scores
-MODIFY TTL scored_at + INTERVAL 5 DAY;
+MODIFY TTL toDateTime(scored_at) + INTERVAL 5 DAY;
 
 ALTER TABLE bsdm.domain_phishing_features
-MODIFY TTL window_start + INTERVAL 5 DAY;
+MODIFY TTL toDateTime(window_start) + INTERVAL 5 DAY;
 
 ALTER TABLE bsdm.beacon_pair_features
-MODIFY TTL window_start + INTERVAL 5 DAY;
+MODIFY TTL toDateTime(window_start) + INTERVAL 5 DAY;


### PR DESCRIPTION
## What changed

- sends an explicit zero `Content-Length` for ClickHouse POST queries with an empty body
- makes the nullable username sorting key explicit with `ifNull`
- casts `DateTime64` values to `DateTime` in base and pilot TTL expressions

## Why

The pilot stack exposed ClickHouse 24.12 compatibility failures during schema initialization and empty-body query execution. Nullable sorting keys and TTL expressions need explicit normalization for this deployment.

## Impact

Fresh ClickHouse initialization and pilot retention setup complete successfully, and cache-indexer queries no longer depend on implicit empty-body framing.

## Validation

- `cargo test -p cache-indexer` — 17 tests passed
- `git diff --cached --check`
- previously verified by starting the full pilot ClickHouse/indexer stack and ingesting proxy events
