### PR TITLE
Fix Admin Console control API access

### DIFF
--- a/admin-console/src/api/amneziawg.ts
+++ b/admin-console/src/api/amneziawg.ts
@@ -1,4 +1,5 @@
 import { demo, isDemoMode, live, type Sourced } from './source'
+import { apiFetch, controlClient } from './client'
 
 export interface AwgObfuscationConfig {
   jc: number
@@ -85,10 +86,8 @@ const mockStatus: AwgServerConfig = {
 export async function fetchAwgStatus(): Promise<Sourced<AwgServerConfig>> {
   if (isDemoMode()) return demo(mockStatus)
   try {
-    const res = await fetch('/api/amneziawg/status')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const json = await res.json()
-    return live(json)
+    const { baseUrl, token } = controlClient()
+    return live(await apiFetch<AwgServerConfig>('/api/amneziawg/status', { baseUrl, token }))
   } catch {
     return demo(mockStatus)
   }
@@ -96,33 +95,33 @@ export async function fetchAwgStatus(): Promise<Sourced<AwgServerConfig>> {
 
 export async function updateAwgConfig(config: AwgServerConfig): Promise<{ status: string; reload_status?: string }> {
   if (isDemoMode()) return { status: 'ok', reload_status: 'Sidecar synced' }
-  const res = await fetch('/api/amneziawg/config', {
+  const { baseUrl, token } = controlClient()
+  return apiFetch('/api/amneziawg/config', {
+    baseUrl,
+    token,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(config),
+    body: config,
   })
-  if (!res.ok) throw new Error('HTTP ' + res.status)
-  return res.json()
 }
 
 export async function addAwgPeer(peer: AwgPeerConfig): Promise<{ status: string; reload_status?: string }> {
   if (isDemoMode()) return { status: 'ok', reload_status: 'Sidecar synced' }
-  const res = await fetch('/api/amneziawg/peers', {
+  const { baseUrl, token } = controlClient()
+  return apiFetch('/api/amneziawg/peers', {
+    baseUrl,
+    token,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(peer),
+    body: peer,
   })
-  if (!res.ok) throw new Error('HTTP ' + res.status)
-  return res.json()
 }
 
 export async function deleteAwgPeer(id: string): Promise<{ status: string; reload_status?: string }> {
   if (isDemoMode()) return { status: 'deleted', reload_status: 'Sidecar synced' }
-  const res = await fetch('/api/amneziawg/peers', {
+  const { baseUrl, token } = controlClient()
+  return apiFetch('/api/amneziawg/peers', {
+    baseUrl,
+    token,
     method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ id }),
+    body: { id },
   })
-  if (!res.ok) throw new Error('HTTP ' + res.status)
-  return res.json()
 }

--- a/admin-console/src/api/auth.ts
+++ b/admin-console/src/api/auth.ts
@@ -1,5 +1,4 @@
-import { apiFetch } from './client';
-import { loadApiSettings } from './settings';
+import { apiFetch, controlClient } from './client';
 
 export interface BasicUser {
     username: string;
@@ -7,24 +6,26 @@ export interface BasicUser {
 }
 
 export async function getBasicUsers(): Promise<BasicUser[]> {
-    const s = loadApiSettings();
-    return apiFetch<BasicUser[]>('/api/auth/basic/users', { baseUrl: s.metricsBaseUrl });
+    const { baseUrl, token } = controlClient();
+    return apiFetch<BasicUser[]>('/api/auth/basic/users', { baseUrl, token });
 }
 
 export async function putBasicUser(username: string, role: string, password?: string): Promise<void> {
-    const s = loadApiSettings();
+    const { baseUrl, token } = controlClient();
     return apiFetch<void>('/api/auth/basic/users', {
         method: 'POST',
-        baseUrl: s.metricsBaseUrl,
+        baseUrl,
+        token,
         body: { username, role, password }
     });
 }
 
 export async function deleteBasicUser(username: string): Promise<void> {
-    const s = loadApiSettings();
+    const { baseUrl, token } = controlClient();
     return apiFetch<void>('/api/auth/basic/users', {
         method: 'DELETE',
-        baseUrl: s.metricsBaseUrl,
+        baseUrl,
+        token,
         body: { username }
     });
 }

--- a/admin-console/src/api/client.ts
+++ b/admin-console/src/api/client.ts
@@ -67,3 +67,11 @@ export function aclClient() {
     token: s.aclToken,
   }
 }
+
+export function controlClient() {
+  const s = loadApiSettings()
+  return {
+    baseUrl: s.metricsBaseUrl,
+    token: s.controlToken,
+  }
+}

--- a/admin-console/src/api/cluster.ts
+++ b/admin-console/src/api/cluster.ts
@@ -1,4 +1,4 @@
-import { apiFetch, aclClient } from './client'
+import { apiFetch, aclClient, controlClient } from './client'
 
 export type ClusterNodeRole = 'primary' | 'worker' | 'edge'
 export type ClusterNodeStatus = 'healthy' | 'degraded' | 'offline'
@@ -390,10 +390,8 @@ const mockThreatSyncReport: ThreatSyncPeersReport = {
 export async function fetchClusterSessionState(): Promise<Sourced<ClusterSessionState>> {
   if (isDemoMode()) return demo(mockClusterSessionState)
   try {
-    const res = await fetch('/api/cluster/session-state')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const json = await res.json()
-    return live(json)
+    const { baseUrl, token } = controlClient()
+    return live(await apiFetch<ClusterSessionState>('/api/cluster/session-state', { baseUrl, token }))
   } catch {
     return demo(mockClusterSessionState)
   }
@@ -402,10 +400,8 @@ export async function fetchClusterSessionState(): Promise<Sourced<ClusterSession
 export async function fetchThreatSyncPeers(): Promise<Sourced<ThreatSyncPeersReport>> {
   if (isDemoMode()) return demo(mockThreatSyncReport)
   try {
-    const res = await fetch('/api/threats/sync/peers')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    const json = await res.json()
-    return live(json)
+    const { baseUrl, token } = controlClient()
+    return live(await apiFetch<ThreatSyncPeersReport>('/api/threats/sync/peers', { baseUrl, token }))
   } catch {
     return demo(mockThreatSyncReport)
   }
@@ -415,11 +411,11 @@ export async function broadcastThreatSync(
   event: Partial<ThreatSyncEvent>
 ): Promise<{ status: string }> {
   if (isDemoMode()) return { status: 'broadcasted' }
-  const res = await fetch('/api/threats/sync/broadcast', {
+  const { baseUrl, token } = controlClient()
+  return apiFetch('/api/threats/sync/broadcast', {
+    baseUrl,
+    token,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(event),
+    body: event,
   })
-  if (!res.ok) throw new Error('HTTP ' + res.status)
-  return res.json()
 }

--- a/admin-console/src/api/security.ts
+++ b/admin-console/src/api/security.ts
@@ -1,4 +1,4 @@
-import { apiFetch, aclClient } from './client'
+import { apiFetch, controlClient } from './client'
 
 export interface DlpPatternDto {
   pattern: string
@@ -6,7 +6,7 @@ export interface DlpPatternDto {
 }
 
 export async function fetchCasbDomains(): Promise<string[]> {
-  const { baseUrl, token } = aclClient()
+  const { baseUrl, token } = controlClient()
   try {
     return await apiFetch<string[]>('/api/security/casb', { baseUrl, token })
   } catch {
@@ -21,7 +21,7 @@ export async function fetchCasbDomains(): Promise<string[]> {
 }
 
 export async function saveCasbDomains(domains: string[]): Promise<void> {
-  const { baseUrl, token } = aclClient()
+  const { baseUrl, token } = controlClient()
   await apiFetch('/api/security/casb', {
     baseUrl,
     token,
@@ -31,7 +31,7 @@ export async function saveCasbDomains(domains: string[]): Promise<void> {
 }
 
 export async function fetchDlpPatterns(): Promise<DlpPatternDto[]> {
-  const { baseUrl, token } = aclClient()
+  const { baseUrl, token } = controlClient()
   try {
     return await apiFetch<DlpPatternDto[]>('/api/security/dlp', { baseUrl, token })
   } catch {
@@ -47,7 +47,7 @@ export async function fetchDlpPatterns(): Promise<DlpPatternDto[]> {
 }
 
 export async function saveDlpPatterns(patterns: DlpPatternDto[]): Promise<void> {
-  const { baseUrl, token } = aclClient()
+  const { baseUrl, token } = controlClient()
   await apiFetch('/api/security/dlp', {
     baseUrl,
     token,

--- a/admin-console/src/api/settings.ts
+++ b/admin-console/src/api/settings.ts
@@ -7,6 +7,7 @@ export interface ApiSettings {
   metricsBaseUrl: string
   searchToken: string
   aclToken: string
+  controlToken: string
 }
 
 const STORAGE_KEY = 'bsdm-admin-api-settings'
@@ -18,19 +19,26 @@ const defaults: ApiSettings = {
   metricsBaseUrl: '',
   searchToken: '',
   aclToken: '',
+  controlToken: '',
+}
+
+let runtimeTokens: Pick<ApiSettings, 'searchToken' | 'aclToken' | 'controlToken'> = {
+  searchToken: '',
+  aclToken: '',
+  controlToken: '',
 }
 
 export function loadApiSettings(): ApiSettings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return { ...defaults }
-    return { ...defaults, ...JSON.parse(raw) }
+    if (!raw) return { ...defaults, ...runtimeTokens }
+    return { ...defaults, ...JSON.parse(raw), ...runtimeTokens }
   } catch {
-    return { ...defaults }
+    return { ...defaults, ...runtimeTokens }
   }
 }
 
-const SENSITIVE_API_KEYS = ['searchToken', 'aclToken'] as const satisfies readonly (keyof ApiSettings)[]
+const SENSITIVE_API_KEYS = ['searchToken', 'aclToken', 'controlToken'] as const satisfies readonly (keyof ApiSettings)[]
 
 function apiSettingsForStorage(settings: ApiSettings): Omit<ApiSettings, (typeof SENSITIVE_API_KEYS)[number]> {
   const stored = { ...settings }
@@ -41,6 +49,11 @@ function apiSettingsForStorage(settings: ApiSettings): Omit<ApiSettings, (typeof
 }
 
 export function saveApiSettings(settings: ApiSettings): void {
+  runtimeTokens = {
+    searchToken: settings.searchToken,
+    aclToken: settings.aclToken,
+    controlToken: settings.controlToken,
+  }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(apiSettingsForStorage(settings)))
 }
 

--- a/admin-console/src/pages/Settings.tsx
+++ b/admin-console/src/pages/Settings.tsx
@@ -641,6 +641,7 @@ function ApiTab({
         <FormGrid>
           <Input label="Search API token" type="password" value={settings.searchToken} onChange={(e) => update('searchToken', e.target.value)} />
           <Input label="ACL API token" type="password" value={settings.aclToken} onChange={(e) => update('aclToken', e.target.value)} />
+          <Input label="Control API token" type="password" value={settings.controlToken} onChange={(e) => update('controlToken', e.target.value)} />
         </FormGrid>
       </FormSection>
       <FormSection title="Demo mode">

--- a/admin-console/vite.config.ts
+++ b/admin-console/vite.config.ts
@@ -2,21 +2,28 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const bearerHeaders = (token: string | undefined) =>
+  token ? { Authorization: `Bearer ${token}` } : undefined
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: '/',
   server: {
     port: 5173,
     proxy: {
-      '/api/search': { target: 'http://127.0.0.1:8080', changeOrigin: true },
-      '/api/events': { target: 'http://127.0.0.1:8080', changeOrigin: true },
-      '/api/acl': { target: 'http://127.0.0.1:9090', changeOrigin: true },
+      '/api/search': { target: 'http://127.0.0.1:8080', changeOrigin: true, headers: bearerHeaders(process.env.SEARCH_API_TOKEN) },
+      '/api/events': { target: 'http://127.0.0.1:8080', changeOrigin: true, headers: bearerHeaders(process.env.SEARCH_API_TOKEN) },
+      '/api/acl': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.ACL_API_TOKEN) },
       '/api/stats': { target: 'http://127.0.0.1:9090', changeOrigin: true },
       '/api/cache': { target: 'http://127.0.0.1:9090', changeOrigin: true },
       '/api/hierarchy': { target: 'http://127.0.0.1:9090', changeOrigin: true },
       '/api/upstream': { target: 'http://127.0.0.1:9090', changeOrigin: true },
-      '/api/security': { target: 'http://127.0.0.1:9090', changeOrigin: true },
-      '/api/auth': { target: 'http://127.0.0.1:9090', changeOrigin: true },
+      '/api/security': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
+      '/api/auth': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
+      '/api/amneziawg': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
+      '/api/cluster': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
+      '/api/threats': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
+      '/api/wasm': { target: 'http://127.0.0.1:9090', changeOrigin: true, headers: bearerHeaders(process.env.CONTROL_API_TOKEN) },
       '/api/threat-scores': { target: 'http://127.0.0.1:8091', changeOrigin: true },
       '/metrics': { target: 'http://127.0.0.1:9090', changeOrigin: true },
     },

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -117,6 +117,10 @@ pub async fn metrics_server(
                                     || path.starts_with("/api/upstream/")
                                     || path.starts_with("/api/security/")
                                     || path.starts_with("/api/auth/")
+                                    || path.starts_with("/api/amneziawg/")
+                                    || path.starts_with("/api/cluster/")
+                                    || path.starts_with("/api/threats/")
+                                    || path.starts_with("/api/wasm/")
                                 {
                                     return Ok::<_, Infallible>(api.handle_request(req).await);
                                 }


### PR DESCRIPTION
## What changed

- routes AWG, cluster, threat-sync, and WASM endpoints through the metrics/control server
- adds a dedicated Control API client and token to Admin Console settings
- uses the Control API token for auth, AWG, cluster, DLP/CASB, and threat-sync calls
- keeps search, ACL, and control tokens session-only instead of persisting them in local storage
- configures the Vite development proxy to forward the appropriate Bearer token per API family

## Why

The Admin Console could render the UI but received unauthorized or not-found responses from several backend components. Some routes were not dispatched by the server, and several clients incorrectly reused the ACL token for Control API endpoints.

## Impact

Operators can access protected Control API components from the Admin Console while ACL and Control API credentials remain separated.

## Validation

- `npm run build`
- `npm run lint` — passes with one pre-existing Fast Refresh warning
- `cargo test -p bsdm-proxy --lib server` — 4 passed, 173 filtered
- `git diff --cached --check`
- exercised the protected APIs against the pilot stack
