### PR TITLE
feat(trust-ui): add Docker multi-stage build and compose stack service for Trust-UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -203,3 +203,19 @@ EXPOSE 53/udp 8092
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -q -O- --spider http://127.0.0.1:8092/health || exit 1
 CMD ["dns-sinkhole"]
+
+# ============================================================
+# Trust-UI web console (Vite + React 19 + Tailwind v4)
+# ============================================================
+FROM node:22-alpine AS trust-ui-builder
+WORKDIR /app
+COPY trust-ui/package.json trust-ui/package-lock.json ./
+RUN npm ci
+COPY trust-ui/ ./
+RUN npm run build
+
+FROM nginx:alpine AS trust-ui
+COPY --from=trust-ui-builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -104,6 +104,17 @@ services:
     command: ["python3", "/mock-upstream.py"]
     restart: unless-stopped
 
+  trust-ui:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: trust-ui
+    ports:
+      - "3001:80"
+    restart: unless-stopped
+    networks:
+      - bsdm-lite
+
 networks:
   bsdm-lite:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,6 +298,17 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9093/-/healthy || exit 1"]
+
+  trust-ui:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: trust-ui
+    ports:
+      - "3001:80"
+    restart: unless-stopped
+    networks:
+      - bsdm-net
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

This PR completes Phase 5 of the Trust-UI roadmap:
- Added multi-stage build targets ( and ) in  using  and .
- Integrated  service entry in  and  running on port .