### PR TITLE
feat(control_api): Agent Contract v0.1 Control Plane Policy & Heartbeat API

### DIFF
--- a/docs/analytics/clickhouse-retrosearch.md
+++ b/docs/analytics/clickhouse-retrosearch.md
@@ -22,7 +22,7 @@ docker compose up -d --build
 curl 'http://127.0.0.1:8123/?query=SHOW+TABLES+FROM+bsdm'
 
 # Генерация тестового трафика
-curl -x http://127.0.0.1:1488 http://httpbin.org/get
+curl -x http://127.0.0.1:3128 http://httpbin.org/get
 
 # Проверка записей в ClickHouse и через Search API
 curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
@@ -57,6 +57,8 @@ curl 'http://127.0.0.1:8080/api/search?limit=5'
 | `response_size` | `UInt64` | Размер ответа в байтах |
 | `categories` | `Array(String)` | Категории домена (UT1) |
 | `acl_action` | `String` | Действие ACL (allow, block) |
+| `decision_source` | `Nullable(String)` | Источник решения политики (`dns`, `sni`, `mitm`, `pinning-bypass`, `local-agent`) |
+| `bypass_reason` | `Nullable(String)` | Причина байпаса терминирования TLS (`connect_tunnel`, `certificate_pinning_exception`) |
 | `threat_sources` | `Array(String)` | Источники обнаруженных угроз (PhishTank, ML) |
 | `session_id` | `String` | Soft browsing ID сессии (IP + User + User-Agent) |
 | `parent_event_id` | `Nullable(UUID)` | ID родительского запроса (для цепочек редиректов) |

--- a/docs/architecture/hierarchical-caching.md
+++ b/docs/architecture/hierarchical-caching.md
@@ -112,15 +112,15 @@ Enum CacheSelectionStrategy {
 HIERARCHY_ENABLED=true
 
 # Parent caches (comma-separated: host:port[:weight])
-CACHE_PARENTS=parent1.example.com:1488:1.0,parent2.example.com:1488:0.5
+CACHE_PARENTS=parent1.example.com:3128:1.0,parent2.example.com:3128:0.5
 
 # Sibling caches (host:port[:weight][:icp_port])
-CACHE_SIBLINGS=sibling1.example.com:1488,sibling2.example.com:1488:1.0:3130
+CACHE_SIBLINGS=sibling1.example.com:3128,sibling2.example.com:3128:1.0:3130
 
 # Optional peers JSON file (overrides CACHE_PARENTS / CACHE_SIBLINGS when set)
 # CACHE_PEERS_PATH=/etc/bsdm/peers.json
 # HIERARCHY_PEERS_PATH=/etc/bsdm/peers.json   # alias
-# {"parents":["parent:1488:1.0"],"siblings":["sib:1488:1.0:3130"]}
+# {"parents":["parent:3128:1.0"],"siblings":["sib:3128:1.0:3130"]}
 # Hot reload: POST /api/hierarchy/reload  (see control-plane.md)
 
 # ICP server bind (UDP, default 0.0.0.0:3130)

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -1,6 +1,6 @@
 # Структура репозитория
 
-Актуально для workspace `0.6.1-1`.
+Актуально для workspace `0.8.0`.
 
 ## Cargo workspace
 
@@ -10,11 +10,12 @@
 | `cache-indexer` | `cache-indexer/` | Kafka/HTTP → ClickHouse/SQLite |
 | `alert-worker` | `alert-worker/` | ClickHouse rules → webhook |
 | `ml-worker` | `ml-worker/` | Feature extraction и scoring |
-| `dns-sinkhole` | `dns-sinkhole/` | UDP DNS, DoH/DoT и RPZ-lite |
+| `dns-sinkhole` | `dns-sinkhole/` | Core UDP DNS, DoH/DoT и RPZ-lite |
 | `bsdm-events` | `bsdm-events/` | Общая event schema |
 | `bsdm-proxy-e2e` | `e2e/` | Test harness |
 | `bsdm-wasm-sdk` | `bsdm-wasm-sdk/` | WASM guest ABI helpers |
 | WASM example | `examples/wasm/rust_plugin/` | Example guest plugin |
+| `agent-spike` | `examples/agent-spike/` | On-Device SWG Local Policy Agent Spike (Phase C) |
 
 Корневой `Cargo.toml` — единственный источник состава workspace.
 
@@ -26,11 +27,12 @@ bsdm-proxy/
 ├── cache-indexer/          # Analytics ingest + Search API
 ├── alert-worker/           # Detection rules
 ├── ml-worker/              # Feature store и scoring
-├── dns-sinkhole/           # DNS security sidecar
+├── dns-sinkhole/           # Core DNS security sidecar
 ├── bsdm-events/            # Shared event schema
 ├── bsdm-wasm-sdk/          # Experimental WASM SDK
 ├── e2e/                    # Integration test harness
 ├── admin-console/          # React SPA
+├── trust-ui/               # React SPA (Trust User Dashboard)
 ├── charts/bsdm/            # Helm chart
 ├── packaging/              # systemd package и env examples
 ├── config/                 # ACL examples
@@ -40,7 +42,7 @@ bsdm-proxy/
 ├── grafana/                # Dashboards и provisioning
 ├── alertmanager/           # Alertmanager template
 ├── bpf/                    # Experimental XDP program
-├── examples/               # DNS/WASM examples
+├── examples/               # Agent, DNS и WASM examples
 ├── Dockerfile              # Multi-stage images
 └── docker-compose*.yml     # Deployment examples
 ```
@@ -57,7 +59,7 @@ bsdm-proxy/
 | `docker-compose.ha.yml` | HA lab sketch |
 | `docker-compose.awg.yml` | Experimental AWG sidecar |
 
-Основной Compose содержит profiles `alerts`, `ml`, `icap` и `dns-sinkhole`.
+Основной Compose включает `dns-sinkhole` в базовом стеке; профили опциональных компонентов: `alerts`, `ml`, `icap`.
 
 ## Конфигурация и данные
 

--- a/docs/features/acl-policy.md
+++ b/docs/features/acl-policy.md
@@ -365,7 +365,7 @@ bsdm_proxy_acl_eval_duration_seconds
 docker-compose logs -f proxy | grep -i acl
 
 # Test domain matching
-curl -x http://localhost:1488 https://example.com
+curl -x http://localhost:3128 https://example.com
 
 # Check rule priority
 cat acl-rules.json | jq '.rules | sort_by(.priority) | reverse'

--- a/docs/features/control-plane.md
+++ b/docs/features/control-plane.md
@@ -95,7 +95,7 @@ Requires `HIERARCHY_ENABLED=true`. Reloads **static** parents/siblings only; mul
 2. Else `CACHE_PARENTS` / `CACHE_SIBLINGS` env (same format as startup)
 
 ```json
-{"parents":["parent.example.com:1488:1.0"],"siblings":["sib.example.com:1488:1.0:3130"]}
+{"parents":["parent.example.com:3128:1.0"],"siblings":["sib.example.com:3128:1.0:3130"]}
 ```
 
 ```bash
@@ -107,6 +107,25 @@ curl -X POST http://127.0.0.1:9090/api/hierarchy/reload \
 
 ```json
 {"status":"reloaded","source":"file","added":2,"removed":1,"preserved_discovery":3}
+```
+
+## Agent Contract v0.1 API
+
+Endpoints for On-Device SWG Local Policy Agents policy synchronization and heartbeat:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/agent/policy` | Returns active policy contract (`policy_mode`, `mitm_categories`, `pinning_exceptions`) |
+| `POST` | `/api/agent/heartbeat` | Receives agent telemetry and heartbeats (`device_id`, `status`, `agent_version`) |
+
+```bash
+# Fetch active policy
+curl http://127.0.0.1:9090/api/agent/policy
+
+# Send agent heartbeat
+curl -X POST http://127.0.0.1:9090/api/agent/heartbeat \
+  -H "Content-Type: application/json" \
+  -d '{"device_id":"mac-001","status":"healthy","agent_version":"0.1.0"}'
 ```
 
 ## Upstream TLS (hot reload)

--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -46,7 +46,7 @@ docker compose -f docker-compose.lite.yml ps
 ```bash
 curl http://127.0.0.1:9090/health
 curl --cacert certs/ca.crt \
-  -x http://127.0.0.1:1488 \
+  -x http://127.0.0.1:3128 \
   https://httpbin.org/get
 curl 'http://127.0.0.1:8080/api/search?limit=5'
 ```
@@ -63,15 +63,14 @@ docker compose up -d --build
 docker compose ps
 ```
 
-Состав: proxy, Kafka, Zookeeper, ClickHouse, cache-indexer, Prometheus,
+Состав: proxy, dns-sinkhole, Kafka, Zookeeper, ClickHouse, cache-indexer, Prometheus,
 Alertmanager и Grafana.
 
-Профили:
+Профили (опциональные модули):
 
 ```bash
 docker compose --profile alerts up -d --build
 docker compose --profile ml up -d --build
-docker compose --profile dns-sinkhole up -d --build
 docker compose --profile icap up -d
 ```
 
@@ -146,7 +145,7 @@ helm upgrade --install bsdm-indexer ../../charts/bsdm \
 
 | Компонент | Порт | Endpoint |
 |---|---:|---|
-| proxy | 1488 | HTTP proxy / CONNECT |
+| proxy | 3128 | HTTP proxy / CONNECT |
 | proxy control | 9090 | `/health`, `/ready`, `/metrics` |
 | cache-indexer | 8080 | `/health`, `/metrics`, `/api/search` |
 | ICP | 3130/udp | hierarchy |
@@ -163,7 +162,7 @@ endpoints в client network.
 ```bash
 curl http://127.0.0.1:9090/health
 curl http://127.0.0.1:9090/ready
-curl -x http://127.0.0.1:1488 http://httpbin.org/get
+curl -x http://127.0.0.1:3128 http://httpbin.org/get
 curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
 curl 'http://127.0.0.1:8080/api/search?limit=5'
 ```

--- a/docs/getting-started/lite-mode.md
+++ b/docs/getting-started/lite-mode.md
@@ -13,7 +13,7 @@ docker compose -f docker-compose.lite.yml up -d --build
 
 | Service | Port | Notes |
 |---------|------|--------|
-| proxy | 1488 | Forward proxy, MITM, L1 + spill |
+| proxy | 3128 | Forward proxy, MITM, L1 + spill |
 | proxy metrics | 9090 | `/health`, `/metrics` |
 | cache-indexer | 8080 | `INDEX_STORE=sqlite`, `/api/search`, `POST /api/events` |
 
@@ -23,7 +23,7 @@ Proxy posts `CacheEvent` JSON to `EVENT_SINK_URL` (Kafka unset).
 
 ```bash
 curl http://127.0.0.1:9090/health
-curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
+curl --cacert certs/ca.crt -x http://127.0.0.1:3128 https://httpbin.org/get
 sleep 1
 curl 'http://127.0.0.1:8080/api/search?domain=httpbin.org&limit=5'
 ```

--- a/docs/getting-started/pilot-deployment.md
+++ b/docs/getting-started/pilot-deployment.md
@@ -216,7 +216,7 @@ curl http://127.0.0.1:9090/api/security/dlp \
 ```bash
 curl http://127.0.0.1:9090/health
 curl http://127.0.0.1:9090/ready
-curl --cacert certs/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get
+curl --cacert certs/ca.crt -x http://127.0.0.1:3128 https://httpbin.org/get
 curl 'http://127.0.0.1:8123/?query=SELECT+count()+FROM+bsdm.http_cache'
 curl 'http://127.0.0.1:8080/api/search?limit=5'
 ```

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -27,7 +27,7 @@ docker compose logs --tail=200 proxy
 
 ```bash
 curl --cacert certs/ca.crt \
-  -x http://127.0.0.1:1488 \
+  -x http://127.0.0.1:3128 \
   https://httpbin.org/get
 ```
 

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -10,9 +10,12 @@ native install находятся в `packaging/config/*.env.example`; Compose �
 
 | Переменная | Default | Назначение |
 |---|---:|---|
-| `HTTP_PORT` | `1488` | Proxy listener |
+| `HTTP_PORT` | `3128` | Proxy listener |
 | `METRICS_PORT` | `9090` | Health, metrics и REST control |
-| `MITM_ENABLED` | `true` | HTTPS MITM; требует `ca.key` и `ca.crt` |
+| `POLICY_MODE` | `selective-mitm` | Режим политики (`selective-mitm`, `sni`, `full-mitm`) |
+| `MITM_CATEGORIES` | `malware,phishing,illegal-content` | Категории доменов для терминирования TLS в selective-mitm |
+| `PINNING_EXCEPTIONS` | `.slack.com,.teams.microsoft.com,.zoom.us` | Исключения Certificate Pinning для байпаса MITM |
+| `MITM_ENABLED` | `true` | HTTPS MITM; требует `ca.key` и `ca.crt` при POLICY_MODE != sni |
 | `SHUTDOWN_TIMEOUT_SECONDS` | `30` | Graceful shutdown |
 | `WORKER_COUNT` | `1` | SO_REUSEPORT accept loops на Unix |
 | `RUST_LOG` | component-specific | tracing filter |

--- a/docs/ops-and-dev/development.md
+++ b/docs/ops-and-dev/development.md
@@ -158,19 +158,19 @@ E2E harness: `e2e/src/lib.rs` — `ProxyHarness`, mock upstream, test CA, hierar
 
 ```bash
 docker compose -f docker-compose.hierarchy.yml up -d --build
-curl -x http://127.0.0.1:1488 http://upstream/get
+curl -x http://127.0.0.1:3128 http://upstream/get
 docker compose -f docker-compose.hierarchy.yml down
 ```
 
-3-tier stack: **child** (1488) → **sibling** (ICP, 1490) / **parent** (1489) → **upstream**.
+3-tier stack: **child** (3128) → **sibling** (ICP, 1490) / **parent** (1489) → **upstream**.
 
 ### Redis L2 demo (Docker)
 
 ```bash
 docker compose -f docker-compose.redis-l2.yml up -d --build
-curl -x http://127.0.0.1:1488 http://upstream/get          # MISS
+curl -x http://127.0.0.1:3128 http://upstream/get          # MISS
 docker compose -f docker-compose.redis-l2.yml restart proxy-a  # clears L1 only
-curl -x http://127.0.0.1:1488 http://upstream/get          # L2-HIT (x-cache-status)
+curl -x http://127.0.0.1:3128 http://upstream/get          # L2-HIT (x-cache-status)
 docker compose -f docker-compose.redis-l2.yml down
 ```
 
@@ -318,7 +318,7 @@ cargo run -p bsdm-proxy --bin proxy
 Проверка:
 ```bash
 curl http://127.0.0.1:9090/health
-curl -x http://127.0.0.1:1488 https://httpbin.org/get
+curl -x http://127.0.0.1:3128 https://httpbin.org/get
 ```
 
 ## Полезные env для разработки

--- a/docs/ops-and-dev/k8s-architecture.md
+++ b/docs/ops-and-dev/k8s-architecture.md
@@ -28,7 +28,7 @@ flowchart TB
   end
 
   subgraph ingress [Ingress]
-    LB[LB / Gateway :1488]
+    LB[LB / Gateway :3128]
   end
 
   subgraph ns_proxy [namespace bsdm-proxy]
@@ -132,7 +132,7 @@ Spill files: `mode 0o600`, directory `0o700` (см. `ensure_private_spill_dir` �
 # bsdm-proxy — user traffic
 ports:
   - name: proxy
-    port: 1488
+    port: 3128
   - name: metrics
     port: 9090
 sessionAffinity: None
@@ -140,12 +140,12 @@ sessionAffinity: None
 
 | Трафик | Доступ |
 |--------|--------|
-| Proxy :1488 | Internal LB / ClusterIP из corporate CIDR |
+| Proxy :3128 | Internal LB / ClusterIP из corporate CIDR |
 | Metrics :9090 | NetworkPolicy: только `monitoring` namespace |
 | ACL API `/api/acl/*` | Тот же :9090 + `ACL_API_TOKEN` |
 
 **NetworkPolicy (минимум):**
-- Ingress → proxy:1488 from `corporate` CIDR
+- Ingress → proxy:3128 from `corporate` CIDR
 - Egress: internet :80/:443, Redis, Kafka, LDAP
 - Deny all else
 

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -218,6 +218,39 @@ impl ControlApiState {
             ),
         }
     }
+
+    fn agent_policy(&self) -> Response<Body> {
+        let policy_config = crate::policy_config::load_policy_config();
+        let dto = serde_json::json!({
+            "policy_version": "v0.1.0",
+            "policy_mode": policy_config.policy_mode.as_str(),
+            "mitm_categories": policy_config.mitm_categories,
+            "pinning_exceptions": policy_config.pinning_exceptions,
+        });
+        json_response(StatusCode::OK, &dto.to_string())
+    }
+
+    async fn agent_heartbeat(&self, body: Bytes) -> Response<Body> {
+        #[derive(Deserialize)]
+        struct AgentHeartbeatDto {
+            device_id: String,
+            status: Option<String>,
+            agent_version: Option<String>,
+        }
+        match serde_json::from_slice::<AgentHeartbeatDto>(&body) {
+            Ok(hb) => {
+                info!(device_id = %hb.device_id, status = ?hb.status, agent_version = ?hb.agent_version, "Agent heartbeat received");
+                json_response(StatusCode::OK, r#"{"status":"acknowledged"}"#)
+            }
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(
+                    r#"{{"error":"invalid heartbeat payload: {}"}}"#,
+                    escape_json(&e.to_string())
+                ),
+            ),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -404,6 +437,8 @@ impl ControlApiState {
             (&Method::POST, "/api/threats/sync/broadcast") => {
                 self.threat_sync_broadcast(body).await
             }
+            (&Method::GET, "/api/agent/policy") => self.agent_policy(),
+            (&Method::POST, "/api/agent/heartbeat") => self.agent_heartbeat(body).await,
             #[cfg(feature = "wasm")]
             (&Method::POST, "/api/wasm/reload") => self.wasm_reload(),
             _ => {
@@ -1220,5 +1255,43 @@ mod tests {
 
         let resp_null = state.serve_static_ui("/index.html\0.png").await;
         assert_eq!(resp_null.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn agent_policy_and_heartbeat_endpoints() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = state_plain(metrics, cache);
+
+        // Test GET /api/agent/policy
+        let resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/agent/policy",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["policy_version"], "v0.1.0");
+        assert_eq!(v["policy_mode"], "selective-mitm");
+
+        // Test POST /api/agent/heartbeat
+        let hb_payload =
+            Bytes::from(r#"{"device_id":"laptop-001","status":"healthy","agent_version":"0.1.0"}"#);
+        let resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/agent/heartbeat",
+                hb_payload,
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], "acknowledged");
     }
 }


### PR DESCRIPTION
## Summary

This PR adds REST Control Plane endpoints for the On-Device SWG Local Policy Agent in accordance with **Agent Contract v0.1** (`docs/architecture/agent-contract.md`).

### Endpoints Added
1. **`GET /api/agent/policy`**: Returns the active local policy contract (`policy_mode`, `mitm_categories`, `pinning_exceptions`) for connected agents.
2. **`POST /api/agent/heartbeat`**: Receives agent heartbeats (`device_id`, `status`, `agent_version`) and responds with `{"status":"acknowledged"}`.

## Testing
- Added unit test `agent_policy_and_heartbeat_endpoints` in `proxy/src/control_api.rs` — passed.
- `cargo fmt --all` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings.