### PR TITLE
Unify Agent API path versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent API versioning** — Standardized Agent Contract v0.1 on
+  `/api/v1/agent/*`; retained the previous `/api/agent/*` policy and heartbeat
+  routes as compatibility aliases, and updated the reference agent heartbeat
+  client to use the canonical versioned endpoint.
+
 ## [0.8.0] - 2026-07-27
 
 Release **0.8.0**. Hybrid Policy Engine & Local Agent Contract, Global Session State & Real-time Threat Sync, Native UI Routing (Trust-UI & Admin Console), OIDC Security Validation, DoH & DoT Encrypted DNS Gateways, and Admin Console modules (RPZ, Wasm, ICAP, Mesh Cluster, eBPF/XDP, Vector AI Cache).

--- a/docs/architecture/agent-contract.md
+++ b/docs/architecture/agent-contract.md
@@ -6,6 +6,18 @@ This document defines the specification and interaction contract between the BSD
 
 The BSDM Agent architecture operates on a **Local Policy Agent** model: policy decision enforcement happens directly on-device using a local policy engine, while the central control plane manages enrollment, policy distribution, heartbeat, and telemetry ingestion.
 
+All Agent Contract v0.1 HTTP endpoints use the canonical
+`/api/v1/agent/*` namespace. The unversioned `/api/agent/*` namespace is
+deprecated and retained only as a compatibility alias for the implemented
+policy and heartbeat endpoints.
+
+### Implementation status
+
+- Implemented: `GET /api/v1/agent/policy`,
+  `POST /api/v1/agent/heartbeat`.
+- Reserved by this contract: `POST /api/v1/agent/enroll`,
+  `POST /api/v1/agent/events`, and policy push.
+
 ---
 
 ## 1. Device Enrollment & Identity Binding

--- a/docs/features/control-plane.md
+++ b/docs/features/control-plane.md
@@ -121,15 +121,21 @@ Endpoints for On-Device SWG Local Policy Agents policy synchronization and heart
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/agent/policy` | Returns active policy contract (`policy_mode`, `mitm_categories`, `pinning_exceptions`) |
-| `POST` | `/api/agent/heartbeat` | Receives agent telemetry and heartbeats (`device_id`, `status`, `agent_version`) |
+| `GET` | `/api/v1/agent/policy` | Returns active policy contract (`policy_mode`, `mitm_categories`, `pinning_exceptions`) |
+| `POST` | `/api/v1/agent/heartbeat` | Receives agent telemetry and heartbeats (`device_id`, `status`, `agent_version`) |
+
+The `/api/v1/agent/*` namespace is canonical for Agent Contract v0.1.
+The previous unversioned `/api/agent/policy` and `/api/agent/heartbeat` paths
+remain compatibility aliases for existing agents and must not be used by new clients.
 
 ```bash
 # Fetch active policy
-curl http://127.0.0.1:9090/api/agent/policy
+curl http://127.0.0.1:9090/api/v1/agent/policy \
+  -H "Authorization: Bearer $CONTROL_API_TOKEN"
 
 # Send agent heartbeat
-curl -X POST http://127.0.0.1:9090/api/agent/heartbeat \
+curl -X POST http://127.0.0.1:9090/api/v1/agent/heartbeat \
+  -H "Authorization: Bearer $CONTROL_API_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"device_id":"mac-001","status":"healthy","agent_version":"0.1.0"}'
 ```

--- a/examples/agent-spike/README.md
+++ b/examples/agent-spike/README.md
@@ -5,7 +5,9 @@ This directory contains a minimal spike of an On-Device SWG Local Policy Agent b
 ## Architectural Highlights
 
 - **On-Device Enforcement**: Executes SNI deny rules, category checks, and certificate pinning bypasses locally without proxy roundtrips.
-- **Heartbeat & Telemetry**: Periodically sends heartbeats to central Control Plane (`:9090`) and logs local decisions with `decision_source = "local-agent"`.
+- **Heartbeat & Telemetry**: Periodically sends heartbeats to the canonical
+  `POST /api/v1/agent/heartbeat` Control Plane endpoint and logs local decisions
+  with `decision_source = "local-agent"`.
 
 ## Running the Spike
 
@@ -16,5 +18,8 @@ cargo run -p agent-spike
 ### Environment Overrides
 
 ```bash
-DEVICE_ID="laptop-win-042" CONTROL_PLANE_URL="http://127.0.0.1:9090" cargo run -p agent-spike
+DEVICE_ID="laptop-win-042" \
+CONTROL_PLANE_URL="http://127.0.0.1:9090" \
+CONTROL_API_TOKEN="replace-me" \
+cargo run -p agent-spike
 ```

--- a/examples/agent-spike/src/main.rs
+++ b/examples/agent-spike/src/main.rs
@@ -46,14 +46,20 @@ pub enum LocalDecision {
 pub struct AgentEngine {
     device_id: String,
     control_plane_url: String,
+    control_api_token: Option<String>,
     policy: Arc<RwLock<LocalPolicy>>,
 }
 
 impl AgentEngine {
-    pub fn new(device_id: String, control_plane_url: String) -> Self {
+    pub fn new(
+        device_id: String,
+        control_plane_url: String,
+        control_api_token: Option<String>,
+    ) -> Self {
         Self {
             device_id,
             control_plane_url,
+            control_api_token,
             policy: Arc::new(RwLock::new(LocalPolicy::default())),
         }
     }
@@ -120,8 +126,20 @@ impl AgentEngine {
             interval.tick().await;
             info!(device_id = %self.device_id, "Sending agent heartbeat to control plane...");
 
-            let health_url = format!("{}/health", self.control_plane_url);
-            match client.get(&health_url).send().await {
+            let heartbeat_url = format!(
+                "{}/api/v1/agent/heartbeat",
+                self.control_plane_url.trim_end_matches('/')
+            );
+            let mut request = client.post(&heartbeat_url).json(&serde_json::json!({
+                "device_id": self.device_id,
+                "status": "healthy",
+                "agent_version": env!("CARGO_PKG_VERSION"),
+            }));
+            if let Some(token) = &self.control_api_token {
+                request = request.bearer_auth(token);
+            }
+
+            match request.send().await {
                 Ok(resp) if resp.status().is_success() => {
                     info!(
                         "Agent heartbeat ACK from control plane ({})",
@@ -132,7 +150,7 @@ impl AgentEngine {
                     warn!("Control plane returned status: {}", resp.status());
                 }
                 Err(e) => {
-                    warn!("Failed to reach control plane at {}: {}", health_url, e);
+                    warn!("Failed to reach control plane at {}: {}", heartbeat_url, e);
                 }
             }
         }
@@ -153,8 +171,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let device_id = std::env::var("DEVICE_ID").unwrap_or_else(|_| "dev-mac-001".to_string());
     let control_plane_url =
         std::env::var("CONTROL_PLANE_URL").unwrap_or_else(|_| "http://127.0.0.1:9090".to_string());
+    let control_api_token = std::env::var("CONTROL_API_TOKEN")
+        .ok()
+        .filter(|token| !token.is_empty());
 
-    let agent = Arc::new(AgentEngine::new(device_id.clone(), control_plane_url));
+    let agent = Arc::new(AgentEngine::new(
+        device_id.clone(),
+        control_plane_url,
+        control_api_token,
+    ));
 
     // Demonstrate local policy evaluation
     let test_domains = vec![

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -3,6 +3,7 @@
 use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
+use hyper::header::HeaderValue;
 use hyper::header::AUTHORIZATION;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -437,8 +438,14 @@ impl ControlApiState {
             (&Method::POST, "/api/threats/sync/broadcast") => {
                 self.threat_sync_broadcast(body).await
             }
-            (&Method::GET, "/api/agent/policy") => self.agent_policy(),
-            (&Method::POST, "/api/agent/heartbeat") => self.agent_heartbeat(body).await,
+            (&Method::GET, "/api/v1/agent/policy") => self.agent_policy(),
+            (&Method::POST, "/api/v1/agent/heartbeat") => self.agent_heartbeat(body).await,
+            (&Method::GET, "/api/agent/policy") => {
+                deprecated_agent_alias(self.agent_policy(), "/api/v1/agent/policy")
+            }
+            (&Method::POST, "/api/agent/heartbeat") => {
+                deprecated_agent_alias(self.agent_heartbeat(body).await, "/api/v1/agent/heartbeat")
+            }
             #[cfg(feature = "wasm")]
             (&Method::POST, "/api/wasm/reload") => self.wasm_reload(),
             _ => {
@@ -1000,6 +1007,21 @@ fn json_response(status: StatusCode, body: &str) -> Response<Body> {
         .unwrap_or_else(|_| Response::new(full(Bytes::from_static(b"500 Internal Server Error"))))
 }
 
+fn deprecated_agent_alias(
+    mut response: Response<Body>,
+    successor_path: &'static str,
+) -> Response<Body> {
+    response
+        .headers_mut()
+        .insert("deprecation", HeaderValue::from_static("true"));
+    response.headers_mut().insert(
+        "link",
+        HeaderValue::from_str(&format!("<{successor_path}>; rel=\"successor-version\""))
+            .expect("static successor path must produce a valid Link header"),
+    );
+    response
+}
+
 fn escape_json(value: &str) -> String {
     value
         .replace('\\', "\\\\")
@@ -1263,11 +1285,11 @@ mod tests {
         let cache = Arc::new(HttpL1Cache::new(100, 4));
         let state = state_plain(metrics, cache);
 
-        // Test GET /api/agent/policy
+        // Canonical versioned policy endpoint.
         let resp = state
             .dispatch(
                 &Method::GET,
-                "/api/agent/policy",
+                "/api/v1/agent/policy",
                 Bytes::new(),
                 &HeaderMap::new(),
             )
@@ -1278,13 +1300,13 @@ mod tests {
         assert_eq!(v["policy_version"], "v0.1.0");
         assert_eq!(v["policy_mode"], "selective-mitm");
 
-        // Test POST /api/agent/heartbeat
+        // Canonical versioned heartbeat endpoint.
         let hb_payload =
             Bytes::from(r#"{"device_id":"laptop-001","status":"healthy","agent_version":"0.1.0"}"#);
         let resp = state
             .dispatch(
                 &Method::POST,
-                "/api/agent/heartbeat",
+                "/api/v1/agent/heartbeat",
                 hb_payload,
                 &HeaderMap::new(),
             )
@@ -1293,5 +1315,48 @@ mod tests {
         let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], "acknowledged");
+
+        // Unversioned v0.1 paths remain aliases for existing agents.
+        let legacy_policy = state
+            .dispatch(
+                &Method::GET,
+                "/api/agent/policy",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(legacy_policy.status(), StatusCode::OK);
+        assert_eq!(legacy_policy.headers()["deprecation"], "true");
+        assert_eq!(
+            legacy_policy.headers()["link"],
+            "</api/v1/agent/policy>; rel=\"successor-version\""
+        );
+
+        let legacy_heartbeat = state
+            .dispatch(
+                &Method::POST,
+                "/api/agent/heartbeat",
+                Bytes::from(
+                    r#"{"device_id":"legacy-001","status":"healthy","agent_version":"0.1.0"}"#,
+                ),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(legacy_heartbeat.status(), StatusCode::OK);
+        assert_eq!(legacy_heartbeat.headers()["deprecation"], "true");
+        assert_eq!(
+            legacy_heartbeat.headers()["link"],
+            "</api/v1/agent/heartbeat>; rel=\"successor-version\""
+        );
+
+        let unsupported_version = state
+            .dispatch(
+                &Method::GET,
+                "/api/v2/agent/policy",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(unsupported_version.status(), StatusCode::NOT_FOUND);
     }
 }


### PR DESCRIPTION
## What changed

- standardized implemented Agent API endpoints on the canonical `/api/v1/agent/*` namespace
- retained `/api/agent/*` as compatibility aliases with `Deprecation` and successor `Link` headers
- updated the reference Agent Spike to send authenticated heartbeats to `/api/v1/agent/heartbeat`
- aligned the Agent Contract, control-plane documentation, examples, and changelog
- added coverage for canonical routes, legacy aliases, and unsupported API versions

## Why

The Agent Contract documented versioned paths while the proxy implementation and example client still used unversioned or health-check endpoints. This made the effective contract ambiguous for agent integrations.

## Impact

New agents have one stable versioned namespace. Existing agents continue to work through compatibility aliases and receive an explicit migration signal. Unknown versions such as `/api/v2/agent/policy` return `404`.

## Validation

- `cargo test -p bsdm-proxy --lib agent_policy_and_heartbeat_endpoints`
- `cargo test -p agent-spike`
- `python3 scripts/check-doc-links.py`
- `git diff --check`