### PR TITLE
Add decision_source observability across policy paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Policy decision-source observability** — Added bounded Prometheus counters,
+  structured decision logs, Grafana breakdowns, and Search API filtering for
+  `dns`, `sni`, `mitm`, and `pinning-bypass`, including compatible SQLite and
+  ClickHouse schema upgrades.
+
 ## [0.8.0] - 2026-07-27
 
 Release **0.8.0**. Hybrid Policy Engine & Local Agent Contract, Global Session State & Real-time Threat Sync, Native UI Routing (Trust-UI & Admin Console), OIDC Security Validation, DoH & DoT Encrypted DNS Gateways, and Admin Console modules (RPZ, Wasm, ICAP, Mesh Cluster, eBPF/XDP, Vector AI Cache).

--- a/cache-indexer/src/search_api.rs
+++ b/cache-indexer/src/search_api.rs
@@ -65,6 +65,12 @@ impl SearchApi {
         let domain = sanitize_filter(query.get("domain").map(String::as_str).unwrap_or(""));
         let username = sanitize_filter(query.get("username").map(String::as_str).unwrap_or(""));
         let session_id = sanitize_filter(query.get("session_id").map(String::as_str).unwrap_or(""));
+        let decision_source = sanitize_filter(
+            query
+                .get("decision_source")
+                .map(String::as_str)
+                .unwrap_or(""),
+        );
         let limit = query
             .get("limit")
             .and_then(|v| v.parse::<u32>().ok())
@@ -94,6 +100,7 @@ impl SearchApi {
             domain,
             username,
             session_id: session_id.clone(),
+            decision_source,
             limit,
             session_timeline: !session_id.is_empty(),
         };
@@ -206,6 +213,7 @@ fn hits_to_csv(hits: &[crate::store::SearchHit]) -> String {
         "session_id",
         "parent_event_id",
         "redirect_url",
+        "decision_source",
     ];
     let mut out = headers.join(",");
     out.push('\n');
@@ -226,6 +234,7 @@ fn hits_to_csv(hits: &[crate::store::SearchHit]) -> String {
             h.session_id.clone(),
             h.parent_event_id.clone().unwrap_or_default(),
             h.redirect_url.clone().unwrap_or_default(),
+            h.decision_source.clone().unwrap_or_default(),
         ];
         out.push_str(
             &row.iter()

--- a/cache-indexer/src/store/memory.rs
+++ b/cache-indexer/src/store/memory.rs
@@ -43,6 +43,10 @@ impl MemoryStore {
                     || e.username.as_deref().unwrap_or("") == query.username.as_str()
             })
             .filter(|e| query.session_id.is_empty() || e.session_id == query.session_id)
+            .filter(|e| {
+                query.decision_source.is_empty()
+                    || e.decision_source.as_deref().unwrap_or("") == query.decision_source.as_str()
+            })
             .map(event_to_hit)
             .collect();
         if query.session_timeline {
@@ -73,6 +77,7 @@ fn event_to_hit(e: &CacheEvent) -> SearchHit {
         session_id: e.session_id.clone(),
         parent_event_id: e.parent_event_id.clone(),
         redirect_url: e.redirect_url.clone(),
+        decision_source: e.decision_source.clone(),
     }
 }
 
@@ -122,6 +127,7 @@ mod tests {
             domain: "a.com".into(),
             username: String::new(),
             session_id: String::new(),
+            decision_source: String::new(),
             limit: 10,
             session_timeline: false,
         });
@@ -139,11 +145,36 @@ mod tests {
             domain: String::new(),
             username: String::new(),
             session_id: String::new(),
+            decision_source: String::new(),
             limit: 10,
             session_timeline: true,
         });
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].ts, 2);
         assert_eq!(hits[1].ts, 3);
+    }
+
+    #[test]
+    fn filters_by_decision_source() {
+        let store = MemoryStore::new(10);
+        let mut mitm = sample("a.com", 1);
+        mitm.decision_source = Some("mitm".into());
+        let mut sni = sample("b.com", 2);
+        sni.decision_source = Some("sni".into());
+        store.insert_batch(&[mitm, sni]);
+
+        let hits = store.search(&SearchQuery {
+            from_ts: 0,
+            to_ts: 100,
+            domain: String::new(),
+            username: String::new(),
+            session_id: String::new(),
+            decision_source: "mitm".into(),
+            limit: 10,
+            session_timeline: false,
+        });
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].domain, "a.com");
+        assert_eq!(hits[0].decision_source.as_deref(), Some("mitm"));
     }
 }

--- a/cache-indexer/src/store/mod.rs
+++ b/cache-indexer/src/store/mod.rs
@@ -18,6 +18,7 @@ pub struct SearchQuery {
     pub domain: String,
     pub username: String,
     pub session_id: String,
+    pub decision_source: String,
     pub limit: u32,
     pub session_timeline: bool,
 }
@@ -36,6 +37,7 @@ pub struct SearchHit {
     pub session_id: String,
     pub parent_event_id: Option<String>,
     pub redirect_url: Option<String>,
+    pub decision_source: Option<String>,
 }
 
 impl SearchHit {
@@ -53,6 +55,7 @@ impl SearchHit {
             "session_id": self.session_id,
             "parent_event_id": self.parent_event_id,
             "redirect_url": self.redirect_url,
+            "decision_source": self.decision_source,
         })
     }
 }
@@ -113,13 +116,14 @@ async fn search_clickhouse(
     };
     let sql = format!(
         "SELECT toUnixTimestamp(ts) AS ts, username, toString(client_ip) AS client_ip, url, method, status, \
-         cache_status, domain, event_id, session_id, parent_event_id, redirect_url \
+         cache_status, domain, event_id, session_id, parent_event_id, redirect_url, decision_source \
          FROM {table} \
          WHERE ts >= fromUnixTimestamp({{from:UInt32}}) \
            AND ts <= fromUnixTimestamp({{to:UInt32}}) \
            AND (length({{domain:String}}) = 0 OR domain = {{domain:String}}) \
            AND (length({{username:String}}) = 0 OR username = {{username:String}}) \
            AND (length({{session_id:String}}) = 0 OR session_id = {{session_id:String}}) \
+           AND (length({{decision_source:String}}) = 0 OR decision_source = {{decision_source:String}}) \
          ORDER BY {order} \
          LIMIT {{limit:UInt32}} \
          FORMAT JSONEachRow"
@@ -130,6 +134,7 @@ async fn search_clickhouse(
         ("domain", query.domain.clone()),
         ("username", query.username.clone()),
         ("session_id", query.session_id.clone()),
+        ("decision_source", query.decision_source.clone()),
         ("limit", query.limit.to_string()),
     ];
     let body = writer
@@ -162,6 +167,7 @@ pub fn parse_search_ndjson(
             session_id: json_string(&v, "session_id"),
             parent_event_id: json_opt_string(&v, "parent_event_id"),
             redirect_url: json_opt_string(&v, "redirect_url"),
+            decision_source: json_opt_string(&v, "decision_source"),
         });
     }
     Ok(out)

--- a/cache-indexer/src/store/sqlite.rs
+++ b/cache-indexer/src/store/sqlite.rs
@@ -22,30 +22,7 @@ impl SqliteStore {
             }
         }
         let conn = Connection::open(path)?;
-        conn.execute_batch(
-            r#"
-            PRAGMA journal_mode=WAL;
-            CREATE TABLE IF NOT EXISTS events (
-              event_id TEXT PRIMARY KEY,
-              ts INTEGER NOT NULL,
-              domain TEXT NOT NULL,
-              username TEXT,
-              client_ip TEXT NOT NULL,
-              url TEXT NOT NULL,
-              method TEXT NOT NULL,
-              status INTEGER NOT NULL,
-              cache_status TEXT NOT NULL,
-              session_id TEXT NOT NULL DEFAULT '',
-              parent_event_id TEXT,
-              redirect_url TEXT,
-              payload TEXT NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
-            CREATE INDEX IF NOT EXISTS idx_events_domain_ts ON events(domain, ts);
-            CREATE INDEX IF NOT EXISTS idx_events_user_ts ON events(username, ts);
-            CREATE INDEX IF NOT EXISTS idx_events_session_ts ON events(session_id, ts);
-            "#,
-        )?;
+        initialize_schema(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
             max_rows: max_rows.max(1),
@@ -63,8 +40,8 @@ impl SqliteStore {
                 r#"
                 INSERT INTO events (
                   event_id, ts, domain, username, client_ip, url, method, status,
-                  cache_status, session_id, parent_event_id, redirect_url, payload
-                ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13)
+                  cache_status, session_id, parent_event_id, redirect_url, decision_source, payload
+                ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)
                 ON CONFLICT(event_id) DO UPDATE SET
                   ts=excluded.ts,
                   domain=excluded.domain,
@@ -77,6 +54,7 @@ impl SqliteStore {
                   session_id=excluded.session_id,
                   parent_event_id=excluded.parent_event_id,
                   redirect_url=excluded.redirect_url,
+                  decision_source=excluded.decision_source,
                   payload=excluded.payload
                 "#,
             )?;
@@ -99,6 +77,7 @@ impl SqliteStore {
                     e.session_id,
                     e.parent_event_id,
                     e.redirect_url,
+                    e.decision_source,
                     payload,
                 ])?;
             }
@@ -131,14 +110,15 @@ impl SqliteStore {
         };
         let sql = format!(
             "SELECT ts, username, client_ip, url, method, status, cache_status, domain, \
-             event_id, session_id, parent_event_id, redirect_url \
+             event_id, session_id, parent_event_id, redirect_url, decision_source \
              FROM events \
              WHERE ts >= ?1 AND ts <= ?2 \
                AND (?3 = '' OR domain = ?3) \
                AND (?4 = '' OR username = ?4) \
                AND (?5 = '' OR session_id = ?5) \
+               AND (?6 = '' OR decision_source = ?6) \
              ORDER BY {order} \
-             LIMIT ?6"
+             LIMIT ?7"
         );
         let conn = self.conn.lock().expect("sqlite lock");
         let mut stmt = conn.prepare(&sql)?;
@@ -149,6 +129,7 @@ impl SqliteStore {
                 query.domain,
                 query.username,
                 query.session_id,
+                query.decision_source,
                 query.limit as i64,
             ],
             |row| {
@@ -165,6 +146,7 @@ impl SqliteStore {
                     session_id: row.get(9)?,
                     parent_event_id: row.get(10)?,
                     redirect_url: row.get(11)?,
+                    decision_source: row.get(12)?,
                 })
             },
         )?;
@@ -176,12 +158,60 @@ impl SqliteStore {
     }
 }
 
+fn initialize_schema(conn: &Connection) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    conn.execute_batch(
+        r#"
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS events (
+              event_id TEXT PRIMARY KEY,
+              ts INTEGER NOT NULL,
+              domain TEXT NOT NULL,
+              username TEXT,
+              client_ip TEXT NOT NULL,
+              url TEXT NOT NULL,
+              method TEXT NOT NULL,
+              status INTEGER NOT NULL,
+              cache_status TEXT NOT NULL,
+              session_id TEXT NOT NULL DEFAULT '',
+              parent_event_id TEXT,
+              redirect_url TEXT,
+              decision_source TEXT,
+              payload TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
+            CREATE INDEX IF NOT EXISTS idx_events_domain_ts ON events(domain, ts);
+            CREATE INDEX IF NOT EXISTS idx_events_user_ts ON events(username, ts);
+            CREATE INDEX IF NOT EXISTS idx_events_session_ts ON events(session_id, ts);
+            "#,
+    )?;
+    if !has_column(conn, "events", "decision_source")? {
+        conn.execute("ALTER TABLE events ADD COLUMN decision_source TEXT", [])?;
+    }
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_decision_source_ts
+         ON events(decision_source, ts)",
+        [],
+    )?;
+    Ok(())
+}
+
+fn has_column(conn: &Connection, table: &str, column: &str) -> Result<bool, rusqlite::Error> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let names = stmt.query_map([], |row| row.get::<_, String>(1))?;
+    for name in names {
+        if name? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn sample(domain: &str, ts: u64, id: &str) -> CacheEvent {
+    fn sample(domain: &str, ts: u64, id: &str, decision_source: Option<&str>) -> CacheEvent {
         CacheEvent {
             url: format!("https://{domain}/"),
             method: "GET".into(),
@@ -206,7 +236,7 @@ mod tests {
             redirect_url: None,
             dlp_violation: None,
             casb_alert: None,
-            decision_source: None,
+            decision_source: decision_source.map(str::to_string),
             bypass_reason: None,
             event_id: id.into(),
         }
@@ -216,7 +246,10 @@ mod tests {
     fn sqlite_roundtrip() {
         let store = SqliteStore::open(":memory:", 100).unwrap();
         store
-            .insert_batch(&[sample("ex.com", 50, "e1"), sample("other.com", 60, "e2")])
+            .insert_batch(&[
+                sample("ex.com", 50, "e1", Some("mitm")),
+                sample("other.com", 60, "e2", Some("sni")),
+            ])
             .unwrap();
         let hits = store
             .search(&SearchQuery {
@@ -225,11 +258,60 @@ mod tests {
                 domain: "ex.com".into(),
                 username: String::new(),
                 session_id: String::new(),
+                decision_source: "mitm".into(),
                 limit: 10,
                 session_timeline: false,
             })
             .unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].event_id, "e1");
+        assert_eq!(hits[0].decision_source.as_deref(), Some("mitm"));
+    }
+
+    #[test]
+    fn migrates_existing_database_with_decision_source() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE events (
+               event_id TEXT PRIMARY KEY,
+               ts INTEGER NOT NULL,
+               domain TEXT NOT NULL,
+               username TEXT,
+               client_ip TEXT NOT NULL,
+               url TEXT NOT NULL,
+               method TEXT NOT NULL,
+               status INTEGER NOT NULL,
+               cache_status TEXT NOT NULL,
+               session_id TEXT NOT NULL DEFAULT '',
+               parent_event_id TEXT,
+               redirect_url TEXT,
+               payload TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+
+        initialize_schema(&conn).unwrap();
+        assert!(has_column(&conn, "events", "decision_source").unwrap());
+
+        let store = SqliteStore {
+            conn: Mutex::new(conn),
+            max_rows: 100,
+        };
+        store
+            .insert_batch(&[sample("ex.com", 50, "e1", Some("pinning-bypass"))])
+            .unwrap();
+        let hits = store
+            .search(&SearchQuery {
+                from_ts: 0,
+                to_ts: 100,
+                domain: String::new(),
+                username: String::new(),
+                session_id: String::new(),
+                decision_source: "pinning-bypass".into(),
+                limit: 10,
+                session_timeline: false,
+            })
+            .unwrap();
+        assert_eq!(hits.len(), 1);
     }
 }

--- a/dns-sinkhole/src/server.rs
+++ b/dns-sinkhole/src/server.rs
@@ -14,7 +14,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use prometheus::{IntCounter, Registry};
+use prometheus::{IntCounter, IntCounterVec, Opts, Registry};
 use std::convert::Infallible;
 use std::fs::File;
 use std::io::BufReader;
@@ -32,6 +32,7 @@ pub struct Metrics {
     pub blocked: IntCounter,
     pub forwarded: IntCounter,
     pub errors: IntCounter,
+    pub policy_decision_source: IntCounterVec,
     pub registry: Registry,
 }
 
@@ -47,6 +48,14 @@ impl Metrics {
                 .map_err(|e| e.to_string())?;
         let errors = IntCounter::new("dns_sinkhole_errors_total", "Handler errors")
             .map_err(|e| e.to_string())?;
+        let policy_decision_source = IntCounterVec::new(
+            Opts::new(
+                "bsdm_proxy_policy_decision_source_total",
+                "Total policy decisions by decision source",
+            ),
+            &["source"],
+        )
+        .map_err(|e| e.to_string())?;
         registry
             .register(Box::new(queries.clone()))
             .map_err(|e| e.to_string())?;
@@ -59,11 +68,15 @@ impl Metrics {
         registry
             .register(Box::new(errors.clone()))
             .map_err(|e| e.to_string())?;
+        registry
+            .register(Box::new(policy_decision_source.clone()))
+            .map_err(|e| e.to_string())?;
         Ok(Self {
             queries,
             blocked,
             forwarded,
             errors,
+            policy_decision_source,
             registry,
         })
     }
@@ -147,6 +160,16 @@ pub async fn process_dns_query(
 
     if let Some(action) = zone.lookup(&query.question.name) {
         metrics.blocked.inc();
+        metrics
+            .policy_decision_source
+            .with_label_values(&["dns"])
+            .inc();
+        info!(
+            domain = %query.question.name,
+            decision_source = "dns",
+            action = "block",
+            "DNS policy decision"
+        );
         return Ok(build_block_response(cfg, &query, action));
     }
 
@@ -508,5 +531,12 @@ mod tests {
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 1); // ANCOUNT
         assert_eq!(&buf[n - 4..n], &[127, 0, 0, 1]);
         assert_eq!(metrics.blocked.get(), 1);
+        assert_eq!(
+            metrics
+                .policy_decision_source
+                .with_label_values(&["dns"])
+                .get(),
+            1
+        );
     }
 }

--- a/docs/analytics/clickhouse-retrosearch.md
+++ b/docs/analytics/clickhouse-retrosearch.md
@@ -130,6 +130,7 @@ LIMIT 50;
 | `domain` | Нет | Фильтр по домену |
 | `username` | Нет | Фильтр по имени пользователя |
 | `session_id` | Нет | Фильтр по сессии с хронологической сортировкой |
+| `decision_source` | Нет | Фильтр по источнику решения (`dns`, `sni`, `mitm`, `pinning-bypass`, `local-agent`) |
 | `from` | Нет | Unix timestamp начала периода |
 | `to` | Нет | Unix timestamp конца периода |
 | `days` | Нет | Глубина поиска в днях (по умолчанию 30) |
@@ -144,6 +145,9 @@ curl -s 'http://127.0.0.1:8080/api/search?domain=httpbin.org&days=7' | jq .
 
 # Экспорт результатов в CSV для SOC / ИБ-расследования
 curl -s 'http://127.0.0.1:8080/api/search?domain=malicious.org&format=csv' -o incident.csv
+
+# Проверка объёма расшифрованного трафика
+curl -s 'http://127.0.0.1:8080/api/search?decision_source=mitm&days=1' | jq .
 
 # Запрос с авторизацией по Bearer токену
 curl -H "Authorization: Bearer secret_token" \

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ Roadmap определяет порядок работ в рамках стра�
 - [x] Движок правил на уровне SNI (ClientHello) до TLS-терминирования.
 - [x] Селективный MITM по списку категорий (`MITM_CATEGORIES=malware,phishing,illegal-content`).
 - [x] Изменение порта прокси по умолчанию с `1488` на `3128`.
-- [ ] Расширенная наблюдаемость исключений (`decision_source` = `dns | sni | mitm | pinning-bypass`).
+- [x] Расширенная наблюдаемость исключений (`decision_source` = `dns | sni | mitm | pinning-bypass`).
 
 ---
 

--- a/grafana/dashboards/bsdm-proxy.json
+++ b/grafana/dashboards/bsdm-proxy.json
@@ -711,6 +711,38 @@
       ],
       "title": "Categorization blocked / enrich",
       "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 32 },
+      "id": 22,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(bsdm_proxy_policy_decision_source_total[5m])) by (source)",
+          "legendFormat": "source: {{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Policy Decision Sources (dns | sni | mitm | pinning-bypass)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -62,6 +62,7 @@ pub struct Metrics {
     pub acl_rules_matched_total: CounterVec,
     pub acl_eval_duration_seconds: Histogram,
     pub policy_cache_hit_total: Counter,
+    pub policy_decision_source_total: CounterVec,
 
     // Rate limit metrics
     pub rate_limit_rejected_total: CounterVec,
@@ -321,6 +322,15 @@ impl Metrics {
         )?;
         registry.register(Box::new(policy_cache_hit_total.clone()))?;
 
+        let policy_decision_source_total = CounterVec::new(
+            Opts::new(
+                "bsdm_proxy_policy_decision_source_total",
+                "Total policy decisions by decision source (dns, sni, mitm, pinning-bypass, auth-deny, bypass)",
+            ),
+            &["source"],
+        )?;
+        registry.register(Box::new(policy_decision_source_total.clone()))?;
+
         let rate_limit_rejected_total = CounterVec::new(
             Opts::new(
                 "bsdm_proxy_rate_limit_rejected_total",
@@ -488,6 +498,7 @@ impl Metrics {
             acl_rules_matched_total,
             acl_eval_duration_seconds,
             policy_cache_hit_total,
+            policy_decision_source_total,
             rate_limit_rejected_total,
             distributed_rate_limit_hits_total,
             global_sessions_active,
@@ -548,6 +559,16 @@ impl Metrics {
 
     pub fn record_categorization_online_enrich_scheduled(&self) {
         self.categorization_online_enrich_scheduled_total.inc();
+    }
+
+    pub fn record_policy_decision_source(&self, source: &str) {
+        let source = match source {
+            "dns" | "sni" | "mitm" | "pinning-bypass" | "auth-deny" | "local-agent" => source,
+            _ => "unknown",
+        };
+        self.policy_decision_source_total
+            .with_label_values(&[source])
+            .inc();
     }
 
     pub fn record_hierarchy_resolution(&self, result: &str) {
@@ -701,5 +722,18 @@ mod tests {
         assert!(out.contains("bsdm_proxy_categorization_blocked_total"));
         assert!(out.contains("bsdm_proxy_categorization_online_enrich_scheduled_total"));
         assert!(out.contains(r#"category="malware""#));
+    }
+
+    #[test]
+    fn policy_decision_source_metrics_are_bounded() {
+        let m = Metrics::new().unwrap();
+        m.record_policy_decision_source("mitm");
+        m.record_policy_decision_source("pinning-bypass");
+        m.record_policy_decision_source("untrusted-arbitrary-value");
+        let out = String::from_utf8(m.export().unwrap()).unwrap();
+        assert!(out.contains(r#"source="mitm"} 1"#));
+        assert!(out.contains(r#"source="pinning-bypass"} 1"#));
+        assert!(out.contains(r#"source="unknown"} 1"#));
+        assert!(!out.contains("untrusted-arbitrary-value"));
     }
 }

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -60,6 +60,64 @@ pub struct ProxyPolicy {
     pub categorization: Option<Arc<CategorizationEngine>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TlsPolicyDecision {
+    pub mitm: bool,
+    pub decision_source: &'static str,
+    pub bypass_reason: Option<&'static str>,
+}
+
+fn classify_tls_policy_decision(
+    mitm_enabled: bool,
+    pinned: bool,
+    policy_mode: crate::policy_config::PolicyMode,
+    selective_mitm: bool,
+) -> TlsPolicyDecision {
+    if !mitm_enabled {
+        return TlsPolicyDecision {
+            mitm: false,
+            decision_source: "sni",
+            bypass_reason: Some("mitm_disabled"),
+        };
+    }
+    if pinned {
+        return TlsPolicyDecision {
+            mitm: false,
+            decision_source: "pinning-bypass",
+            bypass_reason: Some("certificate_pinning_exception"),
+        };
+    }
+    match policy_mode {
+        crate::policy_config::PolicyMode::Sni => TlsPolicyDecision {
+            mitm: false,
+            decision_source: "sni",
+            bypass_reason: Some("policy_mode_sni"),
+        },
+        crate::policy_config::PolicyMode::FullMitm => TlsPolicyDecision {
+            mitm: true,
+            decision_source: "mitm",
+            bypass_reason: None,
+        },
+        crate::policy_config::PolicyMode::SelectiveMitm => TlsPolicyDecision {
+            mitm: selective_mitm,
+            decision_source: if selective_mitm { "mitm" } else { "sni" },
+            bypass_reason: if selective_mitm {
+                None
+            } else {
+                Some("category_not_selected_for_mitm")
+            },
+        },
+    }
+}
+
+fn request_decision_source(url: &str) -> &'static str {
+    if url.starts_with("https://") {
+        "mitm"
+    } else {
+        "sni"
+    }
+}
+
 /// Cloneable handles for streaming MISS completion (runs after body drained).
 #[derive(Clone)]
 struct MissCompletionHandle {
@@ -266,7 +324,7 @@ impl MissCompletionHandle {
                     redirect_url,
                     dlp_violation: None,
                     casb_alert: None,
-                    decision_source: None,
+                    decision_source: Some(request_decision_source(url).to_string()),
                     bypass_reason: None,
                     event_id,
                 };
@@ -322,39 +380,50 @@ pub struct ProxyService {
 }
 
 impl ProxyService {
-    pub fn should_mitm_domain(&self, domain: &str) -> bool {
-        if !self.mitm_enabled {
-            return false;
-        }
-
+    pub(crate) fn tls_policy_decision(&self, domain: &str) -> TlsPolicyDecision {
         let domain_lower = domain.to_ascii_lowercase();
-        if self.pinning_exceptions.iter().any(|exc| {
+        let pinned = self.pinning_exceptions.iter().any(|exc| {
             if exc.starts_with('.') {
                 domain_lower.ends_with(exc) || domain_lower == exc.trim_start_matches('.')
             } else {
                 domain_lower == *exc
             }
-        }) {
-            tracing::info!(
-                domain = %domain,
-                decision_source = "pinning-bypass",
-                bypass_reason = "certificate_pinning_exception",
-                "Skipping TLS MITM due to certificate pinning exception"
-            );
-            return false;
-        }
+        });
 
-        match self.policy_mode {
-            crate::policy_config::PolicyMode::Sni => false,
-            crate::policy_config::PolicyMode::FullMitm => true,
-            crate::policy_config::PolicyMode::SelectiveMitm => {
-                let url = format!("https://{}", domain);
-                let (categories, _) = self.categorize_url(&url);
-                categories
-                    .iter()
-                    .any(|cat| self.mitm_categories.contains(&cat.to_ascii_lowercase()))
-            }
-        }
+        let selective_mitm = if self.mitm_enabled
+            && !pinned
+            && self.policy_mode == crate::policy_config::PolicyMode::SelectiveMitm
+        {
+            let url = format!("https://{}", domain);
+            let (categories, _) = self.categorize_url(&url);
+            categories
+                .iter()
+                .any(|cat| self.mitm_categories.contains(&cat.to_ascii_lowercase()))
+        } else {
+            false
+        };
+        let decision = classify_tls_policy_decision(
+            self.mitm_enabled,
+            pinned,
+            self.policy_mode,
+            selective_mitm,
+        );
+
+        self.metrics
+            .record_policy_decision_source(decision.decision_source);
+        info!(
+            domain = %domain,
+            policy_mode = %self.policy_mode,
+            decision_source = decision.decision_source,
+            mitm = decision.mitm,
+            bypass_reason = decision.bypass_reason.unwrap_or("none"),
+            "TLS policy decision"
+        );
+        decision
+    }
+
+    pub fn should_mitm_domain(&self, domain: &str) -> bool {
+        self.tls_policy_decision(domain).mitm
     }
 
     pub fn http_cache(&self) -> Arc<HttpL1Cache> {
@@ -565,7 +634,7 @@ impl ProxyService {
                 redirect_url,
                 dlp_violation: None,
                 casb_alert: None,
-                decision_source: None,
+                decision_source: Some(request_decision_source(url).to_string()),
                 bypass_reason: None,
                 event_id,
             };
@@ -589,6 +658,14 @@ impl ProxyService {
         threat_sources: &[String],
         request_start: Instant,
     ) {
+        let decision_source = request_decision_source(url);
+        self.metrics.record_policy_decision_source(decision_source);
+        info!(
+            domain = %domain,
+            decision_source,
+            action = %decision.action,
+            "ACL policy decision"
+        );
         if let Ok(timestamp) = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
             let status = match decision.action {
                 AclAction::Deny => 403,
@@ -629,7 +706,7 @@ impl ProxyService {
                 redirect_url,
                 dlp_violation: None,
                 casb_alert: None,
-                decision_source: Some("sni".to_string()),
+                decision_source: Some(decision_source.to_string()),
                 bypass_reason: None,
                 event_id,
             };
@@ -2599,5 +2676,96 @@ impl ProxyService {
                 response
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod decision_source_tests {
+    use super::{classify_tls_policy_decision, request_decision_source, TlsPolicyDecision};
+    use crate::policy_config::PolicyMode;
+
+    #[test]
+    fn classifies_all_policy_modes_and_bypasses() {
+        let cases = [
+            (
+                false,
+                false,
+                PolicyMode::FullMitm,
+                false,
+                TlsPolicyDecision {
+                    mitm: false,
+                    decision_source: "sni",
+                    bypass_reason: Some("mitm_disabled"),
+                },
+            ),
+            (
+                true,
+                true,
+                PolicyMode::FullMitm,
+                false,
+                TlsPolicyDecision {
+                    mitm: false,
+                    decision_source: "pinning-bypass",
+                    bypass_reason: Some("certificate_pinning_exception"),
+                },
+            ),
+            (
+                true,
+                false,
+                PolicyMode::Sni,
+                false,
+                TlsPolicyDecision {
+                    mitm: false,
+                    decision_source: "sni",
+                    bypass_reason: Some("policy_mode_sni"),
+                },
+            ),
+            (
+                true,
+                false,
+                PolicyMode::FullMitm,
+                false,
+                TlsPolicyDecision {
+                    mitm: true,
+                    decision_source: "mitm",
+                    bypass_reason: None,
+                },
+            ),
+            (
+                true,
+                false,
+                PolicyMode::SelectiveMitm,
+                true,
+                TlsPolicyDecision {
+                    mitm: true,
+                    decision_source: "mitm",
+                    bypass_reason: None,
+                },
+            ),
+            (
+                true,
+                false,
+                PolicyMode::SelectiveMitm,
+                false,
+                TlsPolicyDecision {
+                    mitm: false,
+                    decision_source: "sni",
+                    bypass_reason: Some("category_not_selected_for_mitm"),
+                },
+            ),
+        ];
+
+        for (enabled, pinned, mode, selective_mitm, expected) in cases {
+            assert_eq!(
+                classify_tls_policy_decision(enabled, pinned, mode, selective_mitm),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_decrypted_and_plain_http_events() {
+        assert_eq!(request_decision_source("https://example.com/path"), "mitm");
+        assert_eq!(request_decision_source("http://example.com/path"), "sni");
     }
 }

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -29,7 +29,7 @@ use crate::control_api::ControlApiState;
 use crate::http_types::{empty, full};
 use crate::metrics::Metrics;
 use crate::pipeline::{new_event_id, CacheEvent};
-use crate::proxy_service::ProxyService;
+use crate::proxy_service::{ProxyService, TlsPolicyDecision};
 use crate::tls::{parse_authority, rewrite_mitm_request, should_mitm_port};
 
 fn tune_client_tcp(stream: &TcpStream, addr: SocketAddr) {
@@ -276,6 +276,7 @@ async fn handle_connect_tunnel(
     client_ip: String,
     request_start: Instant,
     proxy_user: Option<Arc<UserInfo>>,
+    tls_decision: TlsPolicyDecision,
 ) {
     let mut client_io = TokioIo::new(upgraded);
 
@@ -327,8 +328,13 @@ async fn handle_connect_tunnel(
                             redirect_url: None,
                             dlp_violation: None,
                             casb_alert: None,
-                            decision_source: Some("sni".to_string()),
-                            bypass_reason: Some("connect_tunnel".to_string()),
+                            decision_source: Some(tls_decision.decision_source.to_string()),
+                            bypass_reason: Some(
+                                tls_decision
+                                    .bypass_reason
+                                    .unwrap_or("connect_tunnel")
+                                    .to_string(),
+                            ),
                             event_id,
                         };
                         service.send_cache_event(event);
@@ -537,7 +543,25 @@ pub async fn handle_connection(
                         match hyper::upgrade::on(req).await {
                             Ok(upgraded) => {
                                 let (domain, port) = parse_authority(&authority);
-                                if should_mitm_port(port) && service.should_mitm_domain(&domain) {
+                                let tls_decision = if should_mitm_port(port) {
+                                    service.tls_policy_decision(&domain)
+                                } else {
+                                    service.metrics.record_policy_decision_source("sni");
+                                    info!(
+                                        domain = %domain,
+                                        port,
+                                        decision_source = "sni",
+                                        mitm = false,
+                                        bypass_reason = "non_mitm_port",
+                                        "TLS policy decision"
+                                    );
+                                    TlsPolicyDecision {
+                                        mitm: false,
+                                        decision_source: "sni",
+                                        bypass_reason: Some("non_mitm_port"),
+                                    }
+                                };
+                                if tls_decision.mitm {
                                     handle_connect_mitm(
                                         upgraded, authority, service, client_ip, proxy_user,
                                     )
@@ -550,6 +574,7 @@ pub async fn handle_connection(
                                         client_ip,
                                         request_start,
                                         proxy_user,
+                                        tls_decision,
                                     )
                                     .await;
                                 }

--- a/scripts/clickhouse/http_cache.sql
+++ b/scripts/clickhouse/http_cache.sql
@@ -28,13 +28,22 @@ CREATE TABLE IF NOT EXISTS bsdm.http_cache
     redirect_url Nullable(String),
     headers String DEFAULT '{}',
     dlp_violation Nullable(String),
-    casb_alert Nullable(String)
+    casb_alert Nullable(String),
+    decision_source LowCardinality(Nullable(String)),
+    bypass_reason Nullable(String)
 )
 ENGINE = MergeTree
 PARTITION BY toYYYYMMDD(ts)
 ORDER BY (domain, ifNull(username, ''), ts, event_id)
 TTL toDateTime(ts) + INTERVAL 42 DAY
 SETTINGS index_granularity = 8192;
+
+-- Upgrade existing installations created before decision-source observability.
+ALTER TABLE bsdm.http_cache
+    ADD COLUMN IF NOT EXISTS decision_source LowCardinality(Nullable(String));
+
+ALTER TABLE bsdm.http_cache
+    ADD COLUMN IF NOT EXISTS bypass_reason Nullable(String);
 
 -- M3: who accessed domain X (30 days)
 -- SELECT ts, username, client_ip, url, method, status, cache_status, session_id


### PR DESCRIPTION
Closes #265

## What changed

- records structured `decision_source` decisions for DNS, SNI, Selective/Full MITM, and certificate-pinning bypass paths
- exports bounded `bsdm_proxy_policy_decision_source_total{source}` counters without coupling metrics to analytics event sampling
- preserves `decision_source` and `bypass_reason` in CONNECT, decrypted HTTPS, HTTP, cache-hit, cache-miss, and ACL analytics events
- adds `decision_source` filtering and CSV output to the Search API for memory, SQLite, and ClickHouse backends
- adds backward-compatible SQLite and ClickHouse schema upgrades for existing installations
- adds a Grafana policy decision-source breakdown panel and updates analytics documentation/roadmap

## Why

Hybrid Policy decisions were only partially observable. Operators could not reliably quantify Selective MITM volume, distinguish SNI tunnels from pinning exceptions, or filter historical traffic by the enforcement layer that produced the decision.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `python3 scripts/check-doc-links.py`
- Grafana dashboard JSON validation with `jq`
- `git diff --check`

The full suite includes coverage for every `POLICY_MODE`, bounded metric labels, DNS source metrics, Search API storage filters, and migration of an existing SQLite schema.