### PR TITLE
Align Admin Console with supported Hybrid UI scope

### DIFF
--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -24,17 +24,31 @@ Replaces the legacy static [`web-config/`](../web-config/) generator with a mode
 | `/logs` | Retro-search with server+client filters, live tail, pagination, CSV export, session timeline, XAI modal |
 | `/analytics` | Aggregations over the search sample: traffic over time, status/cache/decision mix, top talkers, threat severity |
 | `/threat-scores` | ML write-back snapshot with model filter and traffic drill-down |
-| `/policies` | Runtime ACL rules viewer / reload |
+| `/security` | Supported data-security controls |
+| `/policies` | Runtime ACL rules viewer / reload / persist |
+| `/rpz` | DNS policy management |
+| `/users` | Basic-auth user management |
 | `/settings` | Live node state + config generator (cache, auth, filtering, threat/ML, hierarchy/TLS, rate-limit/eBPF/Wasm, events) |
+
+The default sidebar only advertises the supported Hybrid operator paths above.
+Frozen modules remain directly routable for development and compatibility, but
+are intentionally hidden from primary navigation:
+
+- `/wasm`
+- `/cluster`
+- `/ai-cache`
+- `/amneziawg`
+
+Their product status is defined in [`docs/project-status.md`](../docs/project-status.md).
 
 ## Data honesty
 
 Every fetcher returns `Sourced<T>` — payload plus provenance (`live` or `demo`).
 A failed request renders a real **error state**; sample data appears **only**
 when the user enables demo mode (Settings → Console API), and is always marked
-with a "Demo" badge. Pages whose backend endpoints don't exist yet (RPZ, Wasm,
-Cluster Mesh, AI Cache, eBPF stats) carry an explicit "Preview — no backend
-endpoint" banner.
+with a "Demo" badge. Developer-only frozen routes carry an explicit preview
+banner when their backend endpoint is not available. Frozen eBPF content is not
+shown on the core Policies workflow.
 
 ## Quick start
 
@@ -74,7 +88,19 @@ Configure base URLs under **Settings → API**. Empty base URLs use Vite dev-ser
 
 Passwords and API tokens are **not** persisted to `localStorage` — they remain in memory for the current browser session only.
 
-When APIs are unreachable, the console shows **demo data** so layouts and XAI components remain testable offline.
+When APIs are unreachable, the console shows an explicit error unless the
+operator has deliberately enabled demo mode.
+
+## Identity and version
+
+The shell identifies itself as a **local, unauthenticated console** until a real
+authentication/session contract is implemented. It does not fabricate an AD
+user or role. API tokens configured under Settings authorize individual backend
+requests; they do not create a UI identity.
+
+The displayed product version is injected at build time from
+[`proxy/Cargo.toml`](../proxy/Cargo.toml), the same manifest used to build the
+proxy binary.
 
 ## UI/UX deliverables
 

--- a/admin-console/src/components/layout/AppLayout.tsx
+++ b/admin-console/src/components/layout/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
-import { Menu, Search, Command, ShieldCheck, ChevronRight } from 'lucide-react'
+import { Menu, Search, Command, ShieldAlert, ChevronRight } from 'lucide-react'
 import { Sidebar } from './Sidebar'
 import { CommandPalette } from '../ui/CommandPalette'
 
@@ -30,7 +30,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     '/wasm': { title: 'Wasm Plugins', category: 'Extensions' },
     '/cluster': { title: 'Cluster Mesh', category: 'Extensions' },
     '/ai-cache': { title: 'AI Semantic Cache', category: 'Extensions' },
-    '/users': { title: 'Active Directory Users', category: 'System' },
+    '/users': { title: 'Users', category: 'System' },
     '/settings': { title: 'Console Settings', category: 'System' },
   }
 
@@ -63,9 +63,9 @@ export function AppLayout({ children }: AppLayoutProps) {
           </div>
 
           <div className="flex items-center gap-3">
-            <div className="hidden sm:flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-success/30 bg-success/10 text-success text-xs font-semibold">
-              <ShieldCheck className="size-3.5" />
-              <span>Node Protected</span>
+            <div className="hidden sm:flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-warning/30 bg-warning/10 text-warning text-xs font-semibold">
+              <ShieldAlert className="size-3.5" />
+              <span>Unauthenticated UI</span>
             </div>
 
             <button
@@ -89,5 +89,4 @@ export function AppLayout({ children }: AppLayoutProps) {
     </div>
   )
 }
-
 

--- a/admin-console/src/components/layout/Sidebar.tsx
+++ b/admin-console/src/components/layout/Sidebar.tsx
@@ -11,18 +11,15 @@ import {
   Brain,
   FlaskConical,
   Radio,
-  Cpu,
-  Network,
-  Sparkles,
   Sun,
   Moon,
   User,
   ChevronRight,
   Languages,
   ShieldAlert,
-  Smartphone,
 } from 'lucide-react'
 import { isDemoMode } from '../../api/source'
+import { APP_VERSION } from '../../lib/build'
 import { applyTheme, loadTheme, type Theme } from '../../lib/theme'
 import { useLanguage, translations } from '../../lib/i18n'
 import { UserProfileModal } from './UserProfileModal'
@@ -56,15 +53,6 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         { to: '/security', label: t.nav.security, icon: ShieldAlert },
         { to: '/policies', label: t.nav.policies, icon: Shield },
         { to: '/rpz', label: t.nav.rpz, icon: Radio },
-      ],
-    },
-    {
-      title: lang === 'ru' ? 'Расширения & Кластер' : 'Extensions & Mesh',
-      items: [
-        { to: '/wasm', label: t.nav.wasm, icon: Cpu },
-        { to: '/cluster', label: t.nav.cluster, icon: Network },
-        { to: '/ai-cache', label: t.nav.aiCache, icon: Sparkles },
-        { to: '/amneziawg', label: 'AmneziaWG Connect', icon: Smartphone },
       ],
     },
     {
@@ -109,14 +97,10 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <div className="flex items-center gap-2.5">
             <div className="relative flex items-center justify-center size-8 rounded-lg bg-accent/15 border border-accent/30 text-accent shadow-glow-accent">
               <Activity className="size-5" />
-              <span className="absolute -top-0.5 -right-0.5 flex size-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-75"></span>
-                <span className="relative inline-flex size-2 rounded-full bg-success"></span>
-              </span>
             </div>
             <div>
               <span className="font-bold text-text-primary text-sm tracking-tight block">BSDM Console</span>
-              <span className="text-[10px] text-text-secondary font-mono leading-none">v0.6 · proxy-node</span>
+              <span className="text-[10px] text-text-secondary font-mono leading-none">v{APP_VERSION} · admin-console</span>
             </div>
           </div>
           <div className="flex items-center gap-1">
@@ -199,8 +183,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
                 <User className="size-4" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs font-bold text-text-primary truncate">admin.user</p>
-                <p className="text-[10px] text-text-secondary truncate">{t.header.activeDirectory}</p>
+                <p className="text-xs font-bold text-text-primary truncate">
+                  {lang === 'ru' ? 'Локальная консоль' : 'Local console'}
+                </p>
+                <p className="text-[10px] text-warning truncate">
+                  {lang === 'ru' ? 'Без аутентифицированной сессии' : 'No authenticated session'}
+                </p>
               </div>
             </div>
             <ChevronRight className="size-4 text-text-secondary group-hover:text-accent shrink-0 transition-transform group-hover:translate-x-0.5" />
@@ -219,4 +207,3 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     </>
   )
 }
-

--- a/admin-console/src/components/layout/UserProfileModal.tsx
+++ b/admin-console/src/components/layout/UserProfileModal.tsx
@@ -1,20 +1,12 @@
 import { useState } from 'react'
-import {
-  User,
-  ShieldCheck,
-  Key,
-  Globe,
-  Clock,
-  LogOut,
-  Moon,
-  Sun,
-  CheckCircle2,
-  Lock,
-  ShieldAlert,
-} from 'lucide-react'
-import { Modal } from '../ui/Modal'
+import { KeyRound, MonitorCog, Moon, Settings, ShieldAlert, Sun } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { loadApiSettings } from '../../api/settings'
+import { APP_VERSION } from '../../lib/build'
+import { useLanguage } from '../../lib/i18n'
+import { applyTheme, loadTheme, type Theme } from '../../lib/theme'
 import { Button } from '../ui/Button'
-import { loadTheme, applyTheme, type Theme } from '../../lib/theme'
+import { Modal } from '../ui/Modal'
 
 interface UserProfileModalProps {
   open: boolean
@@ -23,6 +15,11 @@ interface UserProfileModalProps {
 
 export function UserProfileModal({ open, onClose }: UserProfileModalProps) {
   const [theme, setTheme] = useState<Theme>(loadTheme)
+  const [lang] = useLanguage()
+  const navigate = useNavigate()
+  const settings = loadApiSettings()
+  const hasApiCredentials = Boolean(settings.searchToken || settings.aclToken || settings.controlToken)
+  const ru = lang === 'ru'
 
   const toggleTheme = () => {
     const next = theme === 'dark' ? 'light' : 'dark'
@@ -30,123 +27,112 @@ export function UserProfileModal({ open, onClose }: UserProfileModalProps) {
     applyTheme(next)
   }
 
-  // Simulated active user identity info extracted from current session/headers
-  const user = {
-    username: 'admin.user',
-    displayName: 'Администратор Безопасности (AD User)',
-    email: 'admin.security@company.local',
-    domain: 'CORP.LOCAL',
-    authMethod: 'Active Directory / NTLM & OIDC',
-    role: 'System Administrator (Full Access)',
-    ipAddress: '127.0.0.1',
-    sessionCreated: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-    permissions: [
-      'ZTNA / IAP Reverse Proxy Control',
-      'Active Directory / LDAP Sync',
-      'ACL & Content Filtering Engine',
-      'ML Threat & UEBA Score Management',
-      'Kernel eBPF & Wasm Hooks',
-      'Kafka / ClickHouse Analytics Access',
-    ],
-  }
-
-  const handleLogout = () => {
-    document.cookie = 'bsdm_session=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;'
-    window.location.reload()
+  const openSettings = () => {
+    onClose()
+    navigate('/settings')
   }
 
   return (
-    <Modal open={open} onClose={onClose} title="Профиль пользователя & Сессия" wide>
-      <div className="space-y-6">
-        {/* User Card Header */}
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 rounded-xl border border-accent/30 bg-accent/10 p-4">
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={ru ? 'Доступ к консоли' : 'Console access'}
+      wide
+    >
+      <div className="space-y-5">
+        <div className="flex flex-col items-start justify-between gap-4 rounded-xl border border-warning/40 bg-warning/10 p-4 sm:flex-row sm:items-center">
           <div className="flex items-center gap-4">
-            <div className="flex size-14 items-center justify-center rounded-full bg-accent/20 text-accent font-bold text-xl border border-accent/40 shadow-inner">
-              <User className="size-7" />
+            <div className="flex size-12 shrink-0 items-center justify-center rounded-full border border-warning/40 bg-warning/15 text-warning">
+              <ShieldAlert className="size-6" />
             </div>
             <div>
-              <div className="flex items-center gap-2">
-                <h3 className="text-lg font-bold text-text-primary">{user.displayName}</h3>
-                <span className="rounded-full bg-accent/20 px-2 py-0.5 text-xs font-semibold text-accent border border-accent/30">
-                  AD / SSO Active
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="text-lg font-bold text-text-primary">
+                  {ru ? 'Локальная консоль' : 'Local console'}
+                </h3>
+                <span className="rounded-full border border-warning/40 bg-warning/15 px-2 py-0.5 text-xs font-semibold text-warning">
+                  {ru ? 'Без аутентификации' : 'Unauthenticated'}
                 </span>
               </div>
-              <p className="text-xs text-text-secondary">
-                {user.email} · <span className="font-mono">{user.domain}</span>
+              <p className="mt-1 text-xs text-text-secondary">
+                {ru
+                  ? 'Backend не предоставляет этой UI подтверждённую личность пользователя или роль.'
+                  : 'The backend does not provide this UI with a verified user identity or role.'}
               </p>
             </div>
           </div>
-          <Button
-            type="button"
-            variant="secondary"
-            className="text-xs shrink-0"
-            onClick={toggleTheme}
-          >
+          <Button type="button" variant="secondary" className="shrink-0 text-xs" onClick={toggleTheme}>
             {theme === 'dark' ? (
               <>
-                <Sun className="size-4 text-warning" /> Светлая тема
+                <Sun className="size-4 text-warning" /> {ru ? 'Светлая тема' : 'Light theme'}
               </>
             ) : (
               <>
-                <Moon className="size-4 text-accent" /> Тёмная тема
+                <Moon className="size-4 text-accent" /> {ru ? 'Тёмная тема' : 'Dark theme'}
               </>
             )}
           </Button>
         </div>
 
-        {/* Grid Session Info */}
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="rounded-lg border border-border bg-surface-1 p-3.5 space-y-1">
-            <div className="flex items-center gap-2 text-xs font-semibold text-text-secondary">
-              <Key className="size-3.5 text-accent" /> Метод аутентификации
-            </div>
-            <p className="text-sm font-medium text-text-primary">{user.authMethod}</p>
-          </div>
-          <div className="rounded-lg border border-border bg-surface-1 p-3.5 space-y-1">
-            <div className="flex items-center gap-2 text-xs font-semibold text-text-secondary">
-              <ShieldCheck className="size-3.5 text-accent" /> Роль в системе
-            </div>
-            <p className="text-sm font-medium text-text-primary">{user.role}</p>
-          </div>
-          <div className="rounded-lg border border-border bg-surface-1 p-3.5 space-y-1">
-            <div className="flex items-center gap-2 text-xs font-semibold text-text-secondary">
-              <Globe className="size-3.5 text-accent" /> IP-адрес клиента
-            </div>
-            <p className="font-mono text-sm font-medium text-text-primary">{user.ipAddress}</p>
-          </div>
-          <div className="rounded-lg border border-border bg-surface-1 p-3.5 space-y-1">
-            <div className="flex items-center gap-2 text-xs font-semibold text-text-secondary">
-              <Clock className="size-3.5 text-accent" /> Время старта сессии
-            </div>
-            <p className="text-sm font-medium text-text-primary">{user.sessionCreated} (Активна)</p>
-          </div>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatusCard
+            icon={MonitorCog}
+            label={ru ? 'Режим доступа' : 'Access mode'}
+            value={ru ? 'Локальная browser-сессия' : 'Local browser session'}
+          />
+          <StatusCard
+            icon={KeyRound}
+            label={ru ? 'API credentials' : 'API credentials'}
+            value={
+              hasApiCredentials
+                ? (ru ? 'Заданы для этой вкладки' : 'Configured for this tab')
+                : (ru ? 'Не заданы' : 'Not configured')
+            }
+            warning={!hasApiCredentials}
+          />
+          <StatusCard
+            icon={Settings}
+            label={ru ? 'Версия продукта' : 'Product version'}
+            value={`v${APP_VERSION}`}
+          />
         </div>
 
-        {/* Granted Permissions List */}
-        <div className="space-y-3 rounded-xl border border-border bg-surface-1 p-4">
-          <h4 className="flex items-center gap-2 text-sm font-bold text-text-primary">
-            <Lock className="size-4 text-accent" /> Назначенные привилегии и разрешения
-          </h4>
-          <div className="grid gap-2 sm:grid-cols-2 text-xs">
-            {user.permissions.map((perm, idx) => (
-              <div key={idx} className="flex items-center gap-2 rounded-md bg-surface-0 px-3 py-2 border border-border/50 text-text-primary">
-                <CheckCircle2 className="size-4 shrink-0 text-accent" />
-                <span>{perm}</span>
-              </div>
-            ))}
-          </div>
+        <div className="rounded-lg border border-border bg-surface-1 p-4 text-sm text-text-secondary">
+          {ru
+            ? 'API-токены авторизуют отдельные запросы к сервисам, но не создают пользовательскую сессию в Admin Console. Не публикуйте консоль в недоверенную сеть без внешнего access gateway.'
+            : 'API tokens authorize individual service requests; they do not create an Admin Console user session. Do not expose the console to an untrusted network without an external access gateway.'}
         </div>
 
-        {/* Footer Actions */}
         <div className="flex items-center justify-between border-t border-border pt-4">
-          <span className="text-xs text-text-secondary flex items-center gap-1">
-            <ShieldAlert className="size-3.5 text-accent" /> BSDM ZTNA Security Subsystem v0.6
-          </span>
-          <Button variant="danger" onClick={handleLogout} className="text-xs">
-            <LogOut className="size-4" /> Завершить сессию (Logout)
+          <span className="text-xs text-text-secondary">BSDM Admin Console v{APP_VERSION}</span>
+          <Button variant="primary" onClick={openSettings} className="text-xs">
+            <Settings className="size-4" />
+            {ru ? 'Открыть настройки API' : 'Open API settings'}
           </Button>
         </div>
       </div>
     </Modal>
+  )
+}
+
+function StatusCard({
+  icon: Icon,
+  label,
+  value,
+  warning = false,
+}: {
+  icon: typeof MonitorCog
+  label: string
+  value: string
+  warning?: boolean
+}) {
+  return (
+    <div className="space-y-1 rounded-lg border border-border bg-surface-1 p-3.5">
+      <div className="flex items-center gap-2 text-xs font-semibold text-text-secondary">
+        <Icon className={`size-3.5 ${warning ? 'text-warning' : 'text-accent'}`} />
+        {label}
+      </div>
+      <p className={`text-sm font-medium ${warning ? 'text-warning' : 'text-text-primary'}`}>{value}</p>
+    </div>
   )
 }

--- a/admin-console/src/components/ui/CommandPalette.tsx
+++ b/admin-console/src/components/ui/CommandPalette.tsx
@@ -9,9 +9,6 @@ import {
   Brain,
   BarChart3,
   Radio,
-  Cpu,
-  Network,
-  Sparkles,
   User,
   Command,
   ArrowRight,
@@ -37,10 +34,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
     { to: '/security', title: t.nav.security, desc: 'Security policies & DLP rules', icon: Shield },
     { to: '/policies', title: t.nav.policies, desc: 'ACL configuration rules & IP blocks', icon: Shield },
     { to: '/rpz', title: t.nav.rpz, desc: 'Response Policy Zone DNS filtering', icon: Radio },
-    { to: '/wasm', title: t.nav.wasm, desc: 'Wasm plugin manager & dynamic extensions', icon: Cpu },
-    { to: '/cluster', title: t.nav.cluster, desc: 'Cluster Mesh topology & peer synchronization', icon: Network },
-    { to: '/ai-cache', title: t.nav.aiCache, desc: 'AI Semantic caching & LLM token stats', icon: Sparkles },
-    { to: '/users', title: t.nav.users, desc: 'Active Directory users & proxy permissions', icon: User },
+    { to: '/users', title: t.nav.users, desc: 'Basic authentication users & proxy roles', icon: User },
     { to: '/settings', title: t.nav.settings, desc: 'Live node configuration & export options', icon: Settings },
   ]
 

--- a/admin-console/src/lib/build.ts
+++ b/admin-console/src/lib/build.ts
@@ -1,0 +1,4 @@
+declare const __APP_VERSION__: string
+
+/** Product version injected from proxy/Cargo.toml by Vite at build time. */
+export const APP_VERSION = __APP_VERSION__

--- a/admin-console/src/lib/i18n.ts
+++ b/admin-console/src/lib/i18n.ts
@@ -56,9 +56,7 @@ export const translations = {
     header: {
       brand: 'BSDM Консоль управления',
       profile: 'Профиль пользователя',
-      activeDirectory: 'Active Directory SSO',
       demoMode: 'Демо-режим',
-      version: 'Единая панель управления · v0.6',
       switchLang: 'Переключить на English',
     },
     // General Actions & Statuses
@@ -153,14 +151,6 @@ export const translations = {
       type: 'Тип',
       action: 'Действие',
       status: 'Статус',
-      ebpfTitle: 'Обход сброса пакетов ядра eBPF / XDP (Уровень L4)',
-      xdpMode: 'Режим Kernel XDP',
-      zeroCpuDrops: 'Отброшено пакетов (Zero-CPU)',
-      dropLatency: 'Задержка сброса ядром',
-      blockedIp: 'Заблокированный IP-адрес',
-      reason: 'Причина / Правило',
-      packetsDropped: 'Отброшено пакетов',
-      addedDate: 'Дата добавления',
       liveCrud: 'Live CRUD на порту метрик:',
     },
     // Analytics Page
@@ -312,9 +302,7 @@ export const translations = {
     header: {
       brand: 'BSDM Console',
       profile: 'User Profile',
-      activeDirectory: 'Active Directory SSO',
       demoMode: 'Demo mode',
-      version: 'Single pane of glass · v0.6',
       switchLang: 'Switch to Russian',
     },
     // General Actions & Statuses
@@ -409,14 +397,6 @@ export const translations = {
       type: 'Type',
       action: 'Action',
       status: 'Status',
-      ebpfTitle: 'eBPF / XDP Kernel Packet Drop Bypass (L4 Hardware Layer)',
-      xdpMode: 'Kernel XDP Mode',
-      zeroCpuDrops: 'Zero-CPU Packets Dropped',
-      dropLatency: 'Kernel Drop Latency',
-      blockedIp: 'Blocked IP Address',
-      reason: 'Reason / Rule',
-      packetsDropped: 'Packets Dropped',
-      addedDate: 'Added Date',
       liveCrud: 'Live CRUD on metrics port:',
     },
     // Analytics Page

--- a/admin-console/src/pages/Policies.tsx
+++ b/admin-console/src/pages/Policies.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { RefreshCw, RotateCcw, Save, Trash2, Cpu, Zap } from 'lucide-react'
+import { RefreshCw, RotateCcw, Save, Trash2 } from 'lucide-react'
 import {
   deleteAclRule,
   fetchAclRules,
@@ -8,10 +8,8 @@ import {
   type AclRule,
   type AclRulesResponse,
 } from '../api/acl'
-import { fetchEbpfStats, fetchEbpfBlockedIps, type EbpfStats, type EbpfBlockedIp } from '../api/ebpf'
 import { Button } from '../components/ui/Button'
 import { Panel } from '../components/dashboard/MetricWidget'
-import { PreviewBanner } from '../components/ui/DataState'
 import { useToast } from '../components/ui/Toast'
 import { useLanguage, translations } from '../lib/i18n'
 
@@ -21,21 +19,12 @@ export function PoliciesPage() {
 
   const { toast } = useToast()
   const [data, setData] = useState<AclRulesResponse | null>(null)
-  const [ebpfStats, setEbpfStats] = useState<EbpfStats | null>(null)
-  const [ebpfIps, setEbpfIps] = useState<EbpfBlockedIp[]>([])
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
 
   const load = async () => {
     setLoading(true)
-    const [aclData, st, ips] = await Promise.all([
-      fetchAclRules(),
-      fetchEbpfStats(),
-      fetchEbpfBlockedIps(),
-    ])
-    setData(aclData)
-    setEbpfStats(st)
-    setEbpfIps(ips)
+    setData(await fetchAclRules())
     setLoading(false)
   }
 
@@ -175,69 +164,6 @@ export function PoliciesPage() {
         </div>
       </Panel>
 
-
-      {/* eBPF XDP Kernel Bypass Panel */}
-      <Panel title={tr.policies.ebpfTitle}>
-        <div className="space-y-4">
-          <PreviewBanner feature="The eBPF/XDP stats view" />
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <div className="rounded-md border border-border bg-surface-0 p-3">
-              <div className="flex items-center justify-between text-xs text-text-secondary">
-                <span>{tr.policies.xdpMode}</span>
-                <span className="rounded bg-success/20 px-2 py-0.5 font-mono text-[10px] font-bold text-success">
-                  {ebpfStats?.enabled ? 'ACTIVE' : 'STUB / OFF'}
-                </span>
-              </div>
-              <div className="mt-2 text-lg font-bold font-mono text-text-primary">
-                {ebpfStats?.mode?.toUpperCase() || 'DRIVER'} ({ebpfStats?.interface || 'eth0'})
-              </div>
-            </div>
-
-            <div className="rounded-md border border-border bg-surface-0 p-3">
-              <div className="flex items-center justify-between text-xs text-text-secondary">
-                <span>{tr.policies.zeroCpuDrops}</span>
-                <Zap className="size-4 text-accent" />
-              </div>
-              <div className="mt-2 text-lg font-bold font-mono text-text-primary">
-                {ebpfStats?.packetsDroppedTotal?.toLocaleString() || '184,250'} pkts
-              </div>
-            </div>
-
-            <div className="rounded-md border border-border bg-surface-0 p-3">
-              <div className="flex items-center justify-between text-xs text-text-secondary">
-                <span>{tr.policies.dropLatency}</span>
-                <Cpu className="size-4 text-success" />
-              </div>
-              <div className="mt-2 text-lg font-bold font-mono text-success">
-                {ebpfStats?.kernelLatencyUs || 0.45} µs (0% Userspace CPU)
-              </div>
-            </div>
-          </div>
-
-          <div className="overflow-x-auto">
-            <table className="w-full text-left text-xs">
-              <thead className="border-b border-border text-text-secondary uppercase">
-                <tr>
-                  <th className="py-2 pr-4">{tr.policies.blockedIp}</th>
-                  <th className="py-2 pr-4">{tr.policies.reason}</th>
-                  <th className="py-2 pr-4">{tr.policies.packetsDropped}</th>
-                  <th className="py-2">{tr.policies.addedDate}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50 text-text-primary font-mono">
-                {ebpfIps.map((item) => (
-                  <tr key={item.id}>
-                    <td className="py-2 pr-4 text-accent font-bold">{item.ip}</td>
-                    <td className="py-2 pr-4 font-sans text-text-secondary">{item.reason}</td>
-                    <td className="py-2 pr-4 text-text-primary font-bold">{item.packetsDropped.toLocaleString()}</td>
-                    <td className="py-2 text-text-secondary">{new Date(item.addedAt).toLocaleTimeString()}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </Panel>
 
       <div className="rounded-lg border border-border bg-surface-0 p-4 text-sm text-text-secondary">
         {tr.policies.liveCrud}{' '}

--- a/admin-console/vite.config.ts
+++ b/admin-console/vite.config.ts
@@ -1,12 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'node:fs'
+
+const proxyManifest = readFileSync(new URL('../proxy/Cargo.toml', import.meta.url), 'utf8')
+const appVersion = proxyManifest.match(/^version\s*=\s*"([^"]+)"/m)?.[1]
+
+if (!appVersion) {
+  throw new Error('Unable to read BSDM product version from proxy/Cargo.toml')
+}
 
 const bearerHeaders = (token: string | undefined) =>
   token ? { Authorization: `Bearer ${token}` } : undefined
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+  },
   base: '/',
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary

- hide frozen Wasm, Cluster, AI Cache, and AmneziaWG modules from the sidebar and command palette while preserving their direct routes for developers
- remove the frozen eBPF/XDP preview panel and synthetic statistics from the core Policies workflow
- replace fabricated AD identity and protection state with an explicit local/unauthenticated console status
- inject the displayed product version from `proxy/Cargo.toml` at build time
- document the supported navigation, frozen routes, identity model, and data-error behavior

## Why

The Admin Console presented frozen experiments as supported product surfaces, mixed preview data into live ACL controls, and displayed a fabricated user and stale version. This made it difficult for operators to tell which controls and status were real.

## Impact

The default operator surface now matches the supported Hybrid path. Experimental routes remain available by direct URL, Policies is ACL-only, and the shell clearly states the current authentication limitations and product version.

## Validation

- `npm run lint` (passes; existing Fast Refresh warning in `Toast.tsx`)
- `npm run build`
- browser smoke: sidebar and command palette contain only supported routes
- browser smoke: `/policies` contains no eBPF or Preview content
- browser smoke: access modal reports unauthenticated local console and v0.8.0

Closes #274
Closes #277
Closes #278