### PR TITLE
Simplify Admin Console API connection

### DIFF
--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -82,14 +82,27 @@ The UI talks to existing BSDM REST endpoints (no backend changes required):
 | `GET /api/search` | `:8080` | Logs |
 | `GET/POST /api/acl/*` | `:9090` | Policies |
 | `GET /metrics` | `:9090` | Dashboard |
-| `GET /api/ml/scores` | `:8091` | Dashboard (future; mock fallback) |
+| `GET /api/threat-scores` | `:8091` | Dashboard / Threat Scores |
 
-Configure base URLs under **Settings → API**. Empty base URLs use Vite dev-server proxies defined in `vite.config.ts`.
+Configure the connection under **Settings → Console API**:
 
-Passwords and API tokens are **not** persisted to `localStorage` — they remain in memory for the current browser session only.
+- **Single endpoint** (default) — one Control Plane base URL and token. The
+  deployment gateway must route `/api/search`, `/api/acl`, `/api/stats`,
+  `/api/threat-scores`, and `/metrics` on the same origin.
+- **Advanced split deployment** — independent Search, ACL, Control/Metrics, and
+  ML worker base URLs with the existing Search, ACL, and Control tokens.
 
-When APIs are unreachable, the console shows an explicit error unless the
-operator has deliberately enabled demo mode.
+An empty single-endpoint URL uses same-origin paths; Vite maps those paths to
+the local development services defined in `vite.config.ts`. Existing saved
+multi-URL configurations are migrated to Advanced mode.
+
+Use **Test connection** to run read-only health probes for every dependency.
+Each service is reported as connected, unauthorized, or unreachable.
+
+Passwords and API tokens are **not** persisted to `localStorage` — they remain
+in memory for the current browser tab only. When APIs are unreachable, the
+console shows an explicit service error unless the operator has deliberately
+enabled demo mode.
 
 ## Identity and version
 

--- a/admin-console/src/api/acl.ts
+++ b/admin-console/src/api/acl.ts
@@ -1,4 +1,5 @@
 import { apiFetch, aclClient } from './client'
+import { isDemoMode } from './source'
 
 export interface AclRule {
   id: string
@@ -20,8 +21,9 @@ export async function fetchAclRules(): Promise<AclRulesResponse> {
   const { baseUrl, token } = aclClient()
   try {
     return await apiFetch<AclRulesResponse>('/api/acl/rules', { baseUrl, token })
-  } catch {
-    return mockRules()
+  } catch (error) {
+    if (isDemoMode()) return mockRules()
+    throw error
   }
 }
 

--- a/admin-console/src/api/client.ts
+++ b/admin-console/src/api/client.ts
@@ -1,4 +1,4 @@
-import { loadApiSettings } from './settings'
+import { resolveApiSettings } from './settings'
 
 export class ApiError extends Error {
   status: number
@@ -53,7 +53,7 @@ export async function apiFetch<T>(
 }
 
 export function searchClient() {
-  const s = loadApiSettings()
+  const s = resolveApiSettings()
   return {
     baseUrl: s.searchBaseUrl,
     token: s.searchToken,
@@ -61,7 +61,7 @@ export function searchClient() {
 }
 
 export function aclClient() {
-  const s = loadApiSettings()
+  const s = resolveApiSettings()
   return {
     baseUrl: s.aclBaseUrl,
     token: s.aclToken,
@@ -69,7 +69,7 @@ export function aclClient() {
 }
 
 export function controlClient() {
-  const s = loadApiSettings()
+  const s = resolveApiSettings()
   return {
     baseUrl: s.metricsBaseUrl,
     token: s.controlToken,

--- a/admin-console/src/api/health.ts
+++ b/admin-console/src/api/health.ts
@@ -1,0 +1,110 @@
+import { ApiError, apiFetch } from './client'
+import { resolveApiSettings, type ApiSettings } from './settings'
+
+export type ApiServiceId = 'control' | 'acl' | 'search' | 'ml'
+export type ApiHealthStatus = 'healthy' | 'unauthorized' | 'unreachable'
+
+export interface ApiHealthResult {
+  id: ApiServiceId
+  name: string
+  endpoint: string
+  status: ApiHealthStatus
+  detail: string
+}
+
+interface Probe {
+  id: ApiServiceId
+  name: string
+  path: string
+  baseUrl: string
+  token: string
+}
+
+const HEALTH_TIMEOUT_MS = 5_000
+
+/** Read-only probes for every service consumed by Admin Console. */
+export async function checkApiHealth(settings: ApiSettings): Promise<ApiHealthResult[]> {
+  const resolved = resolveApiSettings(settings)
+  const probes: Probe[] = [
+    {
+      id: 'control',
+      name: 'Control / Metrics',
+      path: '/api/stats',
+      baseUrl: resolved.metricsBaseUrl,
+      token: resolved.controlToken,
+    },
+    {
+      id: 'acl',
+      name: 'ACL',
+      path: '/api/acl/rules',
+      baseUrl: resolved.aclBaseUrl,
+      token: resolved.aclToken,
+    },
+    {
+      id: 'search',
+      name: 'Search',
+      path: '/api/search?limit=1',
+      baseUrl: resolved.searchBaseUrl,
+      token: resolved.searchToken,
+    },
+    {
+      id: 'ml',
+      name: 'ML worker',
+      path: '/api/threat-scores',
+      baseUrl: resolved.mlBaseUrl,
+      token: resolved.mlToken,
+    },
+  ]
+
+  return Promise.all(probes.map(runProbe))
+}
+
+async function runProbe(probe: Probe): Promise<ApiHealthResult> {
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS)
+  const endpoint = `${probe.baseUrl || window.location.origin}${probe.path}`
+
+  try {
+    await apiFetch<unknown>(probe.path, {
+      baseUrl: probe.baseUrl,
+      token: probe.token,
+      signal: controller.signal,
+    })
+    return {
+      id: probe.id,
+      name: probe.name,
+      endpoint,
+      status: 'healthy',
+      detail: 'Connected',
+    }
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+      return {
+        id: probe.id,
+        name: probe.name,
+        endpoint,
+        status: 'unauthorized',
+        detail: `HTTP ${error.status} — credentials rejected`,
+      }
+    }
+
+    const detail =
+      error instanceof ApiError
+        ? `HTTP ${error.status}`
+        : error instanceof DOMException && error.name === 'AbortError'
+          ? `Timed out after ${HEALTH_TIMEOUT_MS / 1000}s`
+          : error instanceof Error
+            ? error.message
+            : 'Connection failed'
+
+    return {
+      id: probe.id,
+      name: probe.name,
+      endpoint,
+      status: 'unreachable',
+      detail,
+    }
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}

--- a/admin-console/src/api/metrics.ts
+++ b/admin-console/src/api/metrics.ts
@@ -1,4 +1,4 @@
-import { loadApiSettings } from './settings'
+import { resolveApiSettings } from './settings'
 import { apiFetch } from './client'
 import { demo, live, isDemoMode, type Sourced } from './source'
 import { groupByLabel, histogram, histogramQuantile, scrapeMetrics, sumMetric, type PromSample } from './prometheus'
@@ -52,9 +52,12 @@ export interface Telemetry {
 }
 
 export async function fetchProxyStats(): Promise<ProxyStats | null> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   try {
-    return await apiFetch<ProxyStats>('/api/stats', { baseUrl: settings.metricsBaseUrl })
+    return await apiFetch<ProxyStats>('/api/stats', {
+      baseUrl: settings.metricsBaseUrl,
+      token: settings.controlToken,
+    })
   } catch {
     return null
   }
@@ -67,9 +70,10 @@ export async function purgeCache(body: {
   tag?: string
   tags?: string[]
 }): Promise<void> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   await apiFetch('/api/cache/purge', {
     baseUrl: settings.metricsBaseUrl,
+    token: settings.controlToken,
     method: 'POST',
     body,
   })
@@ -83,9 +87,12 @@ const WINDOW_MS = 30 * 60_000
  */
 export async function fetchTelemetry(): Promise<Sourced<Telemetry>> {
   try {
-    const settings = loadApiSettings()
+    const settings = resolveApiSettings()
     const [stats, snap] = await Promise.all([
-      apiFetch<ProxyStats>('/api/stats', { baseUrl: settings.metricsBaseUrl }),
+      apiFetch<ProxyStats>('/api/stats', {
+        baseUrl: settings.metricsBaseUrl,
+        token: settings.controlToken,
+      }),
       scrapeMetrics().catch(() => null),
     ])
 

--- a/admin-console/src/api/node.ts
+++ b/admin-console/src/api/node.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from './client'
-import { loadApiSettings } from './settings'
+import { resolveApiSettings } from './settings'
 import { demo, isDemoMode, live, type Sourced } from './source'
 
 /** Live control-plane state of this proxy node (real endpoints on the metrics port). */
@@ -19,10 +19,11 @@ export interface UpstreamTlsStatus {
 }
 
 export async function fetchHierarchyPeers(): Promise<Sourced<HierarchyPeer[]>> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   try {
     const res = await apiFetch<HierarchyPeer[] | { peers: HierarchyPeer[] }>('/api/hierarchy/peers', {
       baseUrl: settings.metricsBaseUrl,
+      token: settings.controlToken,
     })
     return live(Array.isArray(res) ? res : (res.peers ?? []))
   } catch (err) {
@@ -36,9 +37,14 @@ export async function fetchHierarchyPeers(): Promise<Sourced<HierarchyPeer[]>> {
 }
 
 export async function fetchUpstreamTls(): Promise<Sourced<UpstreamTlsStatus>> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   try {
-    return live(await apiFetch<UpstreamTlsStatus>('/api/upstream/tls', { baseUrl: settings.metricsBaseUrl }))
+    return live(
+      await apiFetch<UpstreamTlsStatus>('/api/upstream/tls', {
+        baseUrl: settings.metricsBaseUrl,
+        token: settings.controlToken,
+      }),
+    )
   } catch (err) {
     if (isDemoMode()) return demo({ mode: 'system-roots', client_certs: 0, note: 'demo' })
     throw err

--- a/admin-console/src/api/prometheus.ts
+++ b/admin-console/src/api/prometheus.ts
@@ -1,4 +1,4 @@
-import { loadApiSettings } from './settings'
+import { resolveApiSettings } from './settings'
 
 /** One sample from the Prometheus text exposition format. */
 export interface PromSample {
@@ -20,9 +20,11 @@ export interface PromSnapshot {
 }
 
 export async function scrapeMetrics(): Promise<PromSnapshot> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   const base = settings.metricsBaseUrl.trim()
-  const res = await fetch(`${base}/metrics`, { headers: { Accept: 'text/plain' } })
+  const headers: Record<string, string> = { Accept: 'text/plain' }
+  if (settings.controlToken) headers.Authorization = `Bearer ${settings.controlToken}`
+  const res = await fetch(`${base}/metrics`, { headers })
   if (!res.ok) throw new Error(`GET /metrics → HTTP ${res.status}`)
   const text = await res.text()
   return { scrapedAt: Date.now(), samples: parsePrometheusText(text) }

--- a/admin-console/src/api/settings.ts
+++ b/admin-console/src/api/settings.ts
@@ -1,6 +1,11 @@
 /** Runtime API endpoint configuration (localStorage). */
 
+export type ApiConnectionMode = 'single' | 'advanced'
+
 export interface ApiSettings {
+  connectionMode: ApiConnectionMode
+  controlPlaneBaseUrl: string
+  controlPlaneToken: string
   searchBaseUrl: string
   aclBaseUrl: string
   mlBaseUrl: string
@@ -10,9 +15,23 @@ export interface ApiSettings {
   controlToken: string
 }
 
+export interface ResolvedApiSettings {
+  searchBaseUrl: string
+  aclBaseUrl: string
+  mlBaseUrl: string
+  metricsBaseUrl: string
+  searchToken: string
+  aclToken: string
+  mlToken: string
+  controlToken: string
+}
+
 const STORAGE_KEY = 'bsdm-admin-api-settings'
 
 const defaults: ApiSettings = {
+  connectionMode: 'single',
+  controlPlaneBaseUrl: '',
+  controlPlaneToken: '',
   searchBaseUrl: '',
   aclBaseUrl: '',
   mlBaseUrl: '',
@@ -22,7 +41,10 @@ const defaults: ApiSettings = {
   controlToken: '',
 }
 
-let runtimeTokens: Pick<ApiSettings, 'searchToken' | 'aclToken' | 'controlToken'> = {
+type SensitiveApiKey = 'controlPlaneToken' | 'searchToken' | 'aclToken' | 'controlToken'
+
+let runtimeTokens: Pick<ApiSettings, SensitiveApiKey> = {
+  controlPlaneToken: '',
   searchToken: '',
   aclToken: '',
   controlToken: '',
@@ -32,13 +54,30 @@ export function loadApiSettings(): ApiSettings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return { ...defaults, ...runtimeTokens }
-    return { ...defaults, ...JSON.parse(raw), ...runtimeTokens }
+    const parsed = JSON.parse(raw) as Partial<ApiSettings>
+    const legacyHasSplitConfiguration = [
+      parsed.searchBaseUrl,
+      parsed.aclBaseUrl,
+      parsed.mlBaseUrl,
+      parsed.metricsBaseUrl,
+    ].some((value) => Boolean(value?.trim()))
+    return {
+      ...defaults,
+      ...parsed,
+      connectionMode: parsed.connectionMode ?? (legacyHasSplitConfiguration ? 'advanced' : 'single'),
+      ...runtimeTokens,
+    }
   } catch {
     return { ...defaults, ...runtimeTokens }
   }
 }
 
-const SENSITIVE_API_KEYS = ['searchToken', 'aclToken', 'controlToken'] as const satisfies readonly (keyof ApiSettings)[]
+const SENSITIVE_API_KEYS = [
+  'controlPlaneToken',
+  'searchToken',
+  'aclToken',
+  'controlToken',
+] as const satisfies readonly SensitiveApiKey[]
 
 function apiSettingsForStorage(settings: ApiSettings): Omit<ApiSettings, (typeof SENSITIVE_API_KEYS)[number]> {
   const stored = { ...settings }
@@ -50,11 +89,48 @@ function apiSettingsForStorage(settings: ApiSettings): Omit<ApiSettings, (typeof
 
 export function saveApiSettings(settings: ApiSettings): void {
   runtimeTokens = {
+    controlPlaneToken: settings.controlPlaneToken,
     searchToken: settings.searchToken,
     aclToken: settings.aclToken,
     controlToken: settings.controlToken,
   }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(apiSettingsForStorage(settings)))
+}
+
+/**
+ * Resolve the operator-facing connection model into the service-specific
+ * endpoints consumed by API clients.
+ *
+ * In single-endpoint mode the deployment gateway must expose all `/api/*`
+ * routes and `/metrics` on one origin. Empty URLs keep using same-origin paths
+ * (including Vite's development proxies).
+ */
+export function resolveApiSettings(settings: ApiSettings = loadApiSettings()): ResolvedApiSettings {
+  if (settings.connectionMode === 'single') {
+    const baseUrl = resolveBaseUrl(settings.controlPlaneBaseUrl)
+    const token = settings.controlPlaneToken
+    return {
+      searchBaseUrl: baseUrl,
+      aclBaseUrl: baseUrl,
+      mlBaseUrl: baseUrl,
+      metricsBaseUrl: baseUrl,
+      searchToken: token,
+      aclToken: token,
+      mlToken: token,
+      controlToken: token,
+    }
+  }
+
+  return {
+    searchBaseUrl: resolveBaseUrl(settings.searchBaseUrl),
+    aclBaseUrl: resolveBaseUrl(settings.aclBaseUrl),
+    mlBaseUrl: resolveBaseUrl(settings.mlBaseUrl),
+    metricsBaseUrl: resolveBaseUrl(settings.metricsBaseUrl),
+    searchToken: settings.searchToken,
+    aclToken: settings.aclToken,
+    mlToken: '',
+    controlToken: settings.controlToken,
+  }
 }
 
 export function resolveBaseUrl(configured: string, fallback = ''): string {

--- a/admin-console/src/api/threatScores.ts
+++ b/admin-console/src/api/threatScores.ts
@@ -1,4 +1,4 @@
-import { loadApiSettings } from './settings'
+import { resolveApiSettings } from './settings'
 import { apiFetch } from './client'
 import { demo, isDemoMode, live, type Sourced } from './source'
 import type { MlFactor } from './search'
@@ -19,11 +19,12 @@ export interface ThreatScoreSnapshot {
 }
 
 export async function fetchThreatScores(): Promise<Sourced<ThreatScoreSnapshot>> {
-  const settings = loadApiSettings()
+  const settings = resolveApiSettings()
   try {
     return live(
       await apiFetch<ThreatScoreSnapshot>('/api/threat-scores', {
         baseUrl: settings.mlBaseUrl,
+        token: settings.mlToken,
       }),
     )
   } catch (err) {

--- a/admin-console/src/components/layout/UserProfileModal.tsx
+++ b/admin-console/src/components/layout/UserProfileModal.tsx
@@ -18,7 +18,9 @@ export function UserProfileModal({ open, onClose }: UserProfileModalProps) {
   const [lang] = useLanguage()
   const navigate = useNavigate()
   const settings = loadApiSettings()
-  const hasApiCredentials = Boolean(settings.searchToken || settings.aclToken || settings.controlToken)
+  const hasApiCredentials = Boolean(
+    settings.controlPlaneToken || settings.searchToken || settings.aclToken || settings.controlToken,
+  )
   const ru = lang === 'ru'
 
   const toggleTheme = () => {

--- a/admin-console/src/components/ui/DataState.tsx
+++ b/admin-console/src/components/ui/DataState.tsx
@@ -45,7 +45,7 @@ export function ErrorState({
         <p className="font-semibold text-text-primary text-base">{title}</p>
         {detail && <p className="mt-1 break-all font-mono text-xs text-text-secondary bg-surface-0/60 p-2 rounded-md border border-border">{detail}</p>}
         <p className="mt-2 text-xs text-text-secondary max-w-md">
-          Check API endpoints in Settings → API, or enable demo mode to explore the UI offline.
+          Check the connection in Settings → Console API, or enable demo mode to explore the UI offline.
         </p>
       </div>
       {onRetry && (
@@ -103,4 +103,3 @@ export function PreviewBanner({ feature, children }: { feature: string; children
     </div>
   )
 }
-

--- a/admin-console/src/pages/Policies.tsx
+++ b/admin-console/src/pages/Policies.tsx
@@ -8,8 +8,10 @@ import {
   type AclRule,
   type AclRulesResponse,
 } from '../api/acl'
+import { ApiError } from '../api/client'
 import { Button } from '../components/ui/Button'
 import { Panel } from '../components/dashboard/MetricWidget'
+import { ErrorState } from '../components/ui/DataState'
 import { useToast } from '../components/ui/Toast'
 import { useLanguage, translations } from '../lib/i18n'
 
@@ -19,13 +21,25 @@ export function PoliciesPage() {
 
   const { toast } = useToast()
   const [data, setData] = useState<AclRulesResponse | null>(null)
+  const [loadError, setLoadError] = useState<{ title: string; detail: string } | null>(null)
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
 
   const load = async () => {
     setLoading(true)
-    setData(await fetchAclRules())
-    setLoading(false)
+    setLoadError(null)
+    try {
+      setData(await fetchAclRules())
+    } catch (error) {
+      setData(null)
+      const unauthorized = error instanceof ApiError && (error.status === 401 || error.status === 403)
+      setLoadError({
+        title: unauthorized ? 'ACL API unauthorized' : 'ACL API unreachable',
+        detail: error instanceof ApiError ? `HTTP ${error.status}: ${error.message}` : String(error),
+      })
+    } finally {
+      setLoading(false)
+    }
   }
 
   useEffect(() => {
@@ -96,73 +110,77 @@ export function PoliciesPage() {
             <RefreshCw className={`size-4 ${loading ? 'animate-spin' : ''}`} />
             {tr.policies.refresh}
           </Button>
-          <Button variant="secondary" onClick={handlePersist} disabled={busy}>
+          <Button variant="secondary" onClick={handlePersist} disabled={busy || loading || !data}>
             <Save className="size-4" />
             {tr.policies.persist}
           </Button>
-          <Button variant="primary-glow" onClick={handleReload} disabled={busy}>
+          <Button variant="primary-glow" onClick={handleReload} disabled={busy || loading || !data}>
             <RotateCcw className={`size-4 ${busy ? 'animate-spin' : ''}`} />
             {tr.policies.reload}
           </Button>
         </div>
       </div>
 
-      <Panel
-        title={`${tr.policies.activeRules} (${filteredRules.length})`}
-        action={
-          <div className="w-64">
-            <input
-              type="text"
-              placeholder="Поиск правил..."
-              value={ruleFilter}
-              onChange={(e) => setRuleFilter(e.target.value)}
-              className="w-full rounded-lg border border-border bg-surface-0 px-3 py-1.5 text-xs text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none"
-            />
-          </div>
-        }
-      >
-        <div className="hidden overflow-x-auto md:block">
-          <table className="w-full min-w-[640px] text-left text-sm">
-            <thead className="border-b border-border text-xs uppercase text-text-secondary font-bold">
-              <tr>
-                <th className="pb-3 pr-4">{tr.policies.priority}</th>
-                <th className="pb-3 pr-4">{tr.policies.name}</th>
-                <th className="pb-3 pr-4">{tr.policies.type}</th>
-                <th className="pb-3 pr-4">{tr.policies.action}</th>
-                <th className="pb-3 pr-4">{tr.policies.status}</th>
-                <th className="pb-3"> </th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredRules.map((rule) => (
-                <RuleRow key={rule.id} rule={rule} onDelete={handleDelete} disabled={busy} />
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <div className="space-y-3 md:hidden">
-          {filteredRules.map((rule) => (
-            <div key={rule.id} className="rounded-xl border border-border/80 bg-surface-0/60 p-4">
-              <div className="flex items-start justify-between gap-2">
-                <span className="font-semibold text-text-primary">{rule.name}</span>
-                <button
-                  type="button"
-                  className="text-danger hover:text-danger/80 cursor-pointer"
-                  disabled={busy}
-                  onClick={() => handleDelete(rule.id)}
-                  aria-label={`Delete ${rule.id}`}
-                >
-                  <Trash2 className="size-4" />
-                </button>
-              </div>
-              <p className="mt-1.5 font-mono text-xs text-text-secondary">
-                P{rule.priority} · {rule.action} · {formatRuleType(rule)}
-              </p>
+      {loadError ? (
+        <ErrorState title={loadError.title} detail={loadError.detail} onRetry={load} />
+      ) : (
+        <Panel
+          title={`${tr.policies.activeRules} (${filteredRules.length})`}
+          action={
+            <div className="w-64">
+              <input
+                type="text"
+                placeholder="Поиск правил..."
+                value={ruleFilter}
+                onChange={(e) => setRuleFilter(e.target.value)}
+                className="w-full rounded-lg border border-border bg-surface-0 px-3 py-1.5 text-xs text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none"
+              />
             </div>
-          ))}
-        </div>
-      </Panel>
+          }
+        >
+          <div className="hidden overflow-x-auto md:block">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead className="border-b border-border text-xs uppercase text-text-secondary font-bold">
+                <tr>
+                  <th className="pb-3 pr-4">{tr.policies.priority}</th>
+                  <th className="pb-3 pr-4">{tr.policies.name}</th>
+                  <th className="pb-3 pr-4">{tr.policies.type}</th>
+                  <th className="pb-3 pr-4">{tr.policies.action}</th>
+                  <th className="pb-3 pr-4">{tr.policies.status}</th>
+                  <th className="pb-3"> </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredRules.map((rule) => (
+                  <RuleRow key={rule.id} rule={rule} onDelete={handleDelete} disabled={busy} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="space-y-3 md:hidden">
+              {filteredRules.map((rule) => (
+                <div key={rule.id} className="rounded-xl border border-border/80 bg-surface-0/60 p-4">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-semibold text-text-primary">{rule.name}</span>
+                    <button
+                      type="button"
+                      className="text-danger hover:text-danger/80 cursor-pointer"
+                      disabled={busy}
+                      onClick={() => handleDelete(rule.id)}
+                      aria-label={`Delete ${rule.id}`}
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  </div>
+                  <p className="mt-1.5 font-mono text-xs text-text-secondary">
+                    P{rule.priority} · {rule.action} · {formatRuleType(rule)}
+                  </p>
+                </div>
+              ))}
+          </div>
+        </Panel>
+      )}
 
 
       <div className="rounded-lg border border-border bg-surface-0 p-4 text-sm text-text-secondary">

--- a/admin-console/src/pages/Settings.tsx
+++ b/admin-console/src/pages/Settings.tsx
@@ -1,11 +1,22 @@
-import { useCallback, useState } from 'react'
-import { Download, Eye, FlaskConical, Upload } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import {
+  CheckCircle2,
+  CircleDashed,
+  Download,
+  Eye,
+  FlaskConical,
+  RefreshCw,
+  ShieldAlert,
+  Upload,
+  WifiOff,
+} from 'lucide-react'
 import type { ConfigFormState } from '../lib/config/types'
 import { defaultFormState } from '../lib/config/types'
 import { cacheMetadataEstimate } from '../lib/config/collect'
 import { formatEnv, generateAclRules, generateDockerCompose, downloadFile } from '../lib/config/export'
 import { importEnvFile, loadSavedForm, saveFormState } from '../lib/config/import'
 import { loadApiSettings, saveApiSettings, type ApiSettings } from '../api/settings'
+import { checkApiHealth, type ApiHealthResult } from '../api/health'
 import { isDemoMode, setDemoMode } from '../api/source'
 import { fetchProxyStats, formatUptime } from '../api/metrics'
 import { fetchUpstreamTls } from '../api/node'
@@ -129,7 +140,6 @@ export function SettingsPage() {
               setDemoMode(v)
               toast('info', v ? 'Demo mode ON — unreachable APIs now render sample data marked “Demo”.' : 'Demo mode OFF — failures show real error states.')
             }}
-            tr={tr}
           />
         )}
       </div>
@@ -620,29 +630,110 @@ function ApiTab({
   update,
   demoEnabled,
   onDemoChange,
-  tr,
 }: {
   settings: ApiSettings
   update: <K extends keyof ApiSettings>(key: K, value: ApiSettings[K]) => void
   demoEnabled: boolean
   onDemoChange: (v: boolean) => void
-  tr: any
 }) {
+  const [health, setHealth] = useState<ApiHealthResult[] | null>(null)
+  const [checking, setChecking] = useState(false)
+
+  useEffect(() => {
+    setHealth(null)
+  }, [settings])
+
+  const runHealthCheck = async () => {
+    setChecking(true)
+    try {
+      setHealth(await checkApiHealth(settings))
+    } finally {
+      setChecking(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
-      <FormSection title={tr.settings.tabApi}>
+      <FormSection title="Connection">
         <p className="text-sm text-text-secondary">
-          Leave blank to use Vite dev proxy paths. Set full base URLs in production.
+          Use one product URL for the normal deployment. Leave it blank during local development to use same-origin
+          Vite proxy paths.
         </p>
-        <Input label="Search API base URL" placeholder="http://127.0.0.1:8080" value={settings.searchBaseUrl} onChange={(e) => update('searchBaseUrl', e.target.value)} />
-        <Input label="ACL API base URL" placeholder="http://127.0.0.1:9090" value={settings.aclBaseUrl} onChange={(e) => update('aclBaseUrl', e.target.value)} />
-        <Input label="Metrics base URL" placeholder="http://127.0.0.1:9090" value={settings.metricsBaseUrl} onChange={(e) => update('metricsBaseUrl', e.target.value)} />
-        <Input label="ML worker base URL" placeholder="http://127.0.0.1:8091" value={settings.mlBaseUrl} onChange={(e) => update('mlBaseUrl', e.target.value)} />
-        <FormGrid>
-          <Input label="Search API token" type="password" value={settings.searchToken} onChange={(e) => update('searchToken', e.target.value)} />
-          <Input label="ACL API token" type="password" value={settings.aclToken} onChange={(e) => update('aclToken', e.target.value)} />
-          <Input label="Control API token" type="password" value={settings.controlToken} onChange={(e) => update('controlToken', e.target.value)} />
-        </FormGrid>
+        <div className="grid gap-3 sm:grid-cols-2" role="radiogroup" aria-label="API connection mode">
+          <ConnectionModeCard
+            title="Single endpoint"
+            description="Recommended: one gateway URL and token for every Admin Console API."
+            selected={settings.connectionMode === 'single'}
+            onClick={() => update('connectionMode', 'single')}
+          />
+          <ConnectionModeCard
+            title="Advanced split deployment"
+            description="Configure Search, ACL, Control, and ML services independently."
+            selected={settings.connectionMode === 'advanced'}
+            onClick={() => update('connectionMode', 'advanced')}
+          />
+        </div>
+
+        {settings.connectionMode === 'single' ? (
+          <>
+            <Input
+              label="Control Plane base URL"
+              placeholder="https://proxy.example.com"
+              value={settings.controlPlaneBaseUrl}
+              onChange={(e) => update('controlPlaneBaseUrl', e.target.value)}
+              hint="The gateway must expose /api/search, /api/acl, /api/stats, /api/threat-scores, and /metrics on this origin."
+            />
+            <Input
+              label="Control Plane token"
+              type="password"
+              value={settings.controlPlaneToken}
+              onChange={(e) => update('controlPlaneToken', e.target.value)}
+              hint="Kept in memory for this browser tab; never persisted to localStorage."
+            />
+          </>
+        ) : (
+          <>
+            <p className="rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-warning">
+              Advanced mode is intended for deployments without a unified gateway. Verify every service below.
+            </p>
+            <Input label="Search API base URL" placeholder="http://127.0.0.1:8080" value={settings.searchBaseUrl} onChange={(e) => update('searchBaseUrl', e.target.value)} />
+            <Input label="ACL API base URL" placeholder="http://127.0.0.1:9090" value={settings.aclBaseUrl} onChange={(e) => update('aclBaseUrl', e.target.value)} />
+            <Input label="Control / Metrics base URL" placeholder="http://127.0.0.1:9090" value={settings.metricsBaseUrl} onChange={(e) => update('metricsBaseUrl', e.target.value)} />
+            <Input label="ML worker base URL" placeholder="http://127.0.0.1:8091" value={settings.mlBaseUrl} onChange={(e) => update('mlBaseUrl', e.target.value)} />
+            <FormGrid>
+              <Input label="Search API token" type="password" value={settings.searchToken} onChange={(e) => update('searchToken', e.target.value)} />
+              <Input label="ACL API token" type="password" value={settings.aclToken} onChange={(e) => update('aclToken', e.target.value)} />
+              <Input label="Control API token" type="password" value={settings.controlToken} onChange={(e) => update('controlToken', e.target.value)} />
+            </FormGrid>
+          </>
+        )}
+      </FormSection>
+
+      <FormSection title="Service health">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-text-secondary">
+            Read-only checks show whether each dependency is connected, unauthorized, or unreachable.
+          </p>
+          <Button variant="secondary" onClick={runHealthCheck} disabled={checking}>
+            <RefreshCw className={`size-4 ${checking ? 'animate-spin' : ''}`} />
+            {checking ? 'Checking…' : 'Test connection'}
+          </Button>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2" aria-live="polite">
+          {(health ?? [
+            { id: 'control', name: 'Control / Metrics' },
+            { id: 'acl', name: 'ACL' },
+            { id: 'search', name: 'Search' },
+            { id: 'ml', name: 'ML worker' },
+          ]).map((service) => (
+            <HealthCard
+              key={service.id}
+              result={'status' in service ? service : null}
+              name={service.name}
+              checking={checking}
+            />
+          ))}
+        </div>
       </FormSection>
       <FormSection title="Demo mode">
         <div className="flex items-start gap-3 rounded-md border border-border bg-surface-0 p-4">
@@ -657,6 +748,67 @@ function ApiTab({
           </div>
         </div>
       </FormSection>
+    </div>
+  )
+}
+
+function ConnectionModeCard({
+  title,
+  description,
+  selected,
+  onClick,
+}: {
+  title: string
+  description: string
+  selected: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={onClick}
+      className={`rounded-lg border p-4 text-left transition-colors ${
+        selected
+          ? 'border-accent/60 bg-accent/10'
+          : 'border-border bg-surface-0 hover:border-accent/30 hover:bg-surface-2'
+      }`}
+    >
+      <span className={`block text-sm font-semibold ${selected ? 'text-accent' : 'text-text-primary'}`}>{title}</span>
+      <span className="mt-1 block text-xs leading-relaxed text-text-secondary">{description}</span>
+    </button>
+  )
+}
+
+function HealthCard({
+  name,
+  result,
+  checking,
+}: {
+  name: string
+  result: ApiHealthResult | null
+  checking: boolean
+}) {
+  const state = checking
+    ? { icon: RefreshCw, label: 'Checking…', color: 'text-text-secondary', border: 'border-border' }
+    : result?.status === 'healthy'
+      ? { icon: CheckCircle2, label: result.detail, color: 'text-success', border: 'border-success/30' }
+      : result?.status === 'unauthorized'
+        ? { icon: ShieldAlert, label: result.detail, color: 'text-warning', border: 'border-warning/30' }
+        : result?.status === 'unreachable'
+          ? { icon: WifiOff, label: result.detail, color: 'text-danger', border: 'border-danger/30' }
+          : { icon: CircleDashed, label: 'Not checked', color: 'text-text-secondary', border: 'border-border' }
+  const Icon = state.icon
+
+  return (
+    <div className={`rounded-lg border bg-surface-0 p-3.5 ${state.border}`}>
+      <div className="flex items-center gap-2">
+        <Icon className={`size-4 shrink-0 ${state.color} ${checking ? 'animate-spin' : ''}`} />
+        <span className="text-sm font-semibold text-text-primary">{name}</span>
+      </div>
+      <p className={`mt-1.5 text-xs ${state.color}`}>{state.label}</p>
+      {result && <p className="mt-1 truncate font-mono text-[10px] text-text-secondary" title={result.endpoint}>{result.endpoint}</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- make a single Control Plane base URL and token the default Admin Console connection model
- preserve split Search, ACL, Control/Metrics, and ML endpoints behind an Advanced deployment mode
- migrate existing saved multi-URL settings to Advanced mode without discarding them
- route every API client, including Prometheus and ML, through one resolved settings layer
- add read-only health probes for Control, ACL, Search, and ML with connected, unauthorized, and unreachable states
- stop silently replacing failed ACL reads with sample rules unless demo mode is explicitly enabled
- document the gateway path convention and connection workflow

## Why

The console exposed four URLs and three tokens as the normal setup, even though operators connect to one product. Configuration mistakes then appeared as empty or synthetic UI state. The API clients also applied Control credentials inconsistently.

## Impact

The normal flow now asks for one URL and one session-only token. Split deployments remain supported, existing settings migrate conservatively, service failures are visible before operators enter a workflow, and ACL failures no longer look like live rules.

## Validation

- `npm run lint` (passes; existing Fast Refresh warning in `Toast.tsx`)
- `npm run build`
- browser smoke: Single endpoint is the default UI
- browser smoke: all four probes resolve through the configured single origin
- browser smoke: Advanced mode exposes the legacy split fields
- browser smoke: unreachable services render per-service health errors
- browser smoke: Policies renders `ACL API unreachable` with demo mode off

Closes #276