### PR TITLE
Add ACL deny telemetry and device registry for Trust UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bsdm-events",
  "bytes",
  "http-body-util",
  "hyper",

--- a/bsdm-events/src/clickhouse.rs
+++ b/bsdm-events/src/clickhouse.rs
@@ -31,6 +31,10 @@ pub struct HttpCacheRow {
     pub threat_sources: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acl_action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acl_rule_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acl_reason: Option<String>,
     pub session_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_event_id: Option<String>,
@@ -72,6 +76,8 @@ pub fn cache_event_to_row(event: &CacheEvent) -> HttpCacheRow {
         categories: event.categories.clone(),
         threat_sources: event.threat_sources.clone(),
         acl_action: event.acl_action.clone(),
+        acl_rule_id: event.acl_rule_id.clone(),
+        acl_reason: event.acl_reason.clone(),
         session_id: event.session_id.clone(),
         parent_event_id: event.parent_event_id.clone(),
         redirect_url: event.redirect_url.clone(),
@@ -144,6 +150,8 @@ mod tests {
             categories: vec!["news".to_string()],
             threat_sources: vec!["ut1".to_string()],
             acl_action: Some("allow".to_string()),
+            acl_rule_id: Some("allow-news".to_string()),
+            acl_reason: Some("news is allowed".to_string()),
             session_id: "sess-abc".to_string(),
             parent_event_id: Some("evt-parent".to_string()),
             redirect_url: Some("https://example.com/next".to_string()),
@@ -163,6 +171,7 @@ mod tests {
         assert_eq!(row.client_ip, "10.0.0.5");
         assert_eq!(row.request_duration_ms, 42);
         assert_eq!(row.session_id, "sess-abc");
+        assert_eq!(row.acl_rule_id.as_deref(), Some("allow-news"));
         assert_eq!(row.parent_event_id.as_deref(), Some("evt-parent"));
         assert_eq!(
             row.redirect_url.as_deref(),

--- a/bsdm-events/src/lib.rs
+++ b/bsdm-events/src/lib.rs
@@ -39,6 +39,12 @@ pub struct CacheEvent {
     /// ACL decision when request was denied or redirected: deny, redirect.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acl_action: Option<String>,
+    /// Stable identifier of the ACL rule that produced the decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_rule_id: Option<String>,
+    /// Human-readable reason supplied by the ACL engine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_reason: Option<String>,
     /// Soft browsing session (same IP + principal + UA within idle window).
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub session_id: String,
@@ -101,6 +107,8 @@ mod tests {
             categories: vec![],
             threat_sources: vec![],
             acl_action: None,
+            acl_rule_id: None,
+            acl_reason: None,
             session_id: String::new(),
             parent_event_id: None,
             redirect_url: None,
@@ -133,6 +141,8 @@ mod tests {
         assert_eq!(event.categories, vec!["malware"]);
         assert!(event.threat_sources.is_empty());
         assert!(event.acl_action.is_none());
+        assert!(event.acl_rule_id.is_none());
+        assert!(event.acl_reason.is_none());
     }
 
     #[test]
@@ -156,6 +166,8 @@ mod tests {
             categories: vec!["malware".to_string()],
             threat_sources: vec!["urlhaus".to_string()],
             acl_action: Some("deny".to_string()),
+            acl_rule_id: Some("block-malware".to_string()),
+            acl_reason: Some("malware category denied".to_string()),
             session_id: "sess-1".to_string(),
             parent_event_id: Some("evt-redir".to_string()),
             redirect_url: None,
@@ -167,6 +179,8 @@ mod tests {
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"acl_action\":\"deny\""));
+        assert!(json.contains("\"acl_rule_id\":\"block-malware\""));
+        assert!(json.contains("\"acl_reason\":\"malware category denied\""));
         assert!(json.contains("\"threat_sources\":[\"urlhaus\"]"));
         assert!(json.contains("\"session_id\":\"sess-1\""));
         assert!(json.contains("\"parent_event_id\":\"evt-redir\""));

--- a/cache-indexer/src/search_api.rs
+++ b/cache-indexer/src/search_api.rs
@@ -214,6 +214,9 @@ fn hits_to_csv(hits: &[crate::store::SearchHit]) -> String {
         "parent_event_id",
         "redirect_url",
         "decision_source",
+        "acl_action",
+        "acl_rule_id",
+        "acl_reason",
     ];
     let mut out = headers.join(",");
     out.push('\n');
@@ -235,6 +238,9 @@ fn hits_to_csv(hits: &[crate::store::SearchHit]) -> String {
             h.parent_event_id.clone().unwrap_or_default(),
             h.redirect_url.clone().unwrap_or_default(),
             h.decision_source.clone().unwrap_or_default(),
+            h.acl_action.clone().unwrap_or_default(),
+            h.acl_rule_id.clone().unwrap_or_default(),
+            h.acl_reason.clone().unwrap_or_default(),
         ];
         out.push_str(
             &row.iter()

--- a/cache-indexer/src/store/memory.rs
+++ b/cache-indexer/src/store/memory.rs
@@ -78,6 +78,9 @@ fn event_to_hit(e: &CacheEvent) -> SearchHit {
         parent_event_id: e.parent_event_id.clone(),
         redirect_url: e.redirect_url.clone(),
         decision_source: e.decision_source.clone(),
+        acl_action: e.acl_action.clone(),
+        acl_rule_id: e.acl_rule_id.clone(),
+        acl_reason: e.acl_reason.clone(),
     }
 }
 
@@ -106,6 +109,8 @@ mod tests {
             categories: vec![],
             threat_sources: vec![],
             acl_action: None,
+            acl_rule_id: None,
+            acl_reason: None,
             session_id: "s1".into(),
             parent_event_id: None,
             redirect_url: None,
@@ -176,5 +181,34 @@ mod tests {
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].domain, "a.com");
         assert_eq!(hits[0].decision_source.as_deref(), Some("mitm"));
+    }
+
+    #[test]
+    fn exposes_acl_decision_details() {
+        let store = MemoryStore::new(10);
+        let mut blocked = sample("blocked.example", 1);
+        blocked.status = 403;
+        blocked.cache_status = "BLOCKED".into();
+        blocked.acl_action = Some("deny".into());
+        blocked.acl_rule_id = Some("deny-malware".into());
+        blocked.acl_reason = Some("malware category denied".into());
+        store.insert_batch(&[blocked]);
+
+        let hits = store.search(&SearchQuery {
+            from_ts: 0,
+            to_ts: 100,
+            domain: String::new(),
+            username: String::new(),
+            session_id: String::new(),
+            decision_source: String::new(),
+            limit: 10,
+            session_timeline: false,
+        });
+        assert_eq!(hits[0].acl_action.as_deref(), Some("deny"));
+        assert_eq!(hits[0].acl_rule_id.as_deref(), Some("deny-malware"));
+        assert_eq!(
+            hits[0].acl_reason.as_deref(),
+            Some("malware category denied")
+        );
     }
 }

--- a/cache-indexer/src/store/mod.rs
+++ b/cache-indexer/src/store/mod.rs
@@ -38,6 +38,9 @@ pub struct SearchHit {
     pub parent_event_id: Option<String>,
     pub redirect_url: Option<String>,
     pub decision_source: Option<String>,
+    pub acl_action: Option<String>,
+    pub acl_rule_id: Option<String>,
+    pub acl_reason: Option<String>,
 }
 
 impl SearchHit {
@@ -56,6 +59,9 @@ impl SearchHit {
             "parent_event_id": self.parent_event_id,
             "redirect_url": self.redirect_url,
             "decision_source": self.decision_source,
+            "acl_action": self.acl_action,
+            "acl_rule_id": self.acl_rule_id,
+            "acl_reason": self.acl_reason,
         })
     }
 }
@@ -116,7 +122,8 @@ async fn search_clickhouse(
     };
     let sql = format!(
         "SELECT toUnixTimestamp(ts) AS ts, username, toString(client_ip) AS client_ip, url, method, status, \
-         cache_status, domain, event_id, session_id, parent_event_id, redirect_url, decision_source \
+         cache_status, domain, event_id, session_id, parent_event_id, redirect_url, decision_source, \
+         acl_action, acl_rule_id, acl_reason \
          FROM {table} \
          WHERE ts >= fromUnixTimestamp({{from:UInt32}}) \
            AND ts <= fromUnixTimestamp({{to:UInt32}}) \
@@ -168,6 +175,9 @@ pub fn parse_search_ndjson(
             parent_event_id: json_opt_string(&v, "parent_event_id"),
             redirect_url: json_opt_string(&v, "redirect_url"),
             decision_source: json_opt_string(&v, "decision_source"),
+            acl_action: json_opt_string(&v, "acl_action"),
+            acl_rule_id: json_opt_string(&v, "acl_rule_id"),
+            acl_reason: json_opt_string(&v, "acl_reason"),
         });
     }
     Ok(out)

--- a/cache-indexer/src/store/sqlite.rs
+++ b/cache-indexer/src/store/sqlite.rs
@@ -40,8 +40,9 @@ impl SqliteStore {
                 r#"
                 INSERT INTO events (
                   event_id, ts, domain, username, client_ip, url, method, status,
-                  cache_status, session_id, parent_event_id, redirect_url, decision_source, payload
-                ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14)
+                  cache_status, session_id, parent_event_id, redirect_url, decision_source,
+                  acl_action, acl_rule_id, acl_reason, payload
+                ) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)
                 ON CONFLICT(event_id) DO UPDATE SET
                   ts=excluded.ts,
                   domain=excluded.domain,
@@ -55,6 +56,9 @@ impl SqliteStore {
                   parent_event_id=excluded.parent_event_id,
                   redirect_url=excluded.redirect_url,
                   decision_source=excluded.decision_source,
+                  acl_action=excluded.acl_action,
+                  acl_rule_id=excluded.acl_rule_id,
+                  acl_reason=excluded.acl_reason,
                   payload=excluded.payload
                 "#,
             )?;
@@ -78,6 +82,9 @@ impl SqliteStore {
                     e.parent_event_id,
                     e.redirect_url,
                     e.decision_source,
+                    e.acl_action,
+                    e.acl_rule_id,
+                    e.acl_reason,
                     payload,
                 ])?;
             }
@@ -110,7 +117,8 @@ impl SqliteStore {
         };
         let sql = format!(
             "SELECT ts, username, client_ip, url, method, status, cache_status, domain, \
-             event_id, session_id, parent_event_id, redirect_url, decision_source \
+             event_id, session_id, parent_event_id, redirect_url, decision_source, \
+             acl_action, acl_rule_id, acl_reason \
              FROM events \
              WHERE ts >= ?1 AND ts <= ?2 \
                AND (?3 = '' OR domain = ?3) \
@@ -147,6 +155,9 @@ impl SqliteStore {
                     parent_event_id: row.get(10)?,
                     redirect_url: row.get(11)?,
                     decision_source: row.get(12)?,
+                    acl_action: row.get(13)?,
+                    acl_rule_id: row.get(14)?,
+                    acl_reason: row.get(15)?,
                 })
             },
         )?;
@@ -176,6 +187,9 @@ fn initialize_schema(conn: &Connection) -> Result<(), Box<dyn std::error::Error 
               parent_event_id TEXT,
               redirect_url TEXT,
               decision_source TEXT,
+              acl_action TEXT,
+              acl_rule_id TEXT,
+              acl_reason TEXT,
               payload TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_events_ts ON events(ts);
@@ -186,6 +200,11 @@ fn initialize_schema(conn: &Connection) -> Result<(), Box<dyn std::error::Error 
     )?;
     if !has_column(conn, "events", "decision_source")? {
         conn.execute("ALTER TABLE events ADD COLUMN decision_source TEXT", [])?;
+    }
+    for column in ["acl_action", "acl_rule_id", "acl_reason"] {
+        if !has_column(conn, "events", column)? {
+            conn.execute(&format!("ALTER TABLE events ADD COLUMN {column} TEXT"), [])?;
+        }
     }
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_events_decision_source_ts
@@ -231,6 +250,8 @@ mod tests {
             categories: vec![],
             threat_sources: vec![],
             acl_action: None,
+            acl_rule_id: None,
+            acl_reason: None,
             session_id: "sess".into(),
             parent_event_id: None,
             redirect_url: None,
@@ -292,6 +313,9 @@ mod tests {
 
         initialize_schema(&conn).unwrap();
         assert!(has_column(&conn, "events", "decision_source").unwrap());
+        assert!(has_column(&conn, "events", "acl_action").unwrap());
+        assert!(has_column(&conn, "events", "acl_rule_id").unwrap());
+        assert!(has_column(&conn, "events", "acl_reason").unwrap());
 
         let store = SqliteStore {
             conn: Mutex::new(conn),

--- a/cache-indexer/tests/integration_test.rs
+++ b/cache-indexer/tests/integration_test.rs
@@ -26,6 +26,8 @@ mod tests {
             categories: vec!["malware".to_string()],
             threat_sources: vec!["urlhaus".to_string()],
             acl_action: None,
+            acl_rule_id: None,
+            acl_reason: None,
             session_id: String::new(),
             parent_event_id: None,
             redirect_url: None,
@@ -67,6 +69,8 @@ mod tests {
             categories: vec!["malware".to_string()],
             threat_sources: vec!["urlhaus".to_string()],
             acl_action: None,
+            acl_rule_id: None,
+            acl_reason: None,
             session_id: String::new(),
             parent_event_id: None,
             redirect_url: None,
@@ -127,6 +131,8 @@ mod tests {
             categories: vec!["malware".to_string()],
             threat_sources: vec!["ut1".to_string()],
             acl_action: Some("deny".to_string()),
+            acl_rule_id: Some("deny-malware".to_string()),
+            acl_reason: Some("malware category denied".to_string()),
             session_id: String::new(),
             parent_event_id: None,
             redirect_url: None,
@@ -139,6 +145,8 @@ mod tests {
 
         let row = bsdm_events::cache_event_to_row(&event);
         assert_eq!(row.acl_action.as_deref(), Some("deny"));
+        assert_eq!(row.acl_rule_id.as_deref(), Some("deny-malware"));
+        assert_eq!(row.acl_reason.as_deref(), Some("malware category denied"));
         assert_eq!(row.threat_sources, vec!["ut1"]);
     }
 
@@ -166,6 +174,8 @@ mod tests {
                 categories: vec![],
                 threat_sources: vec![],
                 acl_action: None,
+                acl_rule_id: None,
+                acl_reason: None,
                 session_id: String::new(),
                 parent_event_id: None,
                 redirect_url: None,
@@ -207,6 +217,8 @@ mod tests {
             categories: vec!["malware".to_string()],
             threat_sources: vec!["ut1".to_string()],
             acl_action: Some("deny".to_string()),
+            acl_rule_id: Some("deny-malware".to_string()),
+            acl_reason: Some("malware category denied".to_string()),
             session_id: String::new(),
             parent_event_id: None,
             redirect_url: None,
@@ -219,6 +231,8 @@ mod tests {
 
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"acl_action\":\"deny\""));
+        assert!(json.contains("\"acl_rule_id\":\"deny-malware\""));
+        assert!(json.contains("\"acl_reason\":\"malware category denied\""));
         assert!(json.contains("\"cache_status\":\"BLOCKED\""));
     }
 }

--- a/docs/architecture/agent-contract.md
+++ b/docs/architecture/agent-contract.md
@@ -14,7 +14,8 @@ policy and heartbeat endpoints.
 ### Implementation status
 
 - Implemented: `GET /api/v1/agent/policy`,
-  `POST /api/v1/agent/heartbeat`.
+  `POST /api/v1/agent/heartbeat`, `GET /api/v1/devices`, and
+  `POST /api/v1/devices/{device_id}/revoke`.
 - Reserved by this contract: `POST /api/v1/agent/enroll`,
   `POST /api/v1/agent/events`, and policy push.
 
@@ -63,6 +64,12 @@ policy and heartbeat endpoints.
 ### 3.1 Heartbeat (`POST /api/v1/agent/heartbeat`)
 - Periodicity: Default 60s.
 - Contains: `device_id`, `policy_version`, `agent_version`, `status` (`healthy`, `degraded`).
+- May include inventory/posture fields used by Trust UI: `name`, `ip`,
+  `device_type` (`desktop`, `phone`), `cert_subject`, `cert_fingerprint`,
+  and `trust_score` (0–100).
+- The proxy keeps the latest heartbeat for each device in its runtime registry.
+  `GET /api/v1/devices` exposes only those observed devices; it does not create
+  placeholder inventory.
 
 ### 3.2 Telemetry Ingestion (`POST /api/v1/agent/events`)
 - Batched events logged locally and shipped back to ClickHouse event pipeline via Control Plane API.

--- a/docs/features/control-plane.md
+++ b/docs/features/control-plane.md
@@ -123,6 +123,8 @@ Endpoints for On-Device SWG Local Policy Agents policy synchronization and heart
 |--------|------|-------------|
 | `GET` | `/api/v1/agent/policy` | Returns active policy contract (`policy_mode`, `mitm_categories`, `pinning_exceptions`) |
 | `POST` | `/api/v1/agent/heartbeat` | Receives agent telemetry and heartbeats (`device_id`, `status`, `agent_version`) |
+| `GET` | `/api/v1/devices` | Lists devices observed through agent heartbeats |
+| `POST` | `/api/v1/devices/{device_id}/revoke` | Marks an observed device as revoked |
 
 The `/api/v1/agent/*` namespace is canonical for Agent Contract v0.1.
 The previous unversioned `/api/agent/policy` and `/api/agent/heartbeat` paths

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 base64 = "0.22"
+bsdm-events = { path = "../bsdm-events" }
 bytes = { workspace = true }
 http-body-util = "0.1"
 hyper = { version = "1.10", features = ["server", "http1", "client"] }

--- a/e2e/tests/e2e.rs
+++ b/e2e/tests/e2e.rs
@@ -5,6 +5,9 @@ use bsdm_proxy_e2e::{
     test_ca_cert_path, wait_for_tcp, workspace_path, HarnessConfig, ProxyHarness,
 };
 use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 #[tokio::test]
 async fn e2e_cache_hit_on_repeat_request() {
@@ -100,6 +103,97 @@ async fn e2e_acl_denies_blocked_domain() {
         .expect("blocked request");
 
     assert_eq!(response.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn e2e_acl_denied_connect_emits_policy_event() {
+    let _guard = proxy_test_guard().await;
+    let sink = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind event sink");
+    let sink_port = sink.local_addr().expect("sink address").port();
+    let (event_tx, event_rx) = tokio::sync::oneshot::channel();
+    let sink_task = tokio::spawn(async move {
+        let (mut stream, _) = sink.accept().await.expect("accept event");
+        let mut request = Vec::new();
+        let body = loop {
+            let mut chunk = [0_u8; 4096];
+            let read = stream.read(&mut chunk).await.expect("read event");
+            assert!(read > 0, "event sink request ended before body");
+            request.extend_from_slice(&chunk[..read]);
+            let Some(header_end) = request.windows(4).position(|w| w == b"\r\n\r\n") else {
+                continue;
+            };
+            let header_end = header_end + 4;
+            let headers = std::str::from_utf8(&request[..header_end]).expect("event headers");
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.to_ascii_lowercase()
+                        .strip_prefix("content-length:")
+                        .map(str::trim)
+                        .and_then(|value| value.parse::<usize>().ok())
+                })
+                .expect("content length");
+            if request.len() >= header_end + content_length {
+                break request[header_end..header_end + content_length].to_vec();
+            }
+        };
+        stream
+            .write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .expect("reply to event");
+        event_tx.send(body).expect("send captured event");
+    });
+
+    let harness = ProxyHarness::start(HarnessConfig {
+        acl_enabled: true,
+        acl_rules_path: Some(workspace_path("config/acl-rules.test.json")),
+        extra_env: [(
+            "EVENT_SINK_URL".to_string(),
+            format!("http://127.0.0.1:{sink_port}/api/events"),
+        )]
+        .into(),
+        ..Default::default()
+    })
+    .await
+    .expect("start proxy");
+
+    let mut proxy = TcpStream::connect(("127.0.0.1", harness.proxy_port))
+        .await
+        .expect("connect to proxy");
+    proxy
+        .write_all(
+            b"CONNECT blocked.test:443 HTTP/1.1\r\nHost: blocked.test:443\r\nUser-Agent: e2e-connect\r\n\r\n",
+        )
+        .await
+        .expect("write CONNECT");
+    let mut response = [0_u8; 1024];
+    let read = proxy
+        .read(&mut response)
+        .await
+        .expect("read CONNECT response");
+    assert!(
+        std::str::from_utf8(&response[..read])
+            .expect("CONNECT response text")
+            .starts_with("HTTP/1.1 403"),
+        "CONNECT should be denied"
+    );
+
+    let body = tokio::time::timeout(Duration::from_secs(5), event_rx)
+        .await
+        .expect("policy event timeout")
+        .expect("policy event channel");
+    let event: bsdm_events::CacheEvent =
+        serde_json::from_slice(&body).expect("deserialize policy event");
+    assert_eq!(event.method, "CONNECT");
+    assert_eq!(event.cache_status, "BLOCKED");
+    assert_eq!(event.decision_source.as_deref(), Some("sni"));
+    assert_eq!(event.acl_action.as_deref(), Some("deny"));
+    assert_eq!(event.acl_rule_id.as_deref(), Some("block-test-domain"));
+    assert!(event.acl_reason.is_some());
+
+    sink_task.await.expect("event sink task");
 }
 
 #[tokio::test]

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -7,8 +7,9 @@ use hyper::header::HeaderValue;
 use hyper::header::AUTHORIZATION;
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use std::time::Instant;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tracing::{info, warn};
 
 use crate::cache_key::http_cache_key;
@@ -25,6 +26,36 @@ use crate::upstream::UpstreamClientHandle;
 struct DlpPatternDto {
     pub pattern: String,
     pub description: String,
+}
+
+#[derive(Clone, Debug)]
+struct RegisteredDevice {
+    id: String,
+    name: String,
+    ip: String,
+    device_type: String,
+    agent_status: String,
+    agent_version: Option<String>,
+    policy_version: Option<String>,
+    cert_subject: Option<String>,
+    cert_fingerprint: Option<String>,
+    trust_score: Option<u8>,
+    last_seen: u64,
+    revoked: bool,
+}
+
+#[derive(Deserialize)]
+struct AgentHeartbeatDto {
+    device_id: String,
+    status: Option<String>,
+    agent_version: Option<String>,
+    policy_version: Option<String>,
+    name: Option<String>,
+    ip: Option<String>,
+    device_type: Option<String>,
+    cert_subject: Option<String>,
+    cert_fingerprint: Option<String>,
+    trust_score: Option<u8>,
 }
 
 impl ControlApiState {
@@ -301,15 +332,64 @@ impl ControlApiState {
     }
 
     async fn agent_heartbeat(&self, body: Bytes) -> Response<Body> {
-        #[derive(Deserialize)]
-        struct AgentHeartbeatDto {
-            device_id: String,
-            status: Option<String>,
-            agent_version: Option<String>,
-        }
         match serde_json::from_slice::<AgentHeartbeatDto>(&body) {
             Ok(hb) => {
-                info!(device_id = %hb.device_id, status = ?hb.status, agent_version = ?hb.agent_version, "Agent heartbeat received");
+                if hb.device_id.trim().is_empty() {
+                    return json_response(
+                        StatusCode::BAD_REQUEST,
+                        r#"{"error":"device_id must not be empty"}"#,
+                    );
+                }
+                if hb.trust_score.is_some_and(|score| score > 100) {
+                    return json_response(
+                        StatusCode::BAD_REQUEST,
+                        r#"{"error":"trust_score must be between 0 and 100"}"#,
+                    );
+                }
+                let mut devices = self.devices.write().expect("device registry lock");
+                let previous = devices.get(&hb.device_id);
+                let device = RegisteredDevice {
+                    id: hb.device_id.clone(),
+                    name: hb
+                        .name
+                        .filter(|name| !name.trim().is_empty())
+                        .or_else(|| previous.map(|device| device.name.clone()))
+                        .unwrap_or_else(|| hb.device_id.clone()),
+                    ip: hb
+                        .ip
+                        .or_else(|| previous.map(|device| device.ip.clone()))
+                        .unwrap_or_default(),
+                    device_type: hb
+                        .device_type
+                        .filter(|kind| matches!(kind.as_str(), "desktop" | "phone"))
+                        .or_else(|| previous.map(|device| device.device_type.clone()))
+                        .unwrap_or_else(|| "desktop".to_string()),
+                    agent_status: hb.status.unwrap_or_else(|| "healthy".to_string()),
+                    agent_version: hb
+                        .agent_version
+                        .or_else(|| previous.and_then(|device| device.agent_version.clone())),
+                    policy_version: hb
+                        .policy_version
+                        .or_else(|| previous.and_then(|device| device.policy_version.clone())),
+                    cert_subject: hb
+                        .cert_subject
+                        .or_else(|| previous.and_then(|device| device.cert_subject.clone())),
+                    cert_fingerprint: hb
+                        .cert_fingerprint
+                        .or_else(|| previous.and_then(|device| device.cert_fingerprint.clone())),
+                    trust_score: hb
+                        .trust_score
+                        .or_else(|| previous.and_then(|device| device.trust_score)),
+                    last_seen: unix_timestamp(),
+                    revoked: previous.is_some_and(|device| device.revoked),
+                };
+                info!(
+                    device_id = %device.id,
+                    status = %device.agent_status,
+                    agent_version = ?device.agent_version,
+                    "Agent heartbeat received"
+                );
+                devices.insert(device.id.clone(), device);
                 json_response(StatusCode::OK, r#"{"status":"acknowledged"}"#)
             }
             Err(e) => json_response(
@@ -320,6 +400,58 @@ impl ControlApiState {
                 ),
             ),
         }
+    }
+
+    fn registered_devices(&self) -> Response<Body> {
+        let devices = self.devices.read().expect("device registry lock");
+        let mut rows: Vec<_> = devices
+            .values()
+            .map(|device| {
+                serde_json::json!({
+                    "id": device.id,
+                    "name": device.name,
+                    "ip": device.ip,
+                    "type": device.device_type,
+                    "status": if device.revoked {
+                        "Revoked"
+                    } else if device.agent_status.eq_ignore_ascii_case("healthy") {
+                        "Secured"
+                    } else {
+                        "Flagged"
+                    },
+                    "connection": device.last_seen.to_string(),
+                    "lastSeen": device.last_seen,
+                    "agentStatus": device.agent_status,
+                    "agentVersion": device.agent_version,
+                    "policyVersion": device.policy_version,
+                    "certSubject": device.cert_subject,
+                    "certFingerprint": device.cert_fingerprint,
+                    "trustScore": device.trust_score,
+                })
+            })
+            .collect();
+        rows.sort_by_key(|row| std::cmp::Reverse(row["lastSeen"].as_u64().unwrap_or(0)));
+        json_response(StatusCode::OK, &serde_json::Value::Array(rows).to_string())
+    }
+
+    fn revoke_device(&self, device_id: &str) -> Response<Body> {
+        if device_id.is_empty() || device_id.contains('/') {
+            return json_response(StatusCode::BAD_REQUEST, r#"{"error":"invalid device id"}"#);
+        }
+        let mut devices = self.devices.write().expect("device registry lock");
+        let Some(device) = devices.get_mut(device_id) else {
+            return json_response(StatusCode::NOT_FOUND, r#"{"error":"device not found"}"#);
+        };
+        device.revoked = true;
+        warn!(device_id, "Device trust revoked");
+        json_response(
+            StatusCode::OK,
+            &serde_json::json!({
+                "success": true,
+                "message": format!("Device {device_id} revoked"),
+            })
+            .to_string(),
+        )
     }
 }
 
@@ -344,6 +476,7 @@ pub struct ControlApiState {
     threat_sync: crate::threat_sync::ThreatSyncEngine,
     trust_ui_dir: Option<std::path::PathBuf>,
     admin_console_dir: Option<std::path::PathBuf>,
+    devices: Arc<RwLock<HashMap<String, RegisteredDevice>>>,
 }
 
 impl ControlApiState {
@@ -408,6 +541,7 @@ impl ControlApiState {
                         None
                     }
                 }),
+            devices: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -486,6 +620,18 @@ impl ControlApiState {
             );
             if !public_api && !self.is_authorized(headers) {
                 return json_response(StatusCode::UNAUTHORIZED, r#"{"error":"unauthorized"}"#);
+            }
+        }
+
+        if method == Method::GET && path == "/api/v1/devices" {
+            return self.registered_devices();
+        }
+        if method == Method::POST {
+            if let Some(device_id) = path
+                .strip_prefix("/api/v1/devices/")
+                .and_then(|path| path.strip_suffix("/revoke"))
+            {
+                return self.revoke_device(device_id);
             }
         }
 
@@ -1098,6 +1244,13 @@ fn deprecated_agent_alias(
     response
 }
 
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 fn escape_json(value: &str) -> String {
     value
         .replace('\\', "\\\\")
@@ -1379,8 +1532,9 @@ mod tests {
         assert_eq!(v["policy_mode"], "selective-mitm");
 
         // Canonical versioned heartbeat endpoint.
-        let hb_payload =
-            Bytes::from(r#"{"device_id":"laptop-001","status":"healthy","agent_version":"0.1.0"}"#);
+        let hb_payload = Bytes::from(
+            r#"{"device_id":"laptop-001","name":"Alice laptop","ip":"10.0.0.5","device_type":"desktop","status":"healthy","agent_version":"0.1.0","policy_version":"v0.1.0","trust_score":97}"#,
+        );
         let resp = state
             .dispatch(
                 &Method::POST,
@@ -1393,6 +1547,50 @@ mod tests {
         let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], "acknowledged");
+
+        let devices = state
+            .dispatch(
+                &Method::GET,
+                "/api/v1/devices",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(devices.status(), StatusCode::OK);
+        let body = BodyExt::collect(devices.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let devices: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(devices[0]["id"], "laptop-001");
+        assert_eq!(devices[0]["name"], "Alice laptop");
+        assert_eq!(devices[0]["status"], "Secured");
+        assert_eq!(devices[0]["trustScore"], 97);
+        assert!(devices[0]["lastSeen"].as_u64().unwrap() > 0);
+
+        let revoked = state
+            .dispatch(
+                &Method::POST,
+                "/api/v1/devices/laptop-001/revoke",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(revoked.status(), StatusCode::OK);
+        let devices = state
+            .dispatch(
+                &Method::GET,
+                "/api/v1/devices",
+                Bytes::new(),
+                &HeaderMap::new(),
+            )
+            .await;
+        let body = BodyExt::collect(devices.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let devices: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(devices[0]["status"], "Revoked");
 
         // Unversioned v0.1 paths remain aliases for existing agents.
         let legacy_policy = state

--- a/proxy/src/proxy_service.rs
+++ b/proxy/src/proxy_service.rs
@@ -320,6 +320,8 @@ impl MissCompletionHandle {
                     categories: categories.to_vec(),
                     threat_sources: threat_sources.to_vec(),
                     acl_action: None,
+                    acl_rule_id: None,
+                    acl_reason: None,
                     session_id: corr.session_id,
                     parent_event_id: corr.parent_event_id,
                     redirect_url,
@@ -627,6 +629,8 @@ impl ProxyService {
                 categories: categories.to_vec(),
                 threat_sources: threat_sources.to_vec(),
                 acl_action: None,
+                acl_rule_id: None,
+                acl_reason: None,
                 session_id: corr.session_id,
                 parent_event_id: corr.parent_event_id,
                 redirect_url,
@@ -641,7 +645,7 @@ impl ProxyService {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn emit_policy_event(
+    pub(crate) fn emit_policy_event(
         &self,
         url: &str,
         method: &str,
@@ -655,8 +659,8 @@ impl ProxyService {
         categories: &[String],
         threat_sources: &[String],
         request_start: Instant,
+        decision_source: &str,
     ) {
-        let decision_source = request_decision_source(url);
         self.metrics.record_policy_decision_source(decision_source);
         info!(
             domain = %domain,
@@ -699,6 +703,8 @@ impl ProxyService {
                 categories: categories.to_vec(),
                 threat_sources: threat_sources.to_vec(),
                 acl_action: Some(decision.action.to_string()),
+                acl_rule_id: decision.rule_id.clone(),
+                acl_reason: Some(decision.reason.clone()),
                 session_id: corr.session_id,
                 parent_event_id: corr.parent_event_id,
                 redirect_url,
@@ -1943,6 +1949,7 @@ impl ProxyService {
                 &categories,
                 &threat_sources,
                 request_start,
+                request_decision_source(&url),
             );
             let response = Self::policy_response(&decision);
             if let Some(g) = guard.take() {
@@ -2004,6 +2011,8 @@ impl ProxyService {
                                 categories: categories.to_vec(),
                                 threat_sources: threat_sources.to_vec(),
                                 acl_action: Some("deny".to_string()),
+                                acl_rule_id: None,
+                                acl_reason: Some(err_msg.clone()),
                                 session_id: String::new(),
                                 parent_event_id: None,
                                 redirect_url: None,
@@ -2330,6 +2339,8 @@ impl ProxyService {
                                 categories: categories.to_vec(),
                                 threat_sources: threat_sources.to_vec(),
                                 acl_action: Some("deny".to_string()),
+                                acl_rule_id: None,
+                                acl_reason: Some(err_msg.clone()),
                                 session_id: String::new(),
                                 parent_event_id: None,
                                 redirect_url: None,

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -323,6 +323,8 @@ async fn handle_connect_tunnel(
                             categories: vec![],
                             threat_sources: vec![],
                             acl_action: None,
+                            acl_rule_id: None,
+                            acl_reason: None,
                             session_id: corr.session_id,
                             parent_event_id: corr.parent_event_id,
                             redirect_url: None,
@@ -496,6 +498,11 @@ pub async fn handle_connection(
                     Ok(user) => user,
                     Err(resp) => return Ok(resp),
                 };
+                let user_agent = req
+                    .headers()
+                    .get("user-agent")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
 
                 let policy_username = proxy_user.as_deref().map(|u| u.username.as_str());
                 let policy_groups: Vec<&str> = proxy_user
@@ -521,7 +528,7 @@ pub async fn handle_connection(
                     return Ok::<_, Infallible>(resp);
                 }
 
-                let (policy_decision, _, _) = service
+                let (policy_decision, categories, threat_sources) = service
                     .check_policy(
                         &connect_url,
                         &connect_domain,
@@ -531,6 +538,22 @@ pub async fn handle_connection(
                     )
                     .await;
                 if let Some(decision) = policy_decision {
+                    let (user_id, username) = ProxyService::user_fields(proxy_user.as_deref());
+                    service.emit_policy_event(
+                        &connect_url,
+                        "CONNECT",
+                        service.generate_cache_key("CONNECT", &authority).as_ref(),
+                        &decision,
+                        &user_id,
+                        &username,
+                        user_agent.as_deref(),
+                        &client_ip,
+                        &connect_domain,
+                        &categories,
+                        &threat_sources,
+                        request_start,
+                        "sni",
+                    );
                     return Ok::<_, Infallible>(ProxyService::policy_response(&decision));
                 }
 

--- a/scripts/clickhouse/http_cache.sql
+++ b/scripts/clickhouse/http_cache.sql
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS bsdm.http_cache
     categories Array(LowCardinality(String)),
     threat_sources Array(LowCardinality(String)),
     acl_action LowCardinality(Nullable(String)),
+    acl_rule_id Nullable(String),
+    acl_reason Nullable(String),
     session_id String DEFAULT '',
     parent_event_id Nullable(String),
     redirect_url Nullable(String),
@@ -45,6 +47,12 @@ ALTER TABLE bsdm.http_cache
 ALTER TABLE bsdm.http_cache
     ADD COLUMN IF NOT EXISTS bypass_reason Nullable(String);
 
+ALTER TABLE bsdm.http_cache
+    ADD COLUMN IF NOT EXISTS acl_rule_id Nullable(String);
+
+ALTER TABLE bsdm.http_cache
+    ADD COLUMN IF NOT EXISTS acl_reason Nullable(String);
+
 -- M3: who accessed domain X (30 days)
 -- SELECT ts, username, client_ip, url, method, status, cache_status, session_id
 -- FROM bsdm.http_cache
@@ -58,7 +66,7 @@ ALTER TABLE bsdm.http_cache
 -- ORDER BY ts ASC;
 
 -- M4: blocked events with threat sources
--- SELECT ts, username, domain, url, categories, threat_sources, acl_action, session_id
+-- SELECT ts, username, domain, url, categories, threat_sources, acl_action, acl_rule_id, acl_reason, session_id
 -- FROM bsdm.http_cache
 -- WHERE cache_status = 'DENY' OR acl_action = 'deny'
 --   AND ts >= now() - INTERVAL 7 DAY;

--- a/trust-ui/src/api/devices.ts
+++ b/trust-ui/src/api/devices.ts
@@ -5,6 +5,10 @@ export interface RegisteredDevice {
   type: 'desktop' | 'phone';
   status: 'Secured' | 'Flagged' | 'Revoked';
   connection: string;
+  lastSeen: number;
+  agentStatus: string;
+  agentVersion?: string;
+  policyVersion?: string;
   certSubject?: string;
   certFingerprint?: string;
   trustScore?: number;
@@ -15,7 +19,7 @@ export const fetchRegisteredDevices = async (): Promise<RegisteredDevice[]> => {
   if (!response.ok) {
     throw new Error(
       response.status === 404
-        ? 'Device identity API is not implemented by this node'
+        ? 'Device identity API is unavailable on this node'
         : `Device identity API returned HTTP ${response.status}`,
     );
   }
@@ -29,7 +33,7 @@ export const revokeDeviceCertificate = async (
     method: 'POST',
   });
   if (!response.ok) {
-    throw new Error(`Certificate revoke API returned HTTP ${response.status}`);
+    throw new Error(`Device revoke API returned HTTP ${response.status}`);
   }
   return (await response.json()) as { success: boolean; message: string };
 };

--- a/trust-ui/src/api/events.ts
+++ b/trust-ui/src/api/events.ts
@@ -10,6 +10,9 @@ export interface TrafficEvent {
   event_id: string;
   session_id: string;
   decision_source?: string;
+  acl_action?: string;
+  acl_rule_id?: string;
+  acl_reason?: string;
 }
 
 export const fetchRecentEvents = async (): Promise<TrafficEvent[]> => {

--- a/trust-ui/src/components/DeviceIdentity.tsx
+++ b/trust-ui/src/components/DeviceIdentity.tsx
@@ -80,6 +80,9 @@ export const DeviceIdentity: React.FC = () => {
               <div>
                 <p className="font-semibold text-slate-200">{dev.name}</p>
                 <p className="text-[10px] text-slate-500 font-mono">{dev.ip}</p>
+                <p className="text-[10px] text-slate-600">
+                  Seen {new Date(dev.lastSeen * 1_000).toLocaleString()}
+                </p>
               </div>
             </div>
 
@@ -105,8 +108,9 @@ export const DeviceIdentity: React.FC = () => {
               )}
               <button
                 onClick={() => revokeMutation.mutate(dev.id)}
-                title="Revoke mTLS Certificate"
-                className="p-1 text-slate-500 hover:text-rose-400 transition-colors"
+                disabled={dev.status === 'Revoked' || revokeMutation.isPending}
+                title="Revoke device trust"
+                className="p-1 text-slate-500 hover:text-rose-400 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
               >
                 <ShieldX className="w-3.5 h-3.5" />
               </button>

--- a/trust-ui/src/components/ThreatStream.tsx
+++ b/trust-ui/src/components/ThreatStream.tsx
@@ -4,7 +4,13 @@ import { Activity, Search } from 'lucide-react';
 import { fetchRecentEvents, type TrafficEvent } from '../api/events';
 
 function eventAction(event: TrafficEvent): 'ALLOWED' | 'BLOCKED' | 'INSPECTED' {
-  if (event.status === 403 || event.cache_status === 'DENIED') return 'BLOCKED';
+  if (
+    event.status === 403 ||
+    event.cache_status === 'BLOCKED' ||
+    event.cache_status === 'DENIED' ||
+    event.acl_action === 'deny'
+  )
+    return 'BLOCKED';
   if (event.decision_source === 'mitm') return 'INSPECTED';
   return 'ALLOWED';
 }
@@ -120,6 +126,14 @@ export const ThreatStream: React.FC = () => {
                   <p className="text-[10px] text-slate-500">
                     {event.method} · {event.cache_status}
                   </p>
+                  {eventAction(event) === 'BLOCKED' && (event.acl_rule_id || event.acl_reason) && (
+                    <p
+                      className="text-[10px] text-rose-300 truncate"
+                      title={[event.acl_rule_id, event.acl_reason].filter(Boolean).join(': ')}
+                    >
+                      {event.acl_rule_id || 'ACL'} · {event.acl_reason || 'Denied by policy'}
+                    </p>
+                  )}
                 </div>
                 <div className="col-span-2">{actionBadge(eventAction(event))}</div>
                 <div className="col-span-2 text-right font-bold text-slate-200">{event.status}</div>


### PR DESCRIPTION
## Summary

- Emit policy events with `acl_rule_id` and `acl_reason` when ACL denies CONNECT tunnels (previously only HTTP requests were logged with full ACL context).
- Propagate ACL decision fields through `CacheEvent`, ClickHouse schema, cache-indexer stores/search API, and Trust UI Threat Stream.
- Add runtime device registry backed by agent heartbeats (`GET /api/v1/devices`, `POST /api/v1/devices/{id}/revoke`) so Trust UI Device Identity shows observed agents instead of placeholders.

## Test plan

- [x] `cargo test -p bsdm-events -p cache-indexer -p bsdm-proxy --lib`
- [x] `cargo test -p bsdm-proxy-e2e --test e2e e2e_acl_denied_connect_emits_policy_event`
- [ ] Verify Threat UI shows ACL rule/reason on blocked events
- [ ] Verify device list populates after agent heartbeat and revoke marks device as Revoked
- [ ] Apply ClickHouse migration (`acl_rule_id`, `acl_reason` columns) on existing deployments


Made with [Cursor](https://cursor.com)