### PR TITLE
fix: require credentials for Admin Console mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Make Admin Console mutations fail closed without an in-memory API token, add
+  an explicit read-only banner, and document the console exposure threat model.
 - Reject `POLICY_MODE=full-mitm` in the default `production` deployment profile;
   local development/test use now requires an explicit `ALLOW_FULL_MITM=true` override.
 - Update optional WASM runtime `wasmtime` to 46.0.2 to address

--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -104,6 +104,12 @@ in memory for the current browser tab only. When APIs are unreachable, the
 console shows an explicit service error unless the operator has deliberately
 enabled demo mode.
 
+Without an attached API token the console operates in **read-only safety
+mode**. The shared HTTP client rejects every POST, PUT, PATCH, and DELETE before
+the request reaches the network. The persistent shell banner links directly to
+Settings → Console API, where an operator can attach a token for the current
+tab.
+
 ## Identity and version
 
 The shell identifies itself as a **local, unauthenticated console** until a real
@@ -114,6 +120,9 @@ requests; they do not create a UI identity.
 The displayed product version is injected at build time from
 [`proxy/Cargo.toml`](../proxy/Cargo.toml), the same manifest used to build the
 proxy binary.
+
+The console exposure threat model and deployment requirements are documented
+in [`docs/features/admin-console-security.md`](../docs/features/admin-console-security.md).
 
 ## UI/UX deliverables
 

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "oxlint",
+    "test": "node --test test/*.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/admin-console/src/api/client.ts
+++ b/admin-console/src/api/client.ts
@@ -1,4 +1,5 @@
 import { resolveApiSettings } from './settings'
+import { mutationRequiresCredentials } from './mutationGuard'
 
 export class ApiError extends Error {
   status: number
@@ -16,25 +17,36 @@ export interface RequestOptions {
   signal?: AbortSignal
 }
 
+export const MUTATION_CREDENTIALS_REQUIRED_MESSAGE =
+  'API credentials are required for mutating requests. Open Settings → Console API and attach a token for this browser tab.'
+
+export function requireMutationCredentials(method: string, token: string): void {
+  if (mutationRequiresCredentials(method, token)) {
+    throw new ApiError(MUTATION_CREDENTIALS_REQUIRED_MESSAGE, 401)
+  }
+}
+
 export async function apiFetch<T>(
   path: string,
   options: RequestOptions & { method?: string; body?: unknown } = {},
 ): Promise<T> {
   const base = options.baseUrl ?? ''
   const url = `${base}${path}`
+  const method = options.method ?? 'GET'
+  const token = options.token ?? ''
+  requireMutationCredentials(method, token)
   const headers: Record<string, string> = {
     Accept: 'application/json',
   }
   if (options.body !== undefined) {
     headers['Content-Type'] = 'application/json'
   }
-  const token = options.token ?? ''
   if (token) {
     headers.Authorization = `Bearer ${token}`
   }
 
   const res = await fetch(url, {
-    method: options.method ?? 'GET',
+    method,
     headers,
     body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
     signal: options.signal,

--- a/admin-console/src/api/mutationGuard.ts
+++ b/admin-console/src/api/mutationGuard.ts
@@ -1,0 +1,7 @@
+export function isReadOnlyMethod(method: string): boolean {
+  return ['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase())
+}
+
+export function mutationRequiresCredentials(method: string, token: string): boolean {
+  return !isReadOnlyMethod(method) && token.trim().length === 0
+}

--- a/admin-console/src/api/settings.ts
+++ b/admin-console/src/api/settings.ts
@@ -27,6 +27,7 @@ export interface ResolvedApiSettings {
 }
 
 const STORAGE_KEY = 'bsdm-admin-api-settings'
+export const API_CREDENTIALS_CHANGED_EVENT = 'bsdm-api-credentials-changed'
 
 const defaults: ApiSettings = {
   connectionMode: 'single',
@@ -95,6 +96,13 @@ export function saveApiSettings(settings: ApiSettings): void {
     controlToken: settings.controlToken,
   }
   localStorage.setItem(STORAGE_KEY, JSON.stringify(apiSettingsForStorage(settings)))
+  window.dispatchEvent(new CustomEvent(API_CREDENTIALS_CHANGED_EVENT))
+}
+
+export function hasApiCredentials(settings: ApiSettings = loadApiSettings()): boolean {
+  const resolved = resolveApiSettings(settings)
+  return [resolved.searchToken, resolved.aclToken, resolved.mlToken, resolved.controlToken]
+    .some((token) => token.trim().length > 0)
 }
 
 /**

--- a/admin-console/src/components/layout/AppLayout.tsx
+++ b/admin-console/src/components/layout/AppLayout.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, type ReactNode } from 'react'
-import { useLocation } from 'react-router-dom'
-import { Menu, Search, Command, ShieldAlert, ChevronRight } from 'lucide-react'
+import { Link, useLocation } from 'react-router-dom'
+import { Menu, Search, Command, ShieldAlert, ChevronRight, KeyRound } from 'lucide-react'
 import { Sidebar } from './Sidebar'
 import { CommandPalette } from '../ui/CommandPalette'
+import { API_CREDENTIALS_CHANGED_EVENT, hasApiCredentials } from '../../api/settings'
 
 interface AppLayoutProps {
   children: ReactNode
@@ -11,12 +12,19 @@ interface AppLayoutProps {
 export function AppLayout({ children }: AppLayoutProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [cmdOpen, setCmdOpen] = useState(false)
+  const [credentialsAttached, setCredentialsAttached] = useState(hasApiCredentials)
   const location = useLocation()
 
   useEffect(() => {
     const handleToggle = () => setCmdOpen((prev) => !prev)
     window.addEventListener('toggle-command-palette', handleToggle)
     return () => window.removeEventListener('toggle-command-palette', handleToggle)
+  }, [])
+
+  useEffect(() => {
+    const refreshCredentials = () => setCredentialsAttached(hasApiCredentials())
+    window.addEventListener(API_CREDENTIALS_CHANGED_EVENT, refreshCredentials)
+    return () => window.removeEventListener(API_CREDENTIALS_CHANGED_EVENT, refreshCredentials)
   }, [])
 
   const routeConfig: Record<string, { title: string; category: string }> = {
@@ -82,6 +90,23 @@ export function AppLayout({ children }: AppLayoutProps) {
           </div>
         </header>
 
+        {!credentialsAttached && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-warning/30 bg-warning/10 px-4 py-2.5 text-sm text-warning sm:px-6">
+            <div className="flex items-center gap-2">
+              <KeyRound className="size-4 shrink-0" />
+              <span>
+                <strong>Read-only safety mode.</strong> Mutating API requests are blocked until a token is attached.
+              </span>
+            </div>
+            <Link
+              to="/settings?tab=api"
+              className="rounded-md border border-warning/40 bg-warning/10 px-3 py-1.5 text-xs font-bold text-warning transition-colors hover:bg-warning/20"
+            >
+              Attach API token
+            </Link>
+          </div>
+        )}
+
         <main className="flex-1 overflow-y-auto p-4 sm:p-6 lg:p-8">{children}</main>
       </div>
 
@@ -89,4 +114,3 @@ export function AppLayout({ children }: AppLayoutProps) {
     </div>
   )
 }
-

--- a/admin-console/src/pages/Settings.tsx
+++ b/admin-console/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import {
   CheckCircle2,
   CircleDashed,
@@ -61,7 +62,9 @@ export function SettingsPage() {
   const { toast } = useToast()
   const [form, setForm] = useState<ConfigFormState>(() => loadSavedForm())
   const [apiSettings, setApiSettings] = useState<ApiSettings>(() => loadApiSettings())
-  const [tab, setTab] = useState<SettingsTab>('general')
+  const [searchParams] = useSearchParams()
+  const requestedTab = searchParams.get('tab')
+  const [tab, setTab] = useState<SettingsTab>(() => isSettingsTab(requestedTab) ? requestedTab : 'general')
   const [preview, setPreview] = useState<{ title: string; content: string } | null>(null)
   const [demoEnabled, setDemoEnabled] = useState(isDemoMode)
   const [applying, setApplying] = useState(false)
@@ -76,6 +79,10 @@ export function SettingsPage() {
         // Control API may be offline; local form state remains usable.
       })
   }, [])
+
+  useEffect(() => {
+    if (isSettingsTab(requestedTab)) setTab(requestedTab)
+  }, [requestedTab])
 
   const update = useCallback(<K extends keyof ConfigFormState>(key: K, value: ConfigFormState[K]) => {
     setForm((prev) => {
@@ -231,6 +238,10 @@ export function SettingsPage() {
       </Modal>
     </div>
   )
+}
+
+function isSettingsTab(value: string | null): value is SettingsTab {
+  return tabs.some((tab) => tab.id === value)
 }
 
 function LiveNodePanel({ tr }: { tr: any }) {

--- a/admin-console/test/mutationGuard.test.ts
+++ b/admin-console/test/mutationGuard.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isReadOnlyMethod, mutationRequiresCredentials } from '../src/api/mutationGuard.ts'
+
+test('read-only methods remain available without credentials', () => {
+  for (const method of ['GET', 'get', 'HEAD', 'OPTIONS']) {
+    assert.equal(isReadOnlyMethod(method), true)
+    assert.equal(mutationRequiresCredentials(method, ''), false)
+  }
+})
+
+test('mutating methods require a non-empty token', () => {
+  for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+    assert.equal(mutationRequiresCredentials(method, ''), true)
+    assert.equal(mutationRequiresCredentials(method, '   '), true)
+    assert.equal(mutationRequiresCredentials(method, 'session-token'), false)
+  }
+})

--- a/docs/features/admin-console-security.md
+++ b/docs/features/admin-console-security.md
@@ -1,0 +1,46 @@
+# Admin Console security model
+
+The Admin Console is an operator UI, not an authentication provider. It does
+not establish a user identity, role, or browser login session. The shell must
+therefore identify itself as a local, unauthenticated console even when an API
+token is attached.
+
+## Assets and trust boundaries
+
+- Policy, user, DNS, cache, and runtime configuration mutations are privileged.
+- API tokens entered in the console authorize individual backend requests.
+- Tokens remain in JavaScript memory for the current browser tab and are not
+  written to `localStorage`.
+- The browser, the network path, the gateway serving `/admin`, and each backend
+  API are separate trust boundaries.
+
+## Threats and controls
+
+| Threat | Control |
+|---|---|
+| An unauthenticated visitor opens the SPA and triggers a mutation | The shared API client rejects POST, PUT, PATCH, and DELETE locally when no token is attached. |
+| The UI implies a verified operator identity | The shell displays `Local console` and `Unauthenticated`; no fabricated username or directory role is shown. |
+| A token is recovered from persistent browser storage | API tokens are session-memory only and disappear on reload or tab close. |
+| The console or Control API is reachable from an untrusted network | Deploy an authenticated access gateway, restrict the metrics/control listener, and configure `CONTROL_API_TOKEN`/`ACL_API_TOKEN`. |
+| A caller bypasses the UI and invokes the backend directly | Backend token checks and network policy remain mandatory; the browser guard is defense in depth, not an API security boundary. |
+
+## Safe deployment requirements
+
+1. Do not expose `/admin` or `METRICS_PORT` directly to an untrusted network.
+2. Configure strong `CONTROL_API_TOKEN` and `ACL_API_TOKEN` values for every
+   deployment that enables mutating endpoints.
+3. Terminate operator authentication at a trusted gateway until the Admin
+   Console has a backend session contract and route guards.
+4. Treat a configured API token as request authorization only, never as proof
+   of a named user or role.
+5. Use the read-only monitoring routes without credentials only when their
+   backing endpoints are intentionally public inside the trusted operator
+   network.
+
+## Residual risk
+
+The short-term guard prevents accidental or UI-driven unauthenticated
+mutations. It does not protect an otherwise unauthenticated Control API from a
+direct HTTP client, provide CSRF/session semantics, or create audit attribution
+for a human operator. Those controls require backend authentication and an
+operator session contract.

--- a/docs/features/control-plane.md
+++ b/docs/features/control-plane.md
@@ -10,6 +10,11 @@ Proxy embeds static UI routing directly into the binary:
 - **Admin Console**: Available at `http://127.0.0.1:9090/admin/` (or via reverse proxy).
 - **Trust-UI**: Available at `http://127.0.0.1:9090/trust/` (end-user posture & policy portal).
 
+The Admin Console runs in read-only safety mode until an API token is attached
+for the current browser tab. This UI guard is defense in depth and does not
+replace backend tokens or network isolation. See
+[Admin Console security model](admin-console-security.md).
+
 ## Auth
 
 | Variable | Role |


### PR DESCRIPTION
## What changed

- reject POST, PUT, PATCH, and DELETE in the shared Admin Console client when no API token is attached
- keep read-only GET, HEAD, and OPTIONS requests available
- add a persistent read-only safety banner with a direct link to Console API settings
- make the token status update immediately when credentials change in the current tab
- support deep-linking to `Settings → Console API`
- document the Admin Console threat model, trust boundaries, deployment requirements, and residual risks
- add dependency-free tests for the mutation guard

## Why

The shell already described itself as a local, unauthenticated console, but that
status was informational only. Mutating requests could still leave the browser
with an empty token and reach a backend whose token defaults might be weak or
unset.

## Impact

Operators can continue to use intentionally public read-only monitoring views.
Policy and configuration changes now fail closed in the browser until a token
is attached for the current tab. The token authorizes API requests but does not
fabricate a user identity or authenticated browser session.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`
- `git diff --check`
- browser QA: banner layout, settings deep link, and blocked Save & Apply request without a token

Closes #279
