### PR TITLE
feat: add safe CA rotation tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Run CA rotation drill
+        run: ./scripts/test-ca-rotation.sh
+
       - name: Setup Rust environment
         uses: ./.github/actions/setup-rust
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Add two-phase CA rotation tooling with key-permission validation, archived
+  rollback material, an automated offline rotation drill, and emergency guidance.
 - Make Admin Console mutations fail closed without an in-memory API token, add
   an explicit read-only banner, and document the console exposure threat model.
 - Reject `POLICY_MODE=full-mitm` in the default `production` deployment profile;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup build run run-lite test lint docker-lite docker-full docker-down install package clean
+.PHONY: help setup rotate-ca-drill build run run-lite test lint docker-lite docker-full docker-down install package clean
 
 # Default target
 help:
@@ -8,6 +8,7 @@ help:
 	@echo ""
 	@echo "Targets:"
 	@echo "  setup         Generate CA certificates for MITM"
+	@echo "  rotate-ca-drill  Run an offline CA rotation rehearsal"
 	@echo "  build         Build all workspace members in release mode"
 	@echo "  run           Run the proxy locally (default features)"
 	@echo "  run-lite      Run the proxy locally (lite mode, no Kafka)"
@@ -24,6 +25,9 @@ help:
 setup:
 	@echo "Generating MITM CA certificates..."
 	./scripts/gen-ca.sh
+
+rotate-ca-drill:
+	./scripts/test-ca-rotation.sh
 
 build:
 	cargo build --release --workspace

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ E2E:
 | [Pilot deployment](docs/getting-started/pilot-deployment.md) | 100 пользователей, TTL 5 дней |
 | [Capacity planning](docs/architecture/capacity-planning.md) | Формулы и масштабирование |
 | [Configuration](docs/ops-and-dev/configuration.md) | Переменные окружения |
+| [CA lifecycle](docs/ops-and-dev/ca-lifecycle.md) | Хранение, ротация и аварийный отзыв MITM CA |
 | [Architecture](docs/architecture/overview.md) | Компоненты и потоки |
 | [Roadmap](docs/roadmap.md) | Стратегия развития |
 | [Documentation maintenance](docs/maintenance.md) | Правила и Wiki sync |

--- a/charts/bsdm/README.md
+++ b/charts/bsdm/README.md
@@ -35,6 +35,9 @@ kubectl create secret generic bsdm-mitm-ca -n bsdm-proxy \
 ```
 
 Set `mitm.existingSecret: bsdm-mitm-ca` in values.
+The chart mounts Secret files read-only with mode `0440`; the pod `fsGroup` grants
+the non-root proxy process access without making CA material world-readable. See
+the [CA lifecycle and rotation guide](../../docs/ops-and-dev/ca-lifecycle.md).
 
 ## Values
 

--- a/charts/bsdm/templates/deployment.yaml
+++ b/charts/bsdm/templates/deployment.yaml
@@ -118,6 +118,7 @@ spec:
         - name: mitm-certs
           secret:
             secretName: {{ .Values.mitm.existingSecret }}
+            defaultMode: 0440
         {{- end }}
         {{- if and .Values.acl.enabled .Values.acl.existingConfigMap }}
         - name: acl-rules

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -53,7 +53,7 @@ spill:
 
 mitm:
   enabled: true
-  existingSecret: ""          # if set, mount /certs from secret keys ca.crt, ca.key
+  existingSecret: ""          # mounted 0440 (root:fsGroup); never world-readable
   certMountPath: /certs
 
 acl:

--- a/docs/ops-and-dev/ca-lifecycle.md
+++ b/docs/ops-and-dev/ca-lifecycle.md
@@ -1,46 +1,121 @@
-# CA Lifecycle Management & Security Policy
+# CA lifecycle and rotation
 
-This document details the generation, distribution, rotation, audit, and revocation procedures for BSDM-Proxy TLS MITM Certificate Authority (CA) keypairs (Issue #252).
+BSDM-Proxy uses a private root CA when TLS interception is enabled. Treat its
+private key as a production signing key: possession of `ca.key` permits issuing
+certificates trusted by every enrolled client.
 
----
+## Generation and storage requirements
 
-## 1. Generation & Storage
+Generate the initial pair with:
 
-### 1.1 Private Key Generation
-The root CA keypair must be generated using RSA 4096 or ECDSA P-384:
 ```bash
 ./scripts/gen-ca.sh
+./scripts/rotate-ca.sh verify
 ```
-Keys are generated at `./certs/ca.key` (Private Key) and `./certs/ca.crt` (Public Certificate).
 
-### 1.2 Access Control & Protection
-- `ca.key` MUST be mode `0600` owned by the proxy service user.
-- In production Kubernetes environments, `ca.key` MUST be loaded via Kubernetes Secret or HashiCorp Vault integration, never stored in container images or Git.
+Local generation creates `certs/ca.key` with mode `0600`, `certs/ca.crt` with
+mode `0644`, and the containing directory with mode `0700`.
 
----
+- Never commit the key, bake it into an image, attach it to a ticket, or copy it
+  into a world-readable/shared volume.
+- The private key must have no permissions for `other`. Local files should be
+  `0600`; a Kubernetes Secret may be `0440` when a dedicated pod `fsGroup` needs
+  read access. The Helm chart enforces `0440` and a read-only mount.
+- Restrict Secret/Vault read access to the proxy service identity and the small
+  operator group responsible for CA rotation. Enable access audit logs.
+- Keep backups encrypted, access-controlled, and separate from application
+  backups. Record every export and restore.
+- Do not place CA material on RWX or generally shared storage. Mount it read-only
+  in the proxy container.
 
-## 2. Client Certificate Distribution
+Clients must trust only the public `ca.crt`. Distribute it through the managed
+trust channel for the platform (MDM/GPO/configuration management), never by
+distributing `ca.key`.
 
-Clients (browsers, desktop OS, mobile MDM) must trust `ca.crt`:
-- **Windows**: Store in `Cert:\LocalMachine\Root`
-- **macOS**: `security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ca.crt`
-- **Linux**: `/usr/local/share/ca-certificates/` followed by `update-ca-certificates`
+## Planned two-phase rotation
 
----
+Rotate at least annually, before certificate expiry, or immediately after
+suspected key compromise.
 
-## 3. Rotation Protocol
+### 1. Prepare and establish dual trust
 
-CA rotation must be executed annually or immediately upon suspected key compromise.
+```bash
+./scripts/rotate-ca.sh prepare --common-name "BSDM Root CA 2027"
+./scripts/rotate-ca.sh verify certs/rotation/<timestamp>
+```
 
-1. **Phase 1 (Dual-Trust)**: Push new CA certificate `ca_v2.crt` to all client endpoints via MDM while retaining `ca_v1.crt`.
-2. **Phase 2 (Proxy Key Swap)**: Update proxy `certs/ca.key` and `certs/ca.crt` to `v2`.
-3. **Phase 3 (Cleanup)**: After verification, remove `ca_v1.crt` from client endpoints.
+The command prints the staged directory and SHA-256 fingerprint. Store that
+fingerprint in the change record. Distribute only the staged `ca.crt` to clients,
+while keeping the current root installed. Confirm both fingerprints are present
+on a representative client sample.
 
----
+### 2. Activate during a maintenance window
 
-## 4. Emergency Revocation
+Stop or drain the proxy first; CA files are loaded at process startup.
 
-If `ca.key` is compromised:
-1. Immediately set `POLICY_MODE=sni` to halt TLS decryption across all nodes.
-2. Revoke and remove `ca.crt` from MDM profiles on client devices.
-3. Generate fresh CA keypair and restart rotation procedure.
+```bash
+./scripts/rotate-ca.sh activate certs/rotation/<timestamp>
+# restart the proxy using the deployment-specific command
+curl --cacert certs/ca.crt -x http://127.0.0.1:3128 https://httpbin.org/uuid
+```
+
+Activation validates the key/certificate match, CA constraint, expiry, and key
+permissions. It archives the previous pair under `certs/archive/<timestamp>/`,
+installs the new pair, and removes the duplicate staged private key.
+
+Verify HTTPS interception from each managed client class and check proxy TLS
+errors. If verification fails, stop the proxy, restore the archived pair as
+`certs/ca.key` and `certs/ca.crt`, enforce `0600` on the key, and restart.
+
+### 3. Retire the old root
+
+After the agreed observation window:
+
+1. Remove the old public root from all client trust profiles.
+2. Confirm unmanaged copies are not trusted on the representative client sample.
+3. Move the archived private key to the approved encrypted backup or destroy it
+   according to the organisation's key-destruction policy.
+4. Close the change record with old/new fingerprints, client coverage, operator,
+   timestamps, and verification evidence.
+
+## Automated rotation drill
+
+Run the offline drill without touching the active `certs/` directory:
+
+```bash
+make rotate-ca-drill
+```
+
+The drill creates a temporary initial CA, prepares and validates a new CA,
+confirms that a world-readable key is rejected, activates the new pair, verifies
+that the fingerprint changed, checks the archive, and deletes the temporary data.
+CI runs the same drill for every pull request.
+
+Successful baseline drill recorded on **2026-08-04**:
+
+```text
+CA rotation drill passed
+Old SHA-256: C6:97:F7:2F:FF:20:99:B7:22:1B:5E:08:28:74:49:5E:E8:60:4C:26:C4:5A:EF:E4:7A:4C:63:50:55:0D:C2:DE
+New SHA-256: 78:94:90:FE:07:3C:4E:F9:92:A5:B6:D1:13:9C:9A:DD:20:02:2B:0E:AB:B9:08:70:34:69:8F:47:D7:FD:F6:53
+```
+
+The fingerprints belong only to disposable drill keys, not production material.
+
+## Emergency revocation checklist
+
+When compromise is suspected, preserve incident evidence but prioritise stopping
+new certificate issuance:
+
+- [ ] Declare the incident, record time/scope, and identify the exposed CA fingerprint.
+- [ ] Immediately disable TLS interception on every node (`POLICY_MODE=sni`) and
+      restart/roll out the proxy fleet.
+- [ ] Remove the compromised public root from MDM/GPO trust profiles; force an
+      urgent client policy refresh and verify removal on representative clients.
+- [ ] Revoke the compromised Secret/Vault version and deny further reads. Preserve
+      relevant access/audit logs under incident-retention controls.
+- [ ] Generate a new CA in a clean, approved environment. Never reuse the key.
+- [ ] Distribute the new public root, rotate proxy nodes, and verify fingerprints
+      and HTTPS service per the planned procedure above.
+- [ ] Search for certificates issued by the compromised CA and investigate misuse.
+- [ ] Destroy unapproved copies, rotate credentials that could access CA storage,
+      document client coverage, and obtain incident-owner sign-off before closure.

--- a/scripts/gen-ca.sh
+++ b/scripts/gen-ca.sh
@@ -6,22 +6,40 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CERT_DIR="${ROOT}/certs"
 FORCE=false
 
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --force|-f) FORCE=true ;;
+    --cert-dir)
+      [[ $# -ge 2 ]] || { echo "error: --cert-dir requires a path" >&2; exit 2; }
+      CERT_DIR="$2"
+      shift
+      ;;
     -h|--help)
-      echo "Usage: $0 [--force]"
+      echo "Usage: $0 [--force] [--cert-dir PATH]"
       echo "  Writes ${CERT_DIR}/ca.key and ca.crt (4096-bit RSA, 10y)."
       exit 0
       ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      exit 2
+      ;;
   esac
+  shift
 done
 
+umask 077
 mkdir -p "${CERT_DIR}"
+chmod 700 "${CERT_DIR}"
 
-if [[ -f "${CERT_DIR}/ca.key" && -f "${CERT_DIR}/ca.crt" && "${FORCE}" != true ]]; then
-  echo "CA already exists at ${CERT_DIR}/ (use --force to regenerate)"
-  exit 0
+if [[ -e "${CERT_DIR}/ca.key" || -e "${CERT_DIR}/ca.crt" ]]; then
+  if [[ -f "${CERT_DIR}/ca.key" && -f "${CERT_DIR}/ca.crt" && "${FORCE}" != true ]]; then
+    echo "CA already exists at ${CERT_DIR}/ (use --force to regenerate)"
+    exit 0
+  fi
+  if [[ "${FORCE}" != true ]]; then
+    echo "error: incomplete CA pair exists at ${CERT_DIR}/; inspect it and use --force to replace both files" >&2
+    exit 1
+  fi
 fi
 
 if ! command -v openssl >/dev/null 2>&1; then
@@ -29,7 +47,6 @@ if ! command -v openssl >/dev/null 2>&1; then
   exit 1
 fi
 
-umask 077
 openssl genrsa -out "${CERT_DIR}/ca.key" 4096
 openssl req -new -x509 -days 3650 -key "${CERT_DIR}/ca.key" -out "${CERT_DIR}/ca.crt" \
   -subj "/C=RU/ST=Moscow/L=Moscow/O=BSDM/CN=BSDM Root CA"

--- a/scripts/rotate-ca.sh
+++ b/scripts/rotate-ca.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# Prepare, validate, and activate BSDM MITM CA keypairs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CERT_DIR="${ROOT}/certs"
+COMMON_NAME="BSDM Root CA"
+DAYS=3650
+
+usage() {
+  cat <<'EOF'
+Usage:
+  rotate-ca.sh prepare [--cert-dir PATH] [--common-name NAME] [--days N]
+  rotate-ca.sh verify [PATH] [--cert-dir PATH]
+  rotate-ca.sh activate STAGED_PATH [--cert-dir PATH]
+
+prepare   Generate a new restricted CA pair under CERT_DIR/rotation/.
+verify    Validate a CA pair and reject group/world-readable private keys.
+activate  Archive the current pair, then install a validated staged pair.
+
+Stop the proxy before activation. Distribute the staged ca.crt to clients before
+activation so clients trust both the current and new roots during the swap.
+EOF
+}
+
+file_mode() {
+  if stat -f '%Lp' "$1" >/dev/null 2>&1; then
+    stat -f '%Lp' "$1"
+  else
+    stat -c '%a' "$1"
+  fi
+}
+
+fingerprint() {
+  openssl x509 -in "$1" -noout -fingerprint -sha256 | cut -d= -f2
+}
+
+validate_pair() {
+  local pair_dir="$1"
+  local key="${pair_dir}/ca.key"
+  local cert="${pair_dir}/ca.crt"
+  local mode key_pub cert_pub
+
+  [[ -f "${key}" ]] || { echo "error: missing ${key}" >&2; return 1; }
+  [[ -f "${cert}" ]] || { echo "error: missing ${cert}" >&2; return 1; }
+
+  mode="$(file_mode "${key}")"
+  [[ "${mode}" =~ ^[0-7]{3,4}$ ]] || { echo "error: cannot validate key mode: ${mode}" >&2; return 1; }
+  if (( (8#${mode} & 077) != 0 )); then
+    echo "error: ${key} must not be readable, writable, or executable by group/other (mode ${mode})" >&2
+    return 1
+  fi
+
+  openssl pkey -in "${key}" -noout -check >/dev/null
+  openssl x509 -in "${cert}" -noout -checkend 0 >/dev/null
+  openssl x509 -in "${cert}" -noout -text | grep -q 'CA:TRUE'
+
+  key_pub="$(openssl pkey -in "${key}" -pubout -outform PEM 2>/dev/null | openssl sha256)"
+  cert_pub="$(openssl x509 -in "${cert}" -pubkey -noout | openssl sha256)"
+  [[ "${key_pub}" == "${cert_pub}" ]] || { echo "error: CA key and certificate do not match" >&2; return 1; }
+
+  echo "Valid CA: $(fingerprint "${cert}")"
+}
+
+[[ $# -gt 0 ]] || { usage; exit 2; }
+COMMAND="$1"
+shift
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cert-dir)
+      [[ $# -ge 2 ]] || { echo "error: --cert-dir requires a path" >&2; exit 2; }
+      CERT_DIR="$2"
+      shift
+      ;;
+    --common-name)
+      [[ $# -ge 2 ]] || { echo "error: --common-name requires a value" >&2; exit 2; }
+      COMMON_NAME="$2"
+      shift
+      ;;
+    --days)
+      [[ $# -ge 2 ]] || { echo "error: --days requires a value" >&2; exit 2; }
+      DAYS="$2"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *) POSITIONAL+=("$1") ;;
+  esac
+  shift
+done
+
+command -v openssl >/dev/null 2>&1 || { echo "error: openssl is required" >&2; exit 1; }
+[[ "${DAYS}" =~ ^[1-9][0-9]*$ ]] || { echo "error: --days must be a positive integer" >&2; exit 2; }
+[[ "${COMMON_NAME}" != *"/"* && "${COMMON_NAME}" != *$'\n'* ]] || {
+  echo "error: --common-name must not contain '/' or a newline" >&2
+  exit 2
+}
+
+case "${COMMAND}" in
+  -h|--help)
+    usage
+    ;;
+  prepare)
+    [[ ${#POSITIONAL[@]} -eq 0 ]] || { usage; exit 2; }
+    umask 077
+    mkdir -p "${CERT_DIR}/rotation"
+    chmod 700 "${CERT_DIR}" "${CERT_DIR}/rotation"
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    stage_dir="${CERT_DIR}/rotation/${timestamp}"
+    [[ ! -e "${stage_dir}" ]] || stage_dir="${stage_dir}-$$"
+    mkdir "${stage_dir}"
+    openssl genrsa -out "${stage_dir}/ca.key" 4096
+    openssl req -new -x509 -days "${DAYS}" -key "${stage_dir}/ca.key" -out "${stage_dir}/ca.crt" \
+      -subj "/O=BSDM/CN=${COMMON_NAME}"
+    chmod 600 "${stage_dir}/ca.key"
+    chmod 644 "${stage_dir}/ca.crt"
+    validate_pair "${stage_dir}"
+    echo "Prepared CA: ${stage_dir}"
+    echo "Distribute ${stage_dir}/ca.crt before activation. Keep ca.key private."
+    ;;
+  verify)
+    [[ ${#POSITIONAL[@]} -le 1 ]] || { usage; exit 2; }
+    validate_pair "${POSITIONAL[0]:-${CERT_DIR}}"
+    ;;
+  activate)
+    [[ ${#POSITIONAL[@]} -eq 1 ]] || { usage; exit 2; }
+    stage_dir="${POSITIONAL[0]}"
+    validate_pair "${stage_dir}"
+    [[ -f "${CERT_DIR}/ca.key" && -f "${CERT_DIR}/ca.crt" ]] || {
+      echo "error: active CA pair is incomplete or missing; use gen-ca.sh for initial setup" >&2
+      exit 1
+    }
+    validate_pair "${CERT_DIR}"
+    [[ "$(fingerprint "${stage_dir}/ca.crt")" != "$(fingerprint "${CERT_DIR}/ca.crt")" ]] || {
+      echo "error: staged and active CA certificates are identical" >&2
+      exit 1
+    }
+
+    umask 077
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    archive_dir="${CERT_DIR}/archive/${timestamp}"
+    [[ ! -e "${archive_dir}" ]] || archive_dir="${archive_dir}-$$"
+    mkdir -p "${archive_dir}"
+    chmod 700 "${CERT_DIR}" "${CERT_DIR}/archive" "${archive_dir}"
+    install -m 600 "${CERT_DIR}/ca.key" "${archive_dir}/ca.key"
+    install -m 644 "${CERT_DIR}/ca.crt" "${archive_dir}/ca.crt"
+
+    activation_complete=false
+    rollback_activation() {
+      local exit_code=$?
+      trap - ERR
+      rm -f "${CERT_DIR}/.ca.key.new" "${CERT_DIR}/.ca.crt.new"
+      if [[ "${activation_complete}" != true ]]; then
+        install -m 600 "${archive_dir}/ca.key" "${CERT_DIR}/ca.key"
+        install -m 644 "${archive_dir}/ca.crt" "${CERT_DIR}/ca.crt"
+        echo "error: activation failed; restored archived CA" >&2
+      fi
+      exit "${exit_code}"
+    }
+    trap rollback_activation ERR
+
+    install -m 600 "${stage_dir}/ca.key" "${CERT_DIR}/.ca.key.new"
+    install -m 644 "${stage_dir}/ca.crt" "${CERT_DIR}/.ca.crt.new"
+    mv "${CERT_DIR}/.ca.key.new" "${CERT_DIR}/ca.key"
+    mv "${CERT_DIR}/.ca.crt.new" "${CERT_DIR}/ca.crt"
+    validate_pair "${CERT_DIR}"
+    activation_complete=true
+    trap - ERR
+    rm -f "${stage_dir}/ca.key"
+
+    echo "Activated CA: $(fingerprint "${CERT_DIR}/ca.crt")"
+    echo "Archived previous CA: ${archive_dir}"
+    echo "Restart the proxy, verify HTTPS, then remove the old client trust root."
+    ;;
+  *)
+    echo "error: unknown command: ${COMMAND}" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/test-ca-rotation.sh
+++ b/scripts/test-ca-rotation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Offline rotation drill used locally and by CI.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DRILL_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bsdm-ca-drill.XXXXXX")"
+trap 'rm -rf "${DRILL_DIR}"' EXIT
+CERT_DIR="${DRILL_DIR}/certs"
+
+mkdir -p "${DRILL_DIR}/incomplete"
+touch "${DRILL_DIR}/incomplete/ca.key"
+if "${ROOT}/scripts/gen-ca.sh" --cert-dir "${DRILL_DIR}/incomplete" >/dev/null 2>&1; then
+  echo "CA generator accepted an incomplete existing pair" >&2
+  exit 1
+fi
+
+"${ROOT}/scripts/gen-ca.sh" --cert-dir "${CERT_DIR}" >/dev/null
+old_fingerprint="$(openssl x509 -in "${CERT_DIR}/ca.crt" -noout -fingerprint -sha256 | cut -d= -f2)"
+
+prepare_output="$("${ROOT}/scripts/rotate-ca.sh" prepare --cert-dir "${CERT_DIR}" --common-name "BSDM Rotation Drill")"
+stage_dir="$(printf '%s\n' "${prepare_output}" | sed -n 's/^Prepared CA: //p')"
+[[ -n "${stage_dir}" && -d "${stage_dir}" ]]
+
+"${ROOT}/scripts/rotate-ca.sh" verify "${stage_dir}" >/dev/null
+chmod 644 "${stage_dir}/ca.key"
+if "${ROOT}/scripts/rotate-ca.sh" verify "${stage_dir}" >/dev/null 2>&1; then
+  echo "rotation verifier accepted a world-readable private key" >&2
+  exit 1
+fi
+chmod 600 "${stage_dir}/ca.key"
+"${ROOT}/scripts/rotate-ca.sh" activate "${stage_dir}" --cert-dir "${CERT_DIR}" >/dev/null
+"${ROOT}/scripts/rotate-ca.sh" verify --cert-dir "${CERT_DIR}" >/dev/null
+
+new_fingerprint="$(openssl x509 -in "${CERT_DIR}/ca.crt" -noout -fingerprint -sha256 | cut -d= -f2)"
+[[ "${old_fingerprint}" != "${new_fingerprint}" ]]
+[[ ! -f "${stage_dir}/ca.key" ]]
+[[ "$(find "${CERT_DIR}/archive" -name ca.key -type f | wc -l | tr -d ' ')" == "1" ]]
+
+if stat -f '%Lp' "${CERT_DIR}/ca.key" >/dev/null 2>&1; then
+  key_mode="$(stat -f '%Lp' "${CERT_DIR}/ca.key")"
+else
+  key_mode="$(stat -c '%a' "${CERT_DIR}/ca.key")"
+fi
+[[ "${key_mode}" == "600" ]]
+
+echo "CA rotation drill passed"
+echo "Old SHA-256: ${old_fingerprint}"
+echo "New SHA-256: ${new_fingerprint}"


### PR DESCRIPTION
## What changed

- add `rotate-ca.sh` commands to prepare, verify, and activate a new MITM CA
- reject incomplete CA pairs and group/world-accessible private keys
- archive the previous pair and restore it automatically if activation fails
- add an offline rotation drill and run it in CI
- mount Kubernetes CA Secret files read-only with mode `0440`
- expand the lifecycle guide with storage requirements, rotation evidence, rollback, and an emergency revocation checklist

## Why

The repository documented CA rotation but had no practical, tested operator path. Manual replacement could leave mismatched files, duplicate exposed keys, or no reliable rollback material.

## Impact

Operators can establish dual trust, stage and validate a new CA, perform a controlled maintenance-window swap, and retain a restricted rollback copy. Initial CA generation now fails closed when only one member of a pair already exists.

## Validation

- `bash -n scripts/gen-ca.sh scripts/rotate-ca.sh scripts/test-ca-rotation.sh`
- `make rotate-ca-drill`
- `python3 scripts/check-doc-links.py`
- `git diff --check`

Closes #268
