### PR TITLE
feat: make Admin Console the primary operator UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update optional WASM runtime `wasmtime` to 46.0.2 to address
   RUSTSEC-2026-0222 and RUSTSEC-2026-0223.
 
+### Changed
+
+- Make Admin Console the only supported operator UI, redirect legacy `/trust`
+  entry points to `/admin/`, and move standalone Trust-UI behind an explicit
+  experimental Compose profile.
+
 ### Added
 
 - **Policy decision-source observability** — Added bounded Prometheus counters,

--- a/Dockerfile
+++ b/Dockerfile
@@ -205,7 +205,7 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 CMD ["dns-sinkhole"]
 
 # ============================================================
-# Trust-UI web console (Vite + React 19 + Tailwind v4)
+# Experimental legacy Trust-UI reference (not part of default deployments)
 # ============================================================
 FROM node:22-alpine AS trust-ui-builder
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ security-модулями.
 | Detection | alert-worker, UEBA/phishing/beacon ML, threat-score write-back |
 | Extensions | DNS sinkhole/DoH/DoT, semantic cache, WASM, ICAP, AWG |
 | Operations | REST/gRPC control plane, Prometheus, Helm, systemd packaging |
+| Operator UI | Admin Console at `/admin/` (single supported UI) |
 
 Большинство optional/experimental-компонентов выключено по умолчанию. Исключения,
 включая встроенные DLP-паттерны, перечислены в
@@ -171,6 +172,7 @@ E2E:
 | [Project status](docs/project-status.md) | Зрелость и ограничения функций |
 | [Agent contract](docs/architecture/agent-contract.md) | Протокол взаимодействия локального агента v0.1 |
 | [ADR 0005: Hybrid Policy Agent](docs/adr/0005-local-policy-agent-vs-tunnel-first.md) | Архитектурное решение гибридной фильтрации |
+| [ADR 0006: Single Operator Console](docs/adr/0006-single-operator-console.md) | Единая поддерживаемая операторская UI |
 | [Pilot deployment](docs/getting-started/pilot-deployment.md) | 100 пользователей, TTL 5 дней |
 | [Capacity planning](docs/architecture/capacity-planning.md) | Формулы и масштабирование |
 | [Configuration](docs/ops-and-dev/configuration.md) | Переменные окружения |

--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -2,6 +2,10 @@
 
 Unified **single pane of glass** for BSDM-Proxy: monitoring dashboard, traffic logs with explainable ML decisions, ACL policies, and configuration export.
 
+This is the only supported operator UI. The canonical embedded entry point is
+`/admin/`; `/` and legacy `/trust` paths redirect there. See
+[ADR 0006](../docs/adr/0006-single-operator-console.md).
+
 Replaces the legacy static [`web-config/`](../web-config/) generator with a modern React SPA.
 
 ## Stack
@@ -30,6 +34,11 @@ Replaces the legacy static [`web-config/`](../web-config/) generator with a mode
 | `/users` | Basic-auth user management |
 | `/settings` | Live node state + config generator (cache, auth, filtering, threat/ML, hierarchy/TLS, rate-limit/eBPF/Wasm, events) |
 
+These pages replace the supported overlap with the former standalone Trust-UI:
+Dashboard owns node/security posture, Logs owns the recent decision stream, and
+Threat Scores owns ML posture. Endpoint inventory remains deferred with the
+Agent and is not represented as a working operator feature.
+
 The default sidebar only advertises the supported Hybrid operator paths above.
 Frozen modules remain directly routable for development and compatibility, but
 are intentionally hidden from primary navigation:
@@ -56,7 +65,7 @@ shown on the core Policies workflow.
 cd admin-console
 npm install
 npm run dev
-# → http://127.0.0.1:5173
+# → http://127.0.0.1:5173/admin/
 ```
 
 ### Production build
@@ -67,11 +76,9 @@ npm run preview
 # static output in dist/
 ```
 
-Serve `dist/` behind nginx or embed in your deployment. Example:
-
-```bash
-docker run -d -p 8080:80 -v $(pwd)/admin-console/dist:/usr/share/nginx/html:ro nginx:alpine
-```
+The production bundle uses `/admin/` as its asset and router base. Serve it on
+that path with an SPA fallback to `/admin/index.html`, or let BSDM-Proxy serve
+`dist/` through native UI routing.
 
 ## API integration
 

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -16,7 +16,7 @@ import { Users } from './pages/Users'
 
 export function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <AppLayout>
         <Routes>
           <Route path="/" element={<DashboardPage />} />

--- a/admin-console/vite.config.ts
+++ b/admin-console/vite.config.ts
@@ -15,10 +15,10 @@ const bearerHeaders = (token: string | undefined) =>
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  base: '/admin/',
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
   },
-  base: '/',
   server: {
     port: 5173,
     proxy: {

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -112,6 +112,7 @@ services:
     restart: unless-stopped
 
   trust-ui:
+    profiles: ["experimental-trust-ui"]
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -307,6 +307,7 @@ services:
       test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:9093/-/healthy || exit 1"]
 
   trust-ui:
+    profiles: ["experimental-trust-ui"]
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ GitHub Wiki является автоматически обновляемым �
 - [ADR 0003: ML feature store](adr/0003-ml-worker-feature-store.md)
 - [ADR 0004: DNS sinkhole](adr/0004-dns-sinkhole-sidecar.md)
 - [ADR 0005: Local policy agent](adr/0005-local-policy-agent-vs-tunnel-first.md)
+- [ADR 0006: One supported operator console](adr/0006-single-operator-console.md)
 - [Roadmap](roadmap.md)
 - [Release notes (v0.8.0)](releases/v0.8.0.md)
 

--- a/docs/adr/0006-single-operator-console.md
+++ b/docs/adr/0006-single-operator-console.md
@@ -1,0 +1,69 @@
+# ADR 0006: One supported operator console
+
+- **Status**: Accepted
+- **Date**: 2026-08-04
+- **Deciders**: BSDM Core Architecture Team
+- **Issues**: #275, #280
+
+## Context
+
+The repository contains two React applications with overlapping monitoring and
+security concepts:
+
+- Admin Console, historically served at `/admin/`;
+- Trust-UI, historically served at `/trust/` or on port `3001`.
+
+They use different navigation, deployment paths, and API assumptions. Maintaining
+both as supported operator surfaces makes it unclear where an operator should
+inspect current posture, traffic decisions, and threat signals.
+
+## Decision
+
+Admin Console is the only supported operator interface. Its canonical embedded
+entry point is `/admin/` on the proxy control origin. `/` and every legacy
+`/trust` path permanently redirect to `/admin/`.
+
+The Admin Console build and client router both use `/admin/` as their base path,
+so direct links, refreshes, and static assets share the same deployment contract.
+
+The existing `trust-ui/` source remains temporarily as an experimental design
+reference for endpoint posture concepts. It is not started by default, does not
+define a production security boundary, and receives no new operator features.
+Its Compose service is available only through the `experimental-trust-ui`
+profile while remaining in CI to prevent accidental source decay.
+
+Admin Console owns the supported overlapping workflows:
+
+| Operator need | Canonical Admin Console path |
+|---|---|
+| Node health and security counters | Dashboard `/` inside the SPA |
+| Recent traffic and policy decisions | `/logs` |
+| ML threat posture and drill-down | `/threat-scores` |
+| Runtime policy and configuration | `/policies`, `/settings` |
+
+Endpoint inventory/posture from the experimental Trust-UI is not presented as a
+supported feature until the local Agent and its authenticated device contract
+leave deferred scope. If that happens, the workflow will be implemented inside
+Admin Console using its router, auth model, and shared API client.
+
+## Consequences
+
+### Positive
+
+- Operators have one entry point, navigation model, and credential flow.
+- Existing `/trust` bookmarks converge safely through a compatibility redirect.
+- Compose no longer starts a second overlapping UI by default.
+- Future posture work has an explicit destination and cannot silently create a
+  third API/base-URL contract.
+
+### Negative
+
+- Trust-UI-specific layouts are no longer a supported deployment surface.
+- Consumers embedding `/trust/` must follow the redirect or move links to
+  `/admin/`.
+
+## Reconsider when
+
+Revisit this decision only if a separately authenticated end-user portal has a
+documented audience and security boundary distinct from operator administration.
+That portal must not duplicate operator controls and needs its own ADR.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -65,8 +65,8 @@ CONNECT работает в двух режимах:
 | alert-worker | `alert-worker/` | Periodic ClickHouse rules → webhook |
 | ml-worker | `ml-worker/` | Feature extraction, scoring и write-back |
 | dns-sinkhole | `dns-sinkhole/` | UDP DNS, DoH (8484), DoT (853) и RPZ filtering |
-| trust-ui | `trust-ui/` | Пользовательский веб-портал доверия и статуса (`/trust/`) |
-| admin-console | `admin-console/` | Административная веб-консоль управления (`/admin/`) |
+| admin-console | `admin-console/` | Единственная поддерживаемая операторская консоль (`/admin/`) |
+| trust-ui | `trust-ui/` | Experimental/deprecated reference; legacy `/trust` перенаправляется в Admin Console |
 | agent-spike | `examples/agent-spike/` | Референсный локальный агент согласно Agent Contract v0.1 |
 | monitoring | `prometheus/`, `grafana/`, `alertmanager/` | Metrics, dashboards и alerts |
 

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -31,8 +31,8 @@ bsdm-proxy/
 ├── bsdm-events/            # Shared event schema
 ├── bsdm-wasm-sdk/          # WASM SDK
 ├── e2e/                    # Integration test harness
-├── admin-console/          # React SPA управления (`/admin/`)
-├── trust-ui/               # End-user Trust portal SPA (`/trust/`)
+├── admin-console/          # Поддерживаемая operator SPA (`/admin/`)
+├── trust-ui/               # Experimental/deprecated posture reference
 ├── charts/bsdm/            # Helm chart
 ├── packaging/              # systemd package и env examples
 ├── config/                 # ACL examples
@@ -59,7 +59,9 @@ bsdm-proxy/
 | `docker-compose.ha.yml` | HA lab sketch |
 | `docker-compose.awg.yml` | Experimental AWG sidecar |
 
-Основной Compose включает `dns-sinkhole` в базовом стеке; профили опциональных компонентов: `alerts`, `ml`, `icap`.
+Основной Compose включает `dns-sinkhole` в базовом стеке; профили опциональных
+компонентов: `alerts`, `ml`, `icap`. Legacy Trust-UI запускается только явным
+профилем `experimental-trust-ui`; поддерживаемая операторская UI — Admin Console.
 
 ## Конфигурация и данные
 

--- a/docs/features/control-plane.md
+++ b/docs/features/control-plane.md
@@ -6,9 +6,13 @@ See also: [roadmap.md](../roadmap.md) · [acl.md](acl-policy.md) · [Agent Contr
 
 ## Native UI Routing
 
-Proxy embeds static UI routing directly into the binary:
-- **Admin Console**: Available at `http://127.0.0.1:9090/admin/` (or via reverse proxy).
-- **Trust-UI**: Available at `http://127.0.0.1:9090/trust/` (end-user posture & policy portal).
+Proxy serves one supported operator UI directly from the control origin:
+
+- **Admin Console**: `http://127.0.0.1:9090/admin/` (or the equivalent gateway origin).
+- `/` and legacy `/trust` paths return a permanent redirect to `/admin/`.
+
+Standalone Trust-UI is an experimental legacy reference and is not part of the
+default deployment. See [ADR 0006](../adr/0006-single-operator-console.md).
 
 The Admin Console runs in read-only safety mode until an API token is attached
 for the current browser tab. This UI guard is defense in depth and does not

--- a/docs/ops-and-dev/development.md
+++ b/docs/ops-and-dev/development.md
@@ -292,7 +292,7 @@ ls scripts/archive/
 | Workflow | Trigger | Description |
 |----------|---------|-------------|
 | [ci.yml](../../.github/workflows/ci.yml) | push/PR → main | fmt, clippy, build, tests (unit + e2e + smoke), cargo-audit |
-| [trust-ui.yml](../../.github/workflows/trust-ui.yml) | push/PR → main | npm build & typecheck for trust-ui |
+| [trust-ui.yml](../../.github/workflows/trust-ui.yml) | push/PR → main | build-check experimental/deprecated Trust-UI reference |
 | [admin-console.yml](../../.github/workflows/admin-console.yml) | push/PR → main | npm lint & build for admin-console |
 | [load-test.yml](../../.github/workflows/load-test.yml) | push/PR → main | wrk high-intensity load test |
 | [release.yml](../../.github/workflows/release.yml) | push tag `v*` / manual | test, build packages, GitHub Release |

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -38,7 +38,8 @@
 | Network | eBPF/XDP manager | Experimental (Frozen) | Заморожено. `EBPF_XDP_ENABLED` интерфейс. |
 | Remote access | AmneziaWG sidecar/config API | Experimental (Frozen) | Заморожено. |
 | Cluster | Global sessions, distributed rate limit, threat sync | Experimental (Frozen) | Scaffolding gRPC mesh. |
-| Admin UI & Trust UI | Native Static UI Routing | Beta | Native UI routing на `/admin` (Admin Console) и `/trust` (Trust-UI) прямо через proxy binary. |
+| Admin UI | Admin Console | Beta | Единственная поддерживаемая операторская UI на `/admin/`; `/` и legacy `/trust` перенаправляются туда. |
+| UI reference | Standalone Trust-UI | Experimental (Deprecated) | Не запускается по умолчанию; сохранён только как reference для будущего Agent posture. |
 
 ## Известные ограничения
 

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use hyper::header::HeaderValue;
-use hyper::header::AUTHORIZATION;
+use hyper::header::{AUTHORIZATION, LOCATION};
 use hyper::{HeaderMap, Method, Request, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -612,7 +612,6 @@ pub struct ControlApiState {
     awg_server: Arc<tokio::sync::RwLock<crate::amneziawg::AwgServerConfig>>,
     session_store: crate::session_store::GlobalSessionStore,
     threat_sync: crate::threat_sync::ThreatSyncEngine,
-    trust_ui_dir: Option<std::path::PathBuf>,
     admin_console_dir: Option<std::path::PathBuf>,
     devices: Arc<RwLock<HashMap<String, RegisteredDevice>>>,
     shutdown_tx: Option<watch::Sender<bool>>,
@@ -659,17 +658,6 @@ impl ControlApiState {
             )),
             session_store,
             threat_sync,
-            trust_ui_dir: std::env::var("TRUST_UI_DIR")
-                .ok()
-                .map(std::path::PathBuf::from)
-                .or_else(|| {
-                    let p = std::path::PathBuf::from("./trust-ui/dist");
-                    if p.exists() {
-                        Some(p)
-                    } else {
-                        None
-                    }
-                }),
             admin_console_dir: std::env::var("ADMIN_CONSOLE_DIR")
                 .ok()
                 .map(std::path::PathBuf::from)
@@ -840,17 +828,29 @@ impl ControlApiState {
             return json_response(StatusCode::BAD_REQUEST, r#"{"error":"invalid path"}"#);
         }
 
-        let base_dir = if path.starts_with("/admin") {
-            self.admin_console_dir
-                .clone()
-                .unwrap_or_else(|| std::path::PathBuf::from("./admin-console/dist"))
-        } else {
-            self.trust_ui_dir
-                .clone()
-                .unwrap_or_else(|| std::path::PathBuf::from("./trust-ui/dist"))
-        };
+        // Admin Console is the canonical operator surface. Keep legacy entry
+        // points as redirects so existing bookmarks converge on one UI.
+        if path == "/" || path == "/admin" || path == "/trust" || path.starts_with("/trust/") {
+            return Response::builder()
+                .status(StatusCode::PERMANENT_REDIRECT)
+                .header(LOCATION, "/admin/")
+                .body(full(Bytes::new()))
+                .unwrap_or_else(|_| {
+                    json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        r#"{"error":"internal error"}"#,
+                    )
+                });
+        }
 
-        let relative_path = path.trim_start_matches('/');
+        let base_dir = self
+            .admin_console_dir
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("./admin-console/dist"));
+
+        let relative_path = path
+            .strip_prefix("/admin/")
+            .unwrap_or_else(|| path.trim_start_matches('/'));
         let target = if relative_path.is_empty() {
             base_dir.join("index.html")
         } else {
@@ -1662,6 +1662,51 @@ mod tests {
 
         let resp_null = state.serve_static_ui("/index.html\0.png").await;
         assert_eq!(resp_null.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn legacy_ui_entries_redirect_to_admin_console() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let state = state_plain(metrics, cache);
+
+        for path in ["/", "/admin", "/trust", "/trust/", "/trust/devices"] {
+            let resp = state.serve_static_ui(path).await;
+            assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT, "{path}");
+            assert_eq!(resp.headers().get(LOCATION).unwrap(), "/admin/", "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn admin_console_serves_prefixed_routes_and_assets() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let mut state = state_plain(metrics, cache);
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("assets")).unwrap();
+        std::fs::write(dir.path().join("index.html"), "admin-index").unwrap();
+        std::fs::write(dir.path().join("assets/app.js"), "admin-asset").unwrap();
+        state.admin_console_dir = Some(dir.path().to_path_buf());
+
+        let index = state.serve_static_ui("/admin/").await;
+        assert_eq!(index.status(), StatusCode::OK);
+        assert_eq!(
+            BodyExt::collect(index.into_body())
+                .await
+                .unwrap()
+                .to_bytes(),
+            "admin-index"
+        );
+
+        let asset = state.serve_static_ui("/admin/assets/app.js").await;
+        assert_eq!(asset.status(), StatusCode::OK);
+        assert_eq!(
+            BodyExt::collect(asset.into_body())
+                .await
+                .unwrap()
+                .to_bytes(),
+            "admin-asset"
+        );
     }
 
     #[tokio::test]

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -113,8 +113,10 @@ pub async fn metrics_server(
                             if let Some(api) = &control_api {
                                 if path.starts_with("/api/")
                                     || path == "/"
-                                    || path.starts_with("/trust")
-                                    || path.starts_with("/admin")
+                                    || path == "/trust"
+                                    || path.starts_with("/trust/")
+                                    || path == "/admin"
+                                    || path.starts_with("/admin/")
                                     || path.starts_with("/assets")
                                     || path.ends_with(".svg")
                                     || path.ends_with(".png")

--- a/trust-ui/README.md
+++ b/trust-ui/README.md
@@ -1,22 +1,16 @@
-# Trust-UI
+# Trust-UI (experimental legacy reference)
 
-**Trust-UI** is the live Zero-Trust posture dashboard for **BSDM-Proxy**.
+Trust-UI is no longer a supported operator surface. BSDM Admin Console is the
+single supported interface, available at `/admin/`; the proxy redirects legacy
+`/trust` links there. The architectural decision is recorded in
+[ADR 0006](../docs/adr/0006-single-operator-console.md).
 
-Trust-UI has no demo mode and never substitutes synthetic values when a backend
-is unavailable. Failed, unsupported, and empty APIs are shown explicitly in the
-interface.
+This source tree is retained temporarily as a design reference for future
+endpoint identity/posture work. It is not a security boundary, is not included
+in default deployments, and should not receive new operator features. Current
+posture APIs depend on deferred Agent functionality and may return unsupported.
 
-## Features
-
-- **Node health and runtime stats** from `/health` and `/api/stats`.
-- **Security counters** parsed from the proxy `/metrics` endpoint.
-- **Recent traffic decisions** polled from the cache-indexer `/api/search` endpoint.
-- **Device identity posture** from `/api/v1/devices` when that API is implemented
-  by the deployment. Current BSDM nodes return an explicit unsupported state.
-
-## Getting Started
-
-### Development Mode
+## Reference development only
 
 ```bash
 cd trust-ui
@@ -24,24 +18,16 @@ npm install
 npm run dev
 ```
 
-The application runs on `http://localhost:3001` by default. The Vite development
-server routes proxy health/stats/metrics and future device identity requests to
-`127.0.0.1:9090`, and search requests to the cache-indexer on
-`127.0.0.1:8080`.
+The reference development server listens on `http://127.0.0.1:3001`. It uses
+same-origin browser paths and its Vite-only development proxy sends health,
+stats, metrics, and device requests to `127.0.0.1:9090`, plus search requests to
+`127.0.0.1:8080`. It does not use the forward-proxy port.
 
-Production deployments must expose the same paths through the origin serving
-Trust-UI.
-
-The repository's `trust-ui` Docker image includes an Nginx configuration that
-routes health, stats, and metrics to the `proxy` compose service and search
-requests to `cache-indexer`. `SEARCH_API_TOKEN` and `CONTROL_API_TOKEN` are
-injected into the Nginx configuration at container startup and remain outside
-the browser bundle.
-
-### Production Build
+To inspect the legacy container explicitly:
 
 ```bash
-npm run build
+docker compose --profile experimental-trust-ui up trust-ui
 ```
 
-This compiles static assets into `dist/`.
+The dedicated CI workflow still builds this source to catch accidental
+breakage. A passing build does not promote it beyond Experimental status.


### PR DESCRIPTION
## What changed

- record ADR 0006: Admin Console is the only supported operator UI
- permanently redirect `/`, `/trust`, and `/trust/*` to `/admin/`
- align the Admin Console Vite build and React router on the `/admin/` base path
- serve Admin Console prefixed routes and assets through native proxy routing
- move standalone Trust-UI behind the explicit `experimental-trust-ui` Compose profile
- document where health, decisions, and ML posture live in Admin Console
- mark Trust-UI as an experimental/deprecated reference for deferred Agent posture work

## Why

Two overlapping frontends created conflicting entry points, navigation, deployment ports, and API assumptions. The operator could not tell which UI was authoritative.

## Impact

Operators now have one canonical entry point and one credential/navigation model. Existing Trust-UI bookmarks converge through a compatibility redirect. The old source remains build-checked and explicitly launchable for reference, but no longer starts in default Compose deployments.

## Validation

- `cargo clippy -p bsdm-proxy --lib -- -D warnings`
- `cargo test -p bsdm-proxy --lib control_api` — 14 passed
- `npm test && npm run lint && npm run build` in `admin-console/`
- full and Lite `docker compose config --services`, with and without `experimental-trust-ui`
- `python3 scripts/check-doc-links.py`
- browser QA of `/admin/`, client navigation to `/admin/logs`, and direct `/admin/threat-scores`
- `git diff --check`

Closes #275
