### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   ci:
     name: Format, Lint, Build, Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/onixus/bsdm-proxy/security/code-scanning/27](https://github.com/onixus/bsdm-proxy/security/code-scanning/27)

Add an explicit `permissions` block for the `ci` job to enforce least privilege for `GITHUB_TOKEN`.

Best single fix here (minimal and non-disruptive): in `.github/workflows/ci.yml`, under `jobs.ci` (alongside `name` and `runs-on`), add:

- `permissions:`
- `contents: read`

This keeps current behavior (checkout/read operations) while preventing unintended write scopes inherited from repo/org defaults. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
