### PR TITLE
ci: add portable Jenkins CI/CD pipeline

### DIFF
--- a/.github/workflows/admin-console.yml
+++ b/.github/workflows/admin-console.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'admin-console/**'
+      - 'scripts/ci/**'
       - '.github/workflows/admin-console.yml'
   pull_request:
     branches: [main]
     paths:
       - 'admin-console/**'
+      - 'scripts/ci/**'
       - '.github/workflows/admin-console.yml'
 
 concurrency:
@@ -23,9 +25,6 @@ jobs:
   build:
     name: Build & Lint
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: admin-console
     steps:
       - uses: actions/checkout@v4
 
@@ -35,17 +34,12 @@ jobs:
           cache: npm
           cache-dependency-path: admin-console/package-lock.json
 
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run build
-      - run: npm test
+      - name: Lint, test, and build
+        run: ./scripts/ci/run.sh admin-console-core
 
   ui-smoke:
     name: Local UI smoke test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: admin-console
     steps:
       - uses: actions/checkout@v4
 
@@ -55,13 +49,11 @@ jobs:
           cache: npm
           cache-dependency-path: admin-console/package-lock.json
 
-      - run: npm ci
-      - name: Install Chromium
-        run: npx playwright-core install --with-deps chromium
       - name: Build and drive the console against the fixture backend
-        run: npm run test:ui
+        run: ./scripts/ci/run.sh admin-console-ui
         env:
           UI_TEST_SCREENSHOTS: '1'
+          PLAYWRIGHT_INSTALL_DEPS: '1'
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run CA rotation drill
-        run: ./scripts/test-ca-rotation.sh
+        run: ./scripts/ci/run.sh rust-ca
 
       - name: Setup Rust environment
         uses: ./.github/actions/setup-rust
@@ -33,31 +33,25 @@ jobs:
           components: rustfmt,clippy
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: ./scripts/ci/run.sh rust-fmt
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: ./scripts/ci/run.sh rust-clippy
 
       - name: Build workspace
-        run: cargo build --workspace --all-targets
+        run: ./scripts/ci/run.sh rust-build
 
       - name: Build lite profile (no rdkafka)
-        run: |
-          cargo build -p bsdm-proxy --no-default-features --features auth-basic --all-targets
-          cargo build -p cache-indexer --no-default-features --all-targets
+        run: ./scripts/ci/run.sh rust-lite
 
       - name: Run tests (unit + e2e + smoke)
-        run: cargo test --workspace --all-targets
+        run: ./scripts/ci/run.sh rust-test
 
       - name: Build and test gRPC control plane feature
-        run: |
-          cargo clippy -p bsdm-proxy --features grpc --all-targets -- -D warnings
-          cargo test -p bsdm-proxy --features grpc --lib -- control_grpc
+        run: ./scripts/ci/run.sh rust-grpc
 
       - name: Build and test Wasm plugin host feature
-        run: |
-          cargo clippy -p bsdm-proxy --features wasm --lib -- -D warnings
-          cargo test -p bsdm-proxy --features wasm --lib -- wasm_host
+        run: ./scripts/ci/run.sh rust-wasm
 
   security-audit:
     name: Security Audit

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -7,6 +7,7 @@ on:
       - 'proxy/**'
       - 'scripts/run-load-test.sh'
       - 'scripts/run-hybrid-load-test.sh'
+      - 'scripts/ci/**'
       - 'scripts/wrk-proxy.lua'
       - 'docker-compose.lite.yml'
       - '.github/workflows/load-test.yml'
@@ -16,6 +17,7 @@ on:
       - 'proxy/**'
       - 'scripts/run-load-test.sh'
       - 'scripts/run-hybrid-load-test.sh'
+      - 'scripts/ci/**'
       - 'scripts/wrk-proxy.lua'
       - 'docker-compose.lite.yml'
       - '.github/workflows/load-test.yml'
@@ -41,84 +43,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Generate MITM CA
-        run: |
-          ./scripts/gen-ca.sh
-          sudo chown -R 1000:1000 certs
+      - name: Run lite and hybrid load-test profiles
+        env:
+          RESULTS_DIR: /tmp/hybrid-load-results
+        run: ./scripts/ci/run.sh load-test
 
-      - name: Start bsdm-proxy (Lite Mode)
-        run: |
-          docker compose -f docker-compose.lite.yml up -d --build mock-upstream || {
-            echo "❌ Failed to start mock-upstream. Proxy logs:"
-            docker compose -f docker-compose.lite.yml logs proxy
-            echo "❌ Cache Indexer logs:"
-            docker compose -f docker-compose.lite.yml logs cache-indexer
-            exit 1
-          }
-
-      - name: Wait for Proxy Readiness
-        run: |
-          echo "Waiting for proxy to become healthy..."
-          for i in {1..30}; do
-            if curl -s -I http://localhost:9090/health | grep -q "HTTP/"; then
-              echo "✅ bsdm-proxy is healthy"
-              break
-            fi
-            sleep 1
-            if [ $i -eq 30 ]; then
-              echo "❌ Proxy did not start within 30 seconds"
-              docker compose -f docker-compose.lite.yml logs proxy
-              exit 1
-            fi
-          done
-
-          echo "Waiting for mock-upstream to become healthy..."
-          for i in {1..30}; do
-            if curl -s -I http://localhost:18080/ping | grep -q "HTTP/"; then
-              echo "✅ mock-upstream is healthy"
-              break
-            fi
-            sleep 1
-            if [ $i -eq 30 ]; then
-              echo "❌ mock-upstream did not start within 30 seconds"
-              docker compose -f docker-compose.lite.yml logs mock-upstream
-              exit 1
-            fi
-          done
-
-      - name: Run Standard Load Test Script
-        run: |
-          chmod +x ./scripts/run-load-test.sh
-          PROXY=http://127.0.0.1:3128 METRICS_URL=http://127.0.0.1:9090 UPSTREAM=http://127.0.0.1:18080 \
-            ./scripts/run-load-test.sh
-
-      - name: Run Hybrid Selective-MITM Profile (#269)
-        run: |
-          chmod +x ./scripts/run-hybrid-load-test.sh
-          # CI-friendly duration/users; public upstream may add RTT noise.
-          CONCURRENT_USERS=20 TEST_DURATION=20 \
-          PROXY=http://127.0.0.1:3128 METRICS_URL=http://127.0.0.1:9090 \
-          SNI_URL=http://127.0.0.1:18080/get \
-          MITM_URL=http://127.0.0.1:18080/get \
-          HTTP_URL=http://127.0.0.1:18080/get \
-          WRITE_RESULTS=1 \
-          RESULTS_DIR=/tmp/hybrid-load-results \
-            ./scripts/run-hybrid-load-test.sh
-          echo "=== Hybrid results ==="
-          cat /tmp/hybrid-load-results/latest.md
-
-      - name: Run High-Intensity wrk Benchmark
-        run: |
-          echo "=== Running wrk benchmark with wrk-proxy.lua ==="
-          wrk -t2 -c100 -d30s -s ./scripts/wrk-proxy.lua http://localhost:3128
-
-      - name: Container Resource Metrics
+      - name: Upload hybrid load-test result
+        uses: actions/upload-artifact@v4
         if: always()
-        run: |
-          echo "=== Container resource usage ==="
-          docker stats --no-stream
-
-      - name: Stop & Clean Stack
-        if: always()
-        run: |
-          docker compose -f docker-compose.lite.yml down -v
+        with:
+          name: hybrid-load-test-result
+          path: /tmp/hybrid-load-results
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,40 +50,23 @@ jobs:
 
       - name: Validate release metadata
         shell: bash
-        run: |
-          set -euo pipefail
-          VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' proxy/Cargo.toml | head -1)"
-          test -n "$VERSION"
-          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-            test "${GITHUB_REF_NAME}" = "v${VERSION}"
-          fi
-          for manifest in proxy bsdm-events cache-indexer alert-worker ml-worker dns-sinkhole; do
-            grep -q "^version = \"${VERSION}\"$" "${manifest}/Cargo.toml"
-          done
-          grep -q "^## \[${VERSION}\]" CHANGELOG.md
-          cargo metadata --locked --no-deps --format-version 1 >/dev/null
+        env:
+          CI_RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: ./scripts/ci/run.sh release-validate
 
       - name: Check formatting
-        run: cargo fmt --all -- --check
+        run: ./scripts/ci/run.sh rust-fmt
 
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: ./scripts/ci/run.sh rust-clippy
 
       - name: Run Rust tests
-        run: cargo test --workspace --all-targets
-
-      - name: Install Admin Console dependencies
-        working-directory: admin-console
-        run: npm ci
+        run: ./scripts/ci/run.sh rust-test
 
       - name: Validate Admin Console
-        working-directory: admin-console
-        run: |
-          npm run lint
-          npm test
-          npm run build
-          npx playwright-core install --with-deps chromium
-          npm run test:ui
+        env:
+          PLAYWRIGHT_INSTALL_DEPS: '1'
+        run: ./scripts/ci/run.sh admin-console
 
   build:
     name: Build package (${{ matrix.arch }})
@@ -100,8 +83,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
-      - run: ./scripts/build-package.sh
-      - run: cd dist && sha256sum -c *.tar.gz.sha256
+      - run: ./scripts/ci/run.sh package
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
       - uses: actions/upload-artifact@v4
         with:
           name: bsdm-proxy-package-${{ matrix.arch }}

--- a/.github/workflows/trust-ui.yml
+++ b/.github/workflows/trust-ui.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - 'trust-ui/**'
+      - 'scripts/ci/**'
       - '.github/workflows/trust-ui.yml'
   pull_request:
     branches: [main]
     paths:
       - 'trust-ui/**'
+      - 'scripts/ci/**'
       - '.github/workflows/trust-ui.yml'
 
 concurrency:
@@ -23,9 +25,6 @@ jobs:
   build:
     name: Build & Typecheck
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: trust-ui
     steps:
       - uses: actions/checkout@v4
 
@@ -35,5 +34,5 @@ jobs:
           cache: npm
           cache-dependency-path: trust-ui/package-lock.json
 
-      - run: npm ci
-      - run: npm run build
+      - name: Install and build
+        run: ./scripts/ci/run.sh trust-ui

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,333 @@
+pipeline {
+    agent none
+
+    parameters {
+        string(
+            name: 'CI_AGENT_LABEL',
+            defaultValue: 'linux && bsdm-ci',
+            description: 'Agent with Rust 1.88+, Node.js 24+, Python 3, and cargo-audit'
+        )
+        string(
+            name: 'DOCKER_AGENT_LABEL',
+            defaultValue: 'linux && docker',
+            description: 'Agent with Docker Buildx, Compose, curl, and wrk'
+        )
+        string(
+            name: 'AMD64_AGENT_LABEL',
+            defaultValue: 'linux && amd64 && bsdm-ci',
+            description: 'Native linux/amd64 package builder'
+        )
+        string(
+            name: 'ARM64_AGENT_LABEL',
+            defaultValue: 'linux && arm64 && bsdm-ci',
+            description: 'Native linux/arm64 package builder'
+        )
+        booleanParam(
+            name: 'RUN_UI_TESTS',
+            defaultValue: true,
+            description: 'Run the Chromium Admin Console smoke tests'
+        )
+        booleanParam(
+            name: 'RUN_LOAD_TESTS',
+            defaultValue: false,
+            description: 'Run the Docker-based lite and hybrid load-test profile'
+        )
+        booleanParam(
+            name: 'BUILD_PACKAGES',
+            defaultValue: false,
+            description: 'Build a native package on a non-tag build; tag builds always package amd64'
+        )
+        booleanParam(
+            name: 'BUILD_ARM64_PACKAGE',
+            defaultValue: false,
+            description: 'Also build a native package on the configured arm64 agent'
+        )
+        booleanParam(
+            name: 'PUBLISH_GITHUB_RELEASE',
+            defaultValue: false,
+            description: 'For tag builds only: create a GitHub Release from package artifacts'
+        )
+        booleanParam(
+            name: 'PUBLISH_GHCR_IMAGE',
+            defaultValue: false,
+            description: 'For tag builds only: publish the multi-platform image to GHCR'
+        )
+        string(
+            name: 'GITHUB_TOKEN_CREDENTIALS_ID',
+            defaultValue: 'bsdm-github-token',
+            description: 'Jenkins secret-text credential used by gh release create'
+        )
+        string(
+            name: 'GHCR_CREDENTIALS_ID',
+            defaultValue: 'bsdm-ghcr',
+            description: 'Jenkins username/password credential used for ghcr.io'
+        )
+        string(
+            name: 'GHCR_IMAGE',
+            defaultValue: 'ghcr.io/onixus/bsdm-proxy',
+            description: 'Fully qualified image repository'
+        )
+        string(
+            name: 'GHCR_PLATFORMS',
+            defaultValue: 'linux/amd64,linux/arm64',
+            description: 'Buildx target platforms'
+        )
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '10'))
+        timeout(time: 120, unit: 'MINUTES')
+        timestamps()
+        skipDefaultCheckout(true)
+        parallelsAlwaysFailFast()
+        preserveStashes(buildCount: 5)
+    }
+
+    environment {
+        CARGO_TERM_COLOR = 'always'
+        RUST_BACKTRACE = '1'
+    }
+
+    stages {
+        stage('Preflight') {
+            agent { label "${params.CI_AGENT_LABEL}" }
+            steps {
+                deleteDir()
+                checkout scm
+                sh './scripts/ci/run.sh preflight'
+                sh 'git rev-parse HEAD'
+            }
+        }
+
+        stage('Quality gates') {
+            parallel {
+                stage('Rust') {
+                    agent { label "${params.CI_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        sh './scripts/ci/run.sh rust-all'
+                    }
+                }
+
+                stage('Security audit') {
+                    agent { label "${params.CI_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        sh './scripts/ci/run.sh security-audit'
+                    }
+                }
+
+                stage('Documentation') {
+                    agent { label "${params.CI_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        sh './scripts/ci/run.sh docs'
+                    }
+                }
+
+                stage('Admin Console') {
+                    agent { label "${params.CI_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        withEnv([
+                            "RUN_UI_TESTS=${params.RUN_UI_TESTS ? '1' : '0'}",
+                            'UI_TEST_SCREENSHOTS=1'
+                        ]) {
+                            sh './scripts/ci/run.sh admin-console'
+                        }
+                    }
+                    post {
+                        always {
+                            archiveArtifacts(
+                                artifacts: 'admin-console/test/local/screenshots/**',
+                                allowEmptyArchive: true
+                            )
+                        }
+                    }
+                }
+
+                stage('Trust UI') {
+                    agent { label "${params.CI_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        sh './scripts/ci/run.sh trust-ui'
+                    }
+                }
+            }
+        }
+
+        stage('Load test') {
+            when {
+                beforeAgent true
+                expression { params.RUN_LOAD_TESTS }
+            }
+            agent { label "${params.DOCKER_AGENT_LABEL}" }
+            steps {
+                deleteDir()
+                checkout scm
+                sh './scripts/ci/run.sh load-test'
+            }
+            post {
+                always {
+                    archiveArtifacts(
+                        artifacts: 'load-test-results/**',
+                        allowEmptyArchive: true
+                    )
+                }
+            }
+        }
+
+        stage('Release metadata') {
+            when {
+                beforeAgent true
+                anyOf {
+                    buildingTag()
+                    expression { params.BUILD_PACKAGES }
+                    expression { params.PUBLISH_GITHUB_RELEASE }
+                    expression { params.PUBLISH_GHCR_IMAGE }
+                }
+            }
+            agent { label "${params.CI_AGENT_LABEL}" }
+            steps {
+                deleteDir()
+                checkout scm
+                withEnv(["CI_RELEASE_TAG=${env.TAG_NAME ?: ''}"]) {
+                    sh './scripts/ci/run.sh release-validate'
+                }
+            }
+        }
+
+        stage('Packages') {
+            when {
+                beforeAgent true
+                anyOf {
+                    buildingTag()
+                    expression { params.BUILD_PACKAGES }
+                }
+            }
+            parallel {
+                stage('Package amd64') {
+                    agent { label "${params.AMD64_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        withEnv(['EXPECTED_ARCH=x86_64']) {
+                            sh './scripts/ci/run.sh package'
+                        }
+                        archiveArtifacts(
+                            artifacts: 'dist/*.tar.gz,dist/*.tar.gz.sha256',
+                            fingerprint: true
+                        )
+                        stash(
+                            name: 'package-amd64',
+                            includes: 'dist/*.tar.gz,dist/*.tar.gz.sha256'
+                        )
+                    }
+                }
+
+                stage('Package arm64') {
+                    when {
+                        beforeAgent true
+                        expression { params.BUILD_ARM64_PACKAGE }
+                    }
+                    agent { label "${params.ARM64_AGENT_LABEL}" }
+                    steps {
+                        deleteDir()
+                        checkout scm
+                        withEnv(['EXPECTED_ARCH=aarch64']) {
+                            sh './scripts/ci/run.sh package'
+                        }
+                        archiveArtifacts(
+                            artifacts: 'dist/*.tar.gz,dist/*.tar.gz.sha256',
+                            fingerprint: true
+                        )
+                        stash(
+                            name: 'package-arm64',
+                            includes: 'dist/*.tar.gz,dist/*.tar.gz.sha256'
+                        )
+                    }
+                }
+            }
+        }
+
+        stage('Publish GitHub Release') {
+            when {
+                beforeAgent true
+                allOf {
+                    buildingTag()
+                    expression { params.PUBLISH_GITHUB_RELEASE }
+                }
+            }
+            agent { label "${params.CI_AGENT_LABEL}" }
+            steps {
+                deleteDir()
+                checkout scm
+                unstash 'package-amd64'
+                script {
+                    if (params.BUILD_ARM64_PACKAGE) {
+                        unstash 'package-arm64'
+                    }
+                }
+                withCredentials([
+                    string(
+                        credentialsId: params.GITHUB_TOKEN_CREDENTIALS_ID,
+                        variable: 'GH_TOKEN'
+                    )
+                ]) {
+                    sh './scripts/ci/publish-github-release.sh "$TAG_NAME"'
+                }
+            }
+        }
+
+        stage('Publish GHCR image') {
+            when {
+                beforeAgent true
+                allOf {
+                    buildingTag()
+                    expression { params.PUBLISH_GHCR_IMAGE }
+                }
+            }
+            agent { label "${params.DOCKER_AGENT_LABEL}" }
+            steps {
+                deleteDir()
+                checkout scm
+                withCredentials([
+                    usernamePassword(
+                        credentialsId: params.GHCR_CREDENTIALS_ID,
+                        usernameVariable: 'REGISTRY_USER',
+                        passwordVariable: 'REGISTRY_PASSWORD'
+                    )
+                ]) {
+                    withEnv([
+                        "IMAGE_NAME=${params.GHCR_IMAGE}",
+                        "PLATFORMS=${params.GHCR_PLATFORMS}"
+                    ]) {
+                        sh '''
+                            set +x
+                            trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+                            printf '%s' "$REGISTRY_PASSWORD" |
+                                docker login ghcr.io \
+                                    --username "$REGISTRY_USER" \
+                                    --password-stdin
+                            ./scripts/ci/publish-image.sh "$TAG_NAME"
+                        '''
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            echo 'BSDM-Proxy CI/CD pipeline completed successfully'
+        }
+        failure {
+            echo 'BSDM-Proxy CI/CD pipeline failed; inspect the first failed stage'
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup rotate-ca-drill backup-drill build run run-lite test lint docker-lite docker-full docker-down install package clean
+.PHONY: help setup rotate-ca-drill backup-drill build run run-lite test lint docker-lite docker-full docker-down install package clean ci ci-rust ci-docs ci-admin ci-trust ci-release-validate
 
 # Default target
 help:
@@ -20,6 +20,12 @@ help:
 	@echo "  docker-down   Stop and remove Docker Compose containers"
 	@echo "  install       Run the interactive Linux system installer"
 	@echo "  package       Build the Linux release package tarball"
+	@echo "  ci            Run the portable Rust, docs, and frontend CI contract"
+	@echo "  ci-rust       Run the complete Rust CI gate"
+	@echo "  ci-docs       Validate documentation and Wiki mappings"
+	@echo "  ci-admin      Validate the Admin Console"
+	@echo "  ci-trust      Validate the experimental Trust UI"
+	@echo "  ci-release-validate  Validate release metadata without publishing"
 	@echo "  clean         Clean Cargo build artifacts"
 	@echo ""
 
@@ -68,6 +74,23 @@ install:
 package:
 	@echo "Building release package..."
 	./scripts/build-package.sh
+
+ci: ci-rust ci-docs ci-admin ci-trust
+
+ci-rust:
+	./scripts/ci/run.sh rust-all
+
+ci-docs:
+	./scripts/ci/run.sh docs
+
+ci-admin:
+	./scripts/ci/run.sh admin-console
+
+ci-trust:
+	./scripts/ci/run.sh trust-ui
+
+ci-release-validate:
+	./scripts/ci/run.sh release-validate
 
 clean:
 	cargo clean

--- a/docs/ops-and-dev/development.md
+++ b/docs/ops-and-dev/development.md
@@ -149,6 +149,12 @@ documentation и frontend gates. Load test и CD-стадии отделены �
 smoke Chromium dependencies должны быть установлены в образе агента; сам browser
 кэшируется Playwright в пользовательском каталоге.
 
+Load-test wrapper перед запуском временно назначает сгенерированной CA владельца
+`CA_RUNTIME_UID:CA_RUNTIME_GID` (по умолчанию `1000:1000`, пользователь контейнера)
+и восстанавливает исходного владельца при cleanup. Если Docker-agent работает под
+другим UID, ему нужен passwordless `sudo chown`; режимы каталога `700` и ключа
+`600` не ослабляются.
+
 Создайте Multibranch Pipeline, укажите GitHub repository и оставьте Script Path
 `Jenkinsfile`. Для release jobs включите в GitHub Branch Source trait обнаружение
 тегов: `buildingTag()` и `TAG_NAME` доступны только для tag branch. Значения labels

--- a/docs/ops-and-dev/development.md
+++ b/docs/ops-and-dev/development.md
@@ -99,6 +99,96 @@ cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+### Единый CI-контракт
+
+Команды CI не дублируются в Jenkinsfile и GitHub Actions. Переносимый entrypoint:
+
+```bash
+./scripts/ci/run.sh --help
+./scripts/ci/run.sh rust-all
+./scripts/ci/run.sh docs
+RUN_UI_TESTS=0 ./scripts/ci/run.sh admin-console
+./scripts/ci/run.sh trust-ui
+./scripts/ci/run.sh release-validate
+```
+
+Для полного локального прогона без security audit, packaging и load test:
+
+```bash
+make ci
+```
+
+`security-audit` требует установленный `cargo-audit`, а `load-test` — Docker
+Buildx/Compose, `curl` и `wrk`. Публикующие скрипты не входят в `make ci` и не
+запускаются без отдельного release gate.
+
+## Jenkins CI/CD
+
+Корневой [Jenkinsfile](../../Jenkinsfile) предназначен для **Multibranch
+Pipeline**. Branch и pull request builds запускают параллельные Rust, RustSec,
+documentation и frontend gates. Load test и CD-стадии отделены параметрами.
+
+### Требования к Jenkins
+
+Минимальные controller plugins:
+
+- Pipeline: Declarative и Git;
+- Credentials Binding;
+- Timestamper.
+
+Рекомендуемые agent labels и содержимое:
+
+| Label по умолчанию | Требования |
+|---|---|
+| `linux && bsdm-ci` | Rust 1.88+, Node.js 24+, Python 3, `cargo-audit`, native build packages |
+| `linux && docker` | Docker Buildx/Compose, `curl`, `wrk`, доступ к Docker daemon |
+| `linux && amd64 && bsdm-ci` | Native x86_64 package build |
+| `linux && arm64 && bsdm-ci` | Optional native aarch64 package build |
+
+Для Debian/Ubuntu Rust-agent нужны пакеты из раздела «Требования» выше. Для UI
+smoke Chromium dependencies должны быть установлены в образе агента; сам browser
+кэшируется Playwright в пользовательском каталоге.
+
+Создайте Multibranch Pipeline, укажите GitHub repository и оставьте Script Path
+`Jenkinsfile`. Для release jobs включите в GitHub Branch Source trait обнаружение
+тегов: `buildingTag()` и `TAG_NAME` доступны только для tag branch. Значения labels
+можно переопределить параметрами job без изменения репозитория.
+
+### Параметры и release gates
+
+| Параметр | По умолчанию | Поведение |
+|---|---:|---|
+| `RUN_UI_TESTS` | `true` | Chromium smoke для Admin Console |
+| `RUN_LOAD_TESTS` | `false` | Lite/hybrid Docker profile и архив результата |
+| `BUILD_PACKAGES` | `false` | Native amd64 package для non-tag build |
+| `BUILD_ARM64_PACKAGE` | `false` | Дополнительная сборка на arm64-agent |
+| `PUBLISH_GITHUB_RELEASE` | `false` | Публикация package artifacts только из tag build |
+| `PUBLISH_GHCR_IMAGE` | `false` | Multi-platform Buildx push только из tag build |
+
+Tag build всегда проверяет соответствие `vX.Y.Z` версии product crates,
+`CHANGELOG.md`, `docs/releases/vX.Y.Z.md` и `Cargo.lock`, после чего собирает
+amd64 package. Публикация требует одновременно tag build и явный boolean gate.
+Существующий GitHub Release не перезаписывается; тег `latest` для GHCR обновляется
+только стабильным релизом без prerelease suffix.
+
+Credentials хранятся только в Jenkins Credentials Store:
+
+| Credentials ID по умолчанию | Тип | Минимальные права |
+|---|---|---|
+| `bsdm-github-token` | Secret text | GitHub repository contents: write |
+| `bsdm-ghcr` | Username with password/token | GitHub Packages: write |
+
+Секреты подключаются через `withCredentials`, не передаются параметрами и не
+сохраняются в artifacts. Для dry run включите только `BUILD_PACKAGES`; publish
+flags оставьте выключенными.
+
+Publish stages запускайте только на выделенных trusted agents без параллельных
+untrusted jobs: credentials существуют в environment процесса во время binding.
+Пока GitHub Actions `release.yml` и `docker-publish.yml` остаются включены, Jenkins
+должен использоваться для CI и package dry run, а оба Jenkins publish flag должны
+оставаться `false`. Перед переносом CD выберите один writer и отключите публикацию
+во втором контуре, чтобы tag build не создавал конкурирующие releases/images.
+
 ## Тесты
 
 ### Workspace
@@ -229,9 +319,11 @@ npm run test:ui   # сборка + прогон Chromium по всем марш�
 
 См. [kubernetes.md](k8s-architecture.md) и [k8s-architecture.md](k8s-architecture.md) — Helm chart `charts/bsdm/`, probes, HA.
 
-## GitHub Release (CI)
+## GitHub Release (CI/CD)
 
 Workflow [release.yml](../../.github/workflows/release.yml) публикует release при push тега `v*`.
+Jenkins использует тот же `scripts/ci/validate-release.sh`, но publication в нём
+дополнительно требует ручного `PUBLISH_GITHUB_RELEASE=true`.
 
 ### Порядок релиза
 

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Publish the already-built dist artifacts as a GitHub Release.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TAG="${1:-${CI_RELEASE_TAG:-}}"
+if [[ ! "$TAG" =~ ^v.+ ]]; then
+  echo "usage: publish-github-release.sh <vX.Y.Z>" >&2
+  exit 1
+fi
+
+for command_name in gh sha256sum; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "required command is not available: ${command_name}" >&2
+    exit 1
+  fi
+done
+
+CI_RELEASE_TAG="$TAG" ./scripts/ci/validate-release.sh
+shopt -s nullglob
+archives=(dist/*.tar.gz)
+checksums=(dist/*.tar.gz.sha256)
+if (( ${#archives[@]} == 0 || ${#checksums[@]} == 0 )); then
+  echo "release artifacts are missing in dist/" >&2
+  exit 1
+fi
+
+(
+  cd dist
+  sha256sum -c ./*.tar.gz.sha256
+)
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+  echo "GitHub Release ${TAG} already exists; refusing to overwrite it" >&2
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+./scripts/extract-release-notes.sh "$VERSION" >dist/RELEASE_NOTES.md
+arguments=(
+  release create "$TAG"
+  --verify-tag
+  --title "BSDM-Proxy ${TAG}"
+  --notes-file dist/RELEASE_NOTES.md
+)
+if [[ "$VERSION" == *-* ]]; then
+  arguments+=(--prerelease)
+fi
+
+gh "${arguments[@]}" "${archives[@]}" "${checksums[@]}"

--- a/scripts/ci/publish-image.sh
+++ b/scripts/ci/publish-image.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build and publish the multi-platform proxy image from a validated release tag.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TAG="${1:-${CI_RELEASE_TAG:-}}"
+if [[ ! "$TAG" =~ ^v.+ ]]; then
+  echo "usage: publish-image.sh <vX.Y.Z>" >&2
+  exit 1
+fi
+
+command -v docker >/dev/null 2>&1 || {
+  echo "docker is required" >&2
+  exit 1
+}
+
+CI_RELEASE_TAG="$TAG" SKIP_CARGO_METADATA=1 ./scripts/ci/validate-release.sh
+
+IMAGE_NAME="${IMAGE_NAME:-ghcr.io/onixus/bsdm-proxy}"
+PLATFORMS="${PLATFORMS:-linux/amd64,linux/arm64}"
+VERSION="${TAG#v}"
+tags=(--tag "${IMAGE_NAME}:${VERSION}")
+if [[ "$VERSION" != *-* && "${PUBLISH_LATEST:-1}" == "1" ]]; then
+  tags+=(--tag "${IMAGE_NAME}:latest")
+fi
+
+temporary_builder=""
+cleanup_builder() {
+  if [[ -n "$temporary_builder" ]]; then
+    docker buildx rm "$temporary_builder" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup_builder EXIT
+
+if ! docker buildx inspect >/dev/null 2>&1; then
+  temporary_builder="$(docker buildx create --use)"
+fi
+docker buildx inspect --bootstrap >/dev/null
+
+docker buildx build \
+  --file Dockerfile \
+  --target proxy \
+  --platform "$PLATFORMS" \
+  --provenance=mode=max \
+  --sbom=true \
+  --push \
+  "${tags[@]}" \
+  .

--- a/scripts/ci/run-load-tests.sh
+++ b/scripts/ci/run-load-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Reproducible Docker-based load-test stage for Jenkins and GitHub Actions.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.lite.yml}"
+RESULTS_DIR="${RESULTS_DIR:-${ROOT}/load-test-results}"
+COMPOSE=(docker compose -f "$COMPOSE_FILE")
+
+for command_name in docker curl wrk; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "required command is not available: ${command_name}" >&2
+    exit 1
+  fi
+done
+docker compose version >/dev/null
+docker buildx version >/dev/null
+
+cleanup() {
+  "${COMPOSE[@]}" down -v || true
+}
+
+on_exit() {
+  local status=$?
+  trap - EXIT
+  if (( status != 0 )); then
+    show_logs
+  fi
+  cleanup
+  exit "$status"
+}
+
+show_logs() {
+  "${COMPOSE[@]}" ps || true
+  "${COMPOSE[@]}" logs --no-color proxy cache-indexer mock-upstream || true
+}
+
+wait_for_http() {
+  local name="$1"
+  local url="$2"
+  local attempt
+  for attempt in $(seq 1 60); do
+    if curl --fail --silent --show-error --head "$url" >/dev/null; then
+      echo "${name} is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "${name} did not become ready: ${url}" >&2
+  show_logs
+  return 1
+}
+
+trap on_exit EXIT
+trap 'exit 130' INT TERM
+
+./scripts/gen-ca.sh
+if ! "${COMPOSE[@]}" up -d --build mock-upstream; then
+  echo "failed to start the lite load-test stack" >&2
+  exit 1
+fi
+wait_for_http "proxy" "http://127.0.0.1:9090/health"
+wait_for_http "mock upstream" "http://127.0.0.1:18080/ping"
+
+PROXY="http://127.0.0.1:3128" \
+METRICS_URL="http://127.0.0.1:9090" \
+UPSTREAM="http://127.0.0.1:18080" \
+  ./scripts/run-load-test.sh
+
+CONCURRENT_USERS="${CONCURRENT_USERS:-20}" \
+TEST_DURATION="${TEST_DURATION:-20}" \
+PROXY="http://127.0.0.1:3128" \
+METRICS_URL="http://127.0.0.1:9090" \
+SNI_URL="http://127.0.0.1:18080/get" \
+MITM_URL="http://127.0.0.1:18080/get" \
+HTTP_URL="http://127.0.0.1:18080/get" \
+WRITE_RESULTS=1 \
+RESULTS_DIR="$RESULTS_DIR" \
+  ./scripts/run-hybrid-load-test.sh
+
+cat "${RESULTS_DIR}/latest.md"
+wrk -t"${WRK_THREADS:-2}" -c"${WRK_CONNECTIONS:-100}" \
+  -d"${WRK_DURATION:-30s}" -s ./scripts/wrk-proxy.lua http://127.0.0.1:3128
+docker stats --no-stream

--- a/scripts/ci/run-load-tests.sh
+++ b/scripts/ci/run-load-tests.sh
@@ -81,9 +81,10 @@ restore_ca_ownership() {
     return 0
   fi
 
-  if ! run_privileged chown "$CA_DIR_ORIGINAL_OWNER" "$CERT_DIR" ||
-     ! run_privileged chown "$CA_KEY_ORIGINAL_OWNER" "$CERT_DIR/ca.key" ||
-     ! run_privileged chown "$CA_CERT_ORIGINAL_OWNER" "$CERT_DIR/ca.crt"; then
+  # Keep the directory traversable until its children have been restored.
+  if ! run_privileged chown "$CA_KEY_ORIGINAL_OWNER" "$CERT_DIR/ca.key" ||
+     ! run_privileged chown "$CA_CERT_ORIGINAL_OWNER" "$CERT_DIR/ca.crt" ||
+     ! run_privileged chown "$CA_DIR_ORIGINAL_OWNER" "$CERT_DIR"; then
     echo "warning: failed to restore generated CA ownership in ${CERT_DIR}" >&2
     return 1
   fi
@@ -115,7 +116,7 @@ wait_for_http() {
   local url="$2"
   local attempt
   for attempt in $(seq 1 60); do
-    if curl --fail --silent --show-error --head "$url" >/dev/null; then
+    if curl --fail --silent --show-error --output /dev/null "$url"; then
       echo "${name} is ready"
       return 0
     fi

--- a/scripts/ci/run-load-tests.sh
+++ b/scripts/ci/run-load-tests.sh
@@ -7,7 +7,20 @@ cd "$ROOT"
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.lite.yml}"
 RESULTS_DIR="${RESULTS_DIR:-${ROOT}/load-test-results}"
+CERT_DIR="${CERT_DIR:-${ROOT}/certs}"
+CA_RUNTIME_UID="${CA_RUNTIME_UID:-1000}"
+CA_RUNTIME_GID="${CA_RUNTIME_GID:-1000}"
 COMPOSE=(docker compose -f "$COMPOSE_FILE")
+
+CA_DIR_ORIGINAL_OWNER=""
+CA_KEY_ORIGINAL_OWNER=""
+CA_CERT_ORIGINAL_OWNER=""
+CA_OWNERSHIP_CHANGED=0
+
+if [[ ! "$CA_RUNTIME_UID" =~ ^[0-9]+$ || ! "$CA_RUNTIME_GID" =~ ^[0-9]+$ ]]; then
+  echo "CA_RUNTIME_UID and CA_RUNTIME_GID must be numeric" >&2
+  exit 2
+fi
 
 for command_name in docker curl wrk; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
@@ -17,6 +30,65 @@ for command_name in docker curl wrk; do
 done
 docker compose version >/dev/null
 docker buildx version >/dev/null
+
+run_privileged() {
+  if (( EUID == 0 )); then
+    "$@"
+    return
+  fi
+  if command -v sudo >/dev/null 2>&1; then
+    sudo -n "$@"
+    return
+  fi
+  return 1
+}
+
+prepare_ca_ownership() {
+  local runtime_owner="${CA_RUNTIME_UID}:${CA_RUNTIME_GID}"
+  local current_dir_owner current_key_owner current_cert_owner
+
+  for path in "$CERT_DIR" "$CERT_DIR/ca.key" "$CERT_DIR/ca.crt"; do
+    if [[ ! -e "$path" ]]; then
+      echo "generated CA path is missing: ${path}" >&2
+      return 1
+    fi
+  done
+
+  current_dir_owner="$(stat -c '%u:%g' "$CERT_DIR")"
+  current_key_owner="$(stat -c '%u:%g' "$CERT_DIR/ca.key")"
+  current_cert_owner="$(stat -c '%u:%g' "$CERT_DIR/ca.crt")"
+  CA_DIR_ORIGINAL_OWNER="$current_dir_owner"
+  CA_KEY_ORIGINAL_OWNER="$current_key_owner"
+  CA_CERT_ORIGINAL_OWNER="$current_cert_owner"
+
+  if [[ "$current_dir_owner" == "$runtime_owner" &&
+        "$current_key_owner" == "$runtime_owner" &&
+        "$current_cert_owner" == "$runtime_owner" ]]; then
+    return 0
+  fi
+
+  if ! run_privileged chown \
+    "$runtime_owner" "$CERT_DIR" "$CERT_DIR/ca.key" "$CERT_DIR/ca.crt"; then
+    echo "cannot assign the generated CA to container owner ${runtime_owner}" >&2
+    echo "run the Docker agent as that UID/GID or allow passwordless sudo chown" >&2
+    return 1
+  fi
+  CA_OWNERSHIP_CHANGED=1
+}
+
+restore_ca_ownership() {
+  if (( CA_OWNERSHIP_CHANGED == 0 )); then
+    return 0
+  fi
+
+  if ! run_privileged chown "$CA_DIR_ORIGINAL_OWNER" "$CERT_DIR" ||
+     ! run_privileged chown "$CA_KEY_ORIGINAL_OWNER" "$CERT_DIR/ca.key" ||
+     ! run_privileged chown "$CA_CERT_ORIGINAL_OWNER" "$CERT_DIR/ca.crt"; then
+    echo "warning: failed to restore generated CA ownership in ${CERT_DIR}" >&2
+    return 1
+  fi
+  CA_OWNERSHIP_CHANGED=0
+}
 
 cleanup() {
   "${COMPOSE[@]}" down -v || true
@@ -29,6 +101,7 @@ on_exit() {
     show_logs
   fi
   cleanup
+  restore_ca_ownership || true
   exit "$status"
 }
 
@@ -57,6 +130,7 @@ trap on_exit EXIT
 trap 'exit 130' INT TERM
 
 ./scripts/gen-ca.sh
+prepare_ca_ownership
 if ! "${COMPOSE[@]}" up -d --build mock-upstream; then
   echo "failed to start the lite load-test stack" >&2
   exit 1

--- a/scripts/ci/run.sh
+++ b/scripts/ci/run.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Portable CI entrypoint shared by Jenkins, GitHub Actions, and local runs.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+log() {
+  printf '\n==> %s\n' "$*"
+}
+
+require_commands() {
+  local command_name
+  for command_name in "$@"; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+      echo "required command is not available: ${command_name}" >&2
+      return 1
+    fi
+  done
+}
+
+rust_ca() {
+  log "CA rotation drill"
+  ./scripts/test-ca-rotation.sh
+}
+
+rust_fmt() {
+  log "Rust formatting"
+  cargo fmt --all -- --check
+}
+
+rust_clippy() {
+  log "Rust clippy"
+  cargo clippy --workspace --all-targets -- -D warnings
+}
+
+rust_build() {
+  log "Rust workspace build"
+  cargo build --workspace --all-targets
+}
+
+rust_lite() {
+  log "Lite build without rdkafka"
+  cargo build -p bsdm-proxy --no-default-features --features auth-basic --all-targets
+  cargo build -p cache-indexer --no-default-features --all-targets
+}
+
+rust_test() {
+  log "Rust unit, integration, smoke, and E2E tests"
+  cargo test --workspace --all-targets
+}
+
+rust_grpc() {
+  log "gRPC control plane feature"
+  cargo clippy -p bsdm-proxy --features grpc --all-targets -- -D warnings
+  cargo test -p bsdm-proxy --features grpc --lib -- control_grpc
+}
+
+rust_wasm() {
+  log "Wasm plugin host feature"
+  cargo clippy -p bsdm-proxy --features wasm --lib -- -D warnings
+  cargo test -p bsdm-proxy --features wasm --lib -- wasm_host
+}
+
+rust_all() {
+  require_commands cargo rustc
+  rust_ca
+  rust_fmt
+  rust_clippy
+  rust_build
+  rust_lite
+  rust_test
+  rust_grpc
+  rust_wasm
+}
+
+docs() {
+  require_commands python3
+  log "Markdown links"
+  python3 scripts/check-doc-links.py
+  if grep -q -- "--validate" scripts/sync-wiki.py; then
+    log "Wiki catalog"
+    python3 scripts/sync-wiki.py --validate
+  else
+    echo "Wiki catalog validation is not supported by this branch; skipping"
+  fi
+}
+
+install_chromium() {
+  if [[ "${PLAYWRIGHT_INSTALL_DEPS:-0}" == "1" ]]; then
+    npx playwright-core install --with-deps chromium
+  else
+    npx playwright-core install chromium
+  fi
+}
+
+admin_console_core() {
+  require_commands node npm
+  log "Admin Console lint, unit tests, and build"
+  (
+    cd admin-console
+    npm ci
+    npm run lint
+    npm test
+    npm run build
+  )
+}
+
+admin_console_ui() {
+  require_commands node npm
+  log "Admin Console Chromium smoke test"
+  (
+    cd admin-console
+    npm ci
+    install_chromium
+    UI_TEST_SCREENSHOTS="${UI_TEST_SCREENSHOTS:-1}" npm run test:ui
+  )
+}
+
+admin_console() {
+  require_commands node npm
+  log "Admin Console full gate"
+  (
+    cd admin-console
+    npm ci
+    npm run lint
+    npm test
+    if [[ "${RUN_UI_TESTS:-1}" == "1" ]]; then
+      install_chromium
+      UI_TEST_SCREENSHOTS="${UI_TEST_SCREENSHOTS:-1}" npm run test:ui
+    else
+      npm run build
+    fi
+  )
+}
+
+trust_ui() {
+  require_commands node npm
+  log "Trust UI"
+  (
+    cd trust-ui
+    npm ci
+    npm run build
+  )
+}
+
+security_audit() {
+  require_commands cargo
+  if ! cargo audit --version >/dev/null 2>&1; then
+    echo "cargo-audit is required on this CI agent" >&2
+    return 1
+  fi
+  log "RustSec dependency audit"
+  cargo audit
+}
+
+release_validate() {
+  log "Release metadata"
+  CI_RELEASE_TAG="${CI_RELEASE_TAG:-${2:-}}" ./scripts/ci/validate-release.sh
+}
+
+package() {
+  local actual_arch="$(uname -m)"
+  if [[ -n "${EXPECTED_ARCH:-}" && "$actual_arch" != "$EXPECTED_ARCH" ]]; then
+    echo "package agent architecture mismatch: expected ${EXPECTED_ARCH}, found ${actual_arch}" >&2
+    return 1
+  fi
+  log "Release package"
+  ./scripts/build-package.sh
+  (
+    cd dist
+    sha256sum -c ./*.tar.gz.sha256
+  )
+}
+
+preflight() {
+  require_commands bash git python3 cargo rustc node npm
+  local rust_version rust_major rust_minor node_major
+  rust_version="$(rustc --version | awk '{print $2}')"
+  rust_major="$(cut -d. -f1 <<<"$rust_version")"
+  rust_minor="$(cut -d. -f2 <<<"$rust_version")"
+  node_major="$(node --version | sed 's/^v//' | cut -d. -f1)"
+  if (( rust_major < 1 || (rust_major == 1 && rust_minor < 88) )); then
+    echo "Rust 1.88+ is required; found ${rust_version}" >&2
+    return 1
+  fi
+  if [[ "$node_major" -lt 24 ]]; then
+    echo "Node.js 24+ is required; found $(node --version)" >&2
+    return 1
+  fi
+  log "Toolchain"
+  git --version
+  rustc --version
+  cargo --version
+  node --version
+  npm --version
+  python3 --version
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ci/run.sh <task>
+
+Tasks:
+  preflight          Check the base CI toolchain
+  rust-all           Run the complete Rust quality gate
+  rust-ca            Run the offline CA rotation drill
+  rust-fmt           Check rustfmt
+  rust-clippy        Run clippy for the workspace
+  rust-build         Build the workspace and all targets
+  rust-lite          Build the no-rdkafka profile
+  rust-test          Run workspace tests
+  rust-grpc          Check the optional gRPC feature
+  rust-wasm          Check the optional Wasm feature
+  docs               Validate Markdown links and the Wiki catalog
+  admin-console      Lint, test, build, and optionally UI-test the admin console
+  admin-console-core Lint, test, and build the admin console
+  admin-console-ui   Run the Admin Console Chromium smoke test
+  trust-ui           Build the experimental trust UI
+  security-audit     Run cargo-audit (must be installed on the agent)
+  release-validate   Validate version, tag, changelog, and Cargo metadata
+  package            Build and verify the native release package
+  load-test          Run the Docker-based lite/hybrid load-test profile
+EOF
+}
+
+task="${1:-}"
+case "$task" in
+  preflight) preflight ;;
+  rust-all) rust_all ;;
+  rust-ca) rust_ca ;;
+  rust-fmt) rust_fmt ;;
+  rust-clippy) rust_clippy ;;
+  rust-build) rust_build ;;
+  rust-lite) rust_lite ;;
+  rust-test) rust_test ;;
+  rust-grpc) rust_grpc ;;
+  rust-wasm) rust_wasm ;;
+  docs) docs ;;
+  admin-console) admin_console ;;
+  admin-console-core) admin_console_core ;;
+  admin-console-ui) admin_console_ui ;;
+  trust-ui) trust_ui ;;
+  security-audit) security_audit ;;
+  release-validate) release_validate "$@" ;;
+  package) package ;;
+  load-test) exec ./scripts/ci/run-load-tests.sh ;;
+  -h|--help|help) usage ;;
+  *)
+    usage >&2
+    [[ -n "$task" ]] && echo "unknown task: ${task}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/ci/validate-release.sh
+++ b/scripts/ci/validate-release.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Validate release metadata before building or publishing artifacts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+VERSION="$(sed -n 's/^version = "\([^"]*\)"/\1/p' proxy/Cargo.toml | head -1)"
+if [[ -z "$VERSION" ]]; then
+  echo "cannot read package version from proxy/Cargo.toml" >&2
+  exit 1
+fi
+
+RELEASE_TAG="${CI_RELEASE_TAG:-}"
+if [[ -n "$RELEASE_TAG" && "$RELEASE_TAG" != "v${VERSION}" ]]; then
+  echo "release tag ${RELEASE_TAG} does not match workspace version v${VERSION}" >&2
+  exit 1
+fi
+
+PRODUCT_CRATES=(
+  proxy
+  bsdm-events
+  cache-indexer
+  alert-worker
+  ml-worker
+  dns-sinkhole
+)
+
+for manifest_dir in "${PRODUCT_CRATES[@]}"; do
+  if ! grep -q "^version = \"${VERSION}\"$" "${manifest_dir}/Cargo.toml"; then
+    echo "version mismatch in ${manifest_dir}/Cargo.toml; expected ${VERSION}" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq "## [${VERSION}]" CHANGELOG.md; then
+  echo "CHANGELOG.md has no section for ${VERSION}" >&2
+  exit 1
+fi
+
+if [[ ! -f "docs/releases/v${VERSION}.md" ]]; then
+  echo "release notes are missing: docs/releases/v${VERSION}.md" >&2
+  exit 1
+fi
+
+if [[ "${SKIP_CARGO_METADATA:-0}" != "1" ]]; then
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo is required for locked metadata validation" >&2
+    exit 1
+  fi
+  cargo metadata --locked --no-deps --format-version 1 >/dev/null
+fi
+
+echo "Release metadata OK: version=${VERSION} tag=${RELEASE_TAG:-<dry-run>}"


### PR DESCRIPTION
## Что изменено

- добавлен декларативный multibranch `Jenkinsfile` с параллельными Rust, RustSec, docs и frontend gates
- CI-команды вынесены в переносимый `scripts/ci/run.sh`; Jenkins, GitHub Actions и локальный `make ci` используют один контракт
- добавлены tag/version/release-note/architecture guards, native amd64/optional arm64 packaging и stashed artifacts
- GitHub Release и GHCR publish доступны только для tag build и только через явные boolean gates + Jenkins Credentials Binding
- load-test workflow вынесен в единый wrapper с readiness checks, логами при ошибке и гарантированным cleanup
- generated CA временно передаётся UID/GID контейнера с восстановлением владельцев после теста; приватные режимы каталога и ключа не ослабляются
- readiness probe использует GET, совместимый и с proxy health endpoint, и с mock upstream
- существующие GitHub Actions переведены на общий entrypoint, чтобы Jenkins и Actions не расходились
- development guide дополнен настройкой agents, labels, credentials, dry-run и правилом «один CD writer»

## Проверки

Локально:

- `bash -n scripts/ci/*.sh`
- YAML parse всех `.github/workflows/*.yml`
- structural contract Jenkinsfile + сверка Declarative syntax с официальной Jenkins документацией
- `./scripts/ci/run.sh docs` → 88 Markdown files + 79 Wiki pages
- release tag guard: `v0.9.11` принят, mismatch отклонён
- package architecture mismatch guard отклонён
- Admin Console: lint, 12/12 tests, production build
- Trust UI: production build
- `git diff --check`

На head `92668dd` успешно завершены все PR workflow:

- Documentation #101
- Trust UI CI #12
- Admin Console CI #159
- CI #160
- Performance & Load Testing #156

Load-test log подтверждает готовность proxy и mock upstream; предупреждение о невозможности восстановить владельцев CA отсутствует.

## Важное по CD

Jenkins publish flags по умолчанию выключены. Пока GitHub Actions `release.yml` и `docker-publish.yml` активны, Jenkins следует использовать для CI/package dry run. Перед включением Jenkins publication нужно выбрать один CD writer, чтобы не создавать конкурирующие releases/images.

Полный Rust gate и Chromium smoke должны пройти на GitHub/Jenkins runners: в локальном контейнере нет Cargo, а загрузка Playwright CDN заблокирована сетевой политикой.