### PR TITLE
fix(installer): harden release installation and add installer CI

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,29 @@
+name: Installer Validation
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  installer:
+    name: Validate installer scripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bash syntax check
+        run: |
+          bash -n install.sh
+          bash -n scripts/interactive-install.sh
+          find scripts/installer -name '*.sh' -print0 | xargs -0 -n1 bash -n
+
+      - name: Shellcheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: .
+
+      - name: Installer sanity
+        run: tests/install/test-installer-sanity.sh

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Wrapper script to run the interactive installer
+# Entry point for the BSDM-Proxy interactive installer.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${ROOT_DIR}/scripts/interactive-install.sh"
 
-if [[ "$(id -u)" -ne 0 ]]; then
-  echo "Error: Installer must be run as root (sudo ./install.sh)" >&2
+[[ -x "$INSTALLER" ]] || {
+  echo "Error: interactive installer is missing or not executable: ${INSTALLER}" >&2
   exit 1
-fi
+}
 
-echo "Starting BSDM-Proxy interactive installer..."
-exec "${ROOT_DIR}/scripts/interactive-install.sh" "$@"
+exec "$INSTALLER" "$@"

--- a/scripts/install-binaries.sh
+++ b/scripts/install-binaries.sh
@@ -1,29 +1,172 @@
 #!/usr/bin/env bash
-# BSDM-Proxy binary installer.
-# See release packages for the canonical installation flow.
+# Zero-Compilation Release Binary Installer for BSDM-Proxy
+# Downloads pre-compiled release tarballs from GitHub Releases and installs them.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/onixus/bsdm-proxy/main/scripts/install-binaries.sh | sudo bash
+#   sudo ./scripts/install-binaries.sh [VERSION]
 set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
 
 REPO="onixus/bsdm-proxy"
 PREFIX="/opt/bsdm-proxy"
 ETC_DIR="/etc/bsdm-proxy"
 CERTS_DIR="/certs"
 
+banner() {
+  echo -e "${CYAN}${BOLD}"
+  echo '  ____   _____ _____  __  __   ____  ____   ______   ____   __'
+  echo ' |  _ \ / ____|  __ \|  \/  | |  _ \|  _ \ / __ \ \ / /\ \ / /'
+  echo ' | |_) | (___ | |  | | \  / | | |_) | |_) | |  | \ V /  \ V / '
+  echo ' |  _ < \___ \| |  | | |\/| | |  __/|  _ <| |  | |> <    > <  '
+  echo ' | |_) |____) | |__| | |  | | | |   | |_) | |__| / . \  / . \ '
+  echo ' |____/|_____/|_____/|_|  |_| |_|   |____/ \____/_/ \_\/_/ \_\'
+  echo -e "${NC}"
+  echo -e "${BOLD}  Zero-Compilation Binary Release Installer${NC}\n"
+}
+
 check_root() {
-  [[ "$(id -u)" -eq 0 ]] || {
-    echo "Installer must run as root" >&2
+  if [[ "$(id -u)" -ne 0 ]]; then
+    echo -e "${RED}${BOLD}Error: Installer must be run as root (sudo ./install-binaries.sh)${NC}" >&2
+    exit 1
+  fi
+}
+
+detect_system() {
+  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  ARCH="$(uname -m)"
+
+  case "$ARCH" in
+    x86_64|amd64) ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="aarch64" ;;
+    *)
+      echo -e "${RED}Unsupported architecture: ${ARCH}${NC}" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ "$OS" != "linux" ]]; then
+    echo -e "${RED}Native binary installation is supported on Linux only; detected ${OS}.${NC}" >&2
+    exit 1
+  fi
+
+  echo -e "${GREEN}✓ Detected System:${NC} OS=${BOLD}${OS}${NC}, Arch=${BOLD}${ARCH}${NC}"
+}
+
+fetch_latest_version() {
+  local version_arg="${1:-}"
+  if [[ -n "$version_arg" ]]; then
+    VERSION="${version_arg#v}"
+    echo -e "${GREEN}✓ Target Version:${NC} v${VERSION}"
+    return
+  fi
+
+  echo -e "${YELLOW}Fetching latest release info from GitHub (${REPO})...${NC}"
+  local api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  local json tag
+  json="$(curl -fsSL "$api_url" || true)"
+
+  if [[ -n "$json" ]]; then
+    tag="$(printf '%s\n' "$json" | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/' || true)"
+    VERSION="${tag#v}"
+  fi
+
+  if [[ -z "${VERSION:-}" ]]; then
+    echo -e "${RED}Could not determine the latest release. Pass an explicit version, for example: sudo ./scripts/install-binaries.sh 0.9.13${NC}" >&2
+    exit 1
+  fi
+
+  echo -e "${GREEN}✓ Latest Release Found:${NC} v${VERSION}"
+}
+
+download_and_install() {
+  local tmp_dir package_version package_name tarball_url checksum_url unpacked_dir
+  tmp_dir="$(mktemp -d -t bsdm-install-XXXXXX)"
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  package_version="${VERSION//-b/b}"
+  package_version="${package_version//-test/test}"
+  package_version="${package_version//+/.}"
+  package_name="bsdm-proxy-${package_version}-${OS}-${ARCH}"
+  tarball_url="https://github.com/${REPO}/releases/download/v${VERSION}/${package_name}.tar.gz"
+  checksum_url="${tarball_url}.sha256"
+
+  echo -e "${YELLOW}Downloading pre-compiled release package:${NC} ${tarball_url}"
+  curl -fsSL -o "${tmp_dir}/${package_name}.tar.gz" "$tarball_url" || {
+    echo -e "${RED}Failed to download release tarball for v${VERSION} (${OS}-${ARCH}).${NC}" >&2
     exit 1
   }
+
+  curl -fsSL -o "${tmp_dir}/${package_name}.tar.gz.sha256" "$checksum_url" || {
+    echo -e "${RED}Failed to download release checksum for v${VERSION}.${NC}" >&2
+    exit 1
+  }
+
+  (
+    cd "$tmp_dir"
+    sha256sum -c "${package_name}.tar.gz.sha256"
+  )
+
+  echo -e "${GREEN}✓ Download verified. Unpacking package...${NC}"
+  tar -xzf "${tmp_dir}/${package_name}.tar.gz" -C "$tmp_dir"
+
+  unpacked_dir="${tmp_dir}/${package_name}"
+  [[ -x "${unpacked_dir}/install.sh" ]] || {
+    echo -e "${RED}Release package is missing install.sh.${NC}" >&2
+    exit 1
+  }
+
+  echo -e "${GREEN}✓ Installing pre-compiled binaries and configuration...${NC}"
+  "${unpacked_dir}/install.sh" --prefix "$PREFIX" --etc "$ETC_DIR" --create-user --systemd
+
+  if [[ -e "${CERTS_DIR}/ca.key" || -e "${CERTS_DIR}/ca.crt" ]]; then
+    if [[ ! -f "${CERTS_DIR}/ca.key" || ! -f "${CERTS_DIR}/ca.crt" ]]; then
+      echo -e "${RED}Incomplete CA state in ${CERTS_DIR}; expected both ca.key and ca.crt or neither.${NC}" >&2
+      exit 1
+    fi
+    echo -e "${GREEN}✓ Existing MITM CA preserved${NC}"
+  else
+    echo -e "${YELLOW}Generating MITM CA keypair in ${CERTS_DIR}...${NC}"
+    install -d -m 0750 "$CERTS_DIR"
+    openssl req -x509 -newkey rsa:4096 \
+      -keyout "${CERTS_DIR}/ca.key" \
+      -out "${CERTS_DIR}/ca.crt" \
+      -days 3650 -nodes \
+      -subj "/CN=BSDM Proxy Root CA/O=BSDM Security"
+    chmod 0600 "${CERTS_DIR}/ca.key"
+    chmod 0644 "${CERTS_DIR}/ca.crt"
+    if id bsdm-proxy >/dev/null 2>&1; then
+      chown bsdm-proxy:bsdm-proxy "${CERTS_DIR}/ca.key" "${CERTS_DIR}/ca.crt"
+    fi
+    echo -e "${GREEN}✓ MITM Root CA generated successfully${NC}"
+  fi
 }
 
 main() {
+  banner
   check_root
-  echo "BSDM-Proxy binary installer"
-  echo "Default proxy endpoint: http://127.0.0.1:3128"
-  echo "Metrics endpoint: http://127.0.0.1:9090"
-  echo "Repository: ${REPO}"
-  echo "Install prefix: ${PREFIX}"
-  echo "Config: ${ETC_DIR}"
-  echo "Certificates: ${CERTS_DIR}"
+  command -v curl >/dev/null 2>&1 || { echo "curl is required" >&2; exit 1; }
+  command -v sha256sum >/dev/null 2>&1 || { echo "sha256sum is required" >&2; exit 1; }
+  command -v openssl >/dev/null 2>&1 || { echo "openssl is required" >&2; exit 1; }
+  detect_system
+  fetch_latest_version "${1:-}"
+  download_and_install
+
+  echo -e "\n${GREEN}${BOLD}============================================================${NC}"
+  echo -e "${GREEN}${BOLD}   BSDM-Proxy Installed Successfully (Zero-Compilation)!   ${NC}"
+  echo -e "${GREEN}${BOLD}============================================================${NC}\n"
+  echo -e "Start proxy service:"
+  echo -e "  ${CYAN}sudo systemctl enable --now bsdm-proxy${NC}"
+  echo -e "\nVerify installation:"
+  echo -e "  ${CYAN}curl http://127.0.0.1:9090/health${NC}"
+  echo -e "  ${CYAN}curl --cacert ${CERTS_DIR}/ca.crt -x http://127.0.0.1:3128 https://httpbin.org/get${NC}"
+  echo ""
 }
 
 main "$@"

--- a/scripts/install-binaries.sh
+++ b/scripts/install-binaries.sh
@@ -1,160 +1,29 @@
 #!/usr/bin/env bash
-# Zero-Compilation Release Binary Installer for BSDM-Proxy
-# Downloads pre-compiled release tarballs from GitHub Releases and installs them.
-#
-# Usage:
-#   curl -fsSL https://raw.githubusercontent.com/onixus/bsdm-proxy/main/scripts/install-binaries.sh | sudo bash
-#   sudo ./scripts/install-binaries.sh [VERSION]
+# BSDM-Proxy binary installer.
+# See release packages for the canonical installation flow.
 set -euo pipefail
-
-# Color codes
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
 
 REPO="onixus/bsdm-proxy"
 PREFIX="/opt/bsdm-proxy"
 ETC_DIR="/etc/bsdm-proxy"
 CERTS_DIR="/certs"
 
-banner() {
-  echo -e "${CYAN}${BOLD}"
-  echo '  ____   _____ _____  __  __   ____  ____   ______   ____   __'
-  echo ' |  _ \ / ____|  __ \|  \/  | |  _ \|  _ \ / __ \ \ / /\ \ / /'
-  echo ' | |_) | (___ | |  | | \  / | | |_) | |_) | |  | \ V /  \ V / '
-  echo ' |  _ < \___ \| |  | | |\/| | |  __/|  _ <| |  | |> <    > <  '
-  echo ' | |_) |____) | |__| | |  | | | |   | |_) | |__| / . \  / . \ '
-  echo ' |____/|_____/|_____/|_|  |_| |_|   |____/ \____/_/ \_\/_/ \_\'
-  echo -e "${NC}"
-  echo -e "${BOLD}  Zero-Compilation Binary Release Installer${NC}\n"
-}
-
 check_root() {
-  if [[ "$(id -u)" -ne 0 ]]; then
-    echo -e "${RED}${BOLD}Error: Installer must be run as root (sudo ./install-binaries.sh)${NC}" >&2
+  [[ "$(id -u)" -eq 0 ]] || {
+    echo "Installer must run as root" >&2
     exit 1
-  fi
-}
-
-detect_system() {
-  OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  ARCH="$(uname -m)"
-
-  case "$ARCH" in
-    x86_64|amd64)
-      ARCH="x86_64"
-      ;;
-    aarch64|arm64)
-      ARCH="aarch64"
-      ;;
-    *)
-      echo -e "${RED}Unsupported architecture: ${ARCH}${NC}" >&2
-      exit 1
-      ;;
-  esac
-
-  if [[ "$OS" != "linux" && "$OS" != "darwin" ]]; then
-    echo -e "${RED}Unsupported operating system: ${OS}${NC}" >&2
-    exit 1
-  fi
-
-  echo -e "${GREEN}✓ Detected System:${NC} OS=${BOLD}${OS}${NC}, Arch=${BOLD}${ARCH}${NC}"
-}
-
-fetch_latest_version() {
-  local version_arg="${1:-}"
-  if [[ -n "$version_arg" ]]; then
-    VERSION="${version_arg#v}"
-    echo -e "${GREEN}✓ Target Version:${NC} v${VERSION}"
-    return
-  fi
-
-  echo -e "${YELLOW}Fetching latest release info from GitHub (${REPO})...${NC}"
-  local api_url="https://api.github.com/repos/${REPO}/releases/latest"
-  local json
-  json="$(curl -fsSL "$api_url" || echo "")"
-
-  if [[ -n "$json" ]]; then
-    TAG="$(echo "$json" | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')"
-    VERSION="${TAG#v}"
-  fi
-
-  if [[ -z "${VERSION:-}" ]]; then
-    VERSION="0.6.0"
-    echo -e "${YELLOW}Warning: Could not fetch latest release tag via GitHub API. Defaulting to v${VERSION}.${NC}"
-  else
-    echo -e "${GREEN}✓ Latest Release Found:${NC} v${VERSION}"
-  fi
-}
-
-download_and_install() {
-  TMP_DIR="$(mktemp -d -t bsdm-install-XXXXXX)"
-  trap 'rm -rf "$TMP_DIR"' EXIT
-
-  # Cargo version substitution rules: 0.5.7+033 → 0.5.7.033
-  PACKAGE_VERSION="${VERSION//+/.}"
-  PACKAGE_NAME="bsdm-proxy-${PACKAGE_VERSION}-${OS}-${ARCH}"
-  TARBALL_URL="https://github.com/${REPO}/releases/download/v${VERSION}/${PACKAGE_NAME}.tar.gz"
-
-  echo -e "${YELLOW}Downloading pre-compiled release package:${NC} ${TARBALL_URL}"
-
-  if ! curl -fsSL -o "${TMP_DIR}/${PACKAGE_NAME}.tar.gz" "${TARBALL_URL}"; then
-    # Fallback attempt to download latest release asset pattern
-    echo -e "${YELLOW}Retrying download with latest release artifact...${NC}"
-    TARBALL_URL="https://github.com/${REPO}/releases/latest/download/${PACKAGE_NAME}.tar.gz"
-    curl -fsSL -o "${TMP_DIR}/${PACKAGE_NAME}.tar.gz" "${TARBALL_URL}" || {
-      echo -e "${RED}Failed to download release tarball for v${VERSION} (${OS}-${ARCH}).${NC}" >&2
-      echo -e "${RED}URL: ${TARBALL_URL}${NC}" >&2
-      exit 1
-    }
-  fi
-
-  echo -e "${GREEN}✓ Download complete. Unpacking package...${NC}"
-  tar -xzf "${TMP_DIR}/${PACKAGE_NAME}.tar.gz" -C "${TMP_DIR}"
-
-  UNPACKED_DIR="${TMP_DIR}/${PACKAGE_NAME}"
-  if [[ ! -d "$UNPACKED_DIR" ]]; then
-    UNPACKED_DIR="$(find "${TMP_DIR}" -mindepth 1 -maxdepth 1 -type d | head -1)"
-  fi
-
-  echo -e "${GREEN}✓ Installing pre-compiled binaries and configuration...${NC}"
-  chmod +x "${UNPACKED_DIR}/install.sh"
-  "${UNPACKED_DIR}/install.sh" --prefix "${PREFIX}" --etc "${ETC_DIR}" --create-user --systemd
-
-  # Generate CA certificates if missing
-  if [[ ! -f "${CERTS_DIR}/ca.key" || ! -f "${CERTS_DIR}/ca.crt" ]]; then
-    echo -e "${YELLOW}Generating MITM CA keypair in ${CERTS_DIR}...${NC}"
-    mkdir -p "${CERTS_DIR}"
-    openssl req -x509 -newkey rsa:4096 -keyout "${CERTS_DIR}/ca.key" -out "${CERTS_DIR}/ca.crt" \
-      -days 3650 -nodes -subj "/CN=BSDM Proxy Root CA/O=BSDM Security" 2>/dev/null || true
-    chmod 0600 "${CERTS_DIR}/ca.key"
-    chmod 0644 "${CERTS_DIR}/ca.crt"
-    if id bsdm-proxy &>/dev/null; then
-      chown bsdm-proxy:bsdm-proxy "${CERTS_DIR}" "${CERTS_DIR}"/* 2>/dev/null || true
-    fi
-    echo -e "${GREEN}✓ MITM Root CA generated successfully${NC}"
-  fi
+  }
 }
 
 main() {
-  banner
   check_root
-  detect_system
-  fetch_latest_version "${1:-}"
-  download_and_install
-
-  echo -e "\n${GREEN}${BOLD}============================================================${NC}"
-  echo -e "${GREEN}${BOLD}   BSDM-Proxy Installed Successfully (Zero-Compilation)!   ${NC}"
-  echo -e "${GREEN}${BOLD}============================================================${NC}\n"
-  echo -e "Start proxy service:"
-  echo -e "  ${CYAN}sudo systemctl enable --now bsdm-proxy${NC}"
-  echo -e "\nVerify installation:"
-  echo -e "  ${CYAN}curl http://127.0.0.1:9090/health${NC}"
-  echo -e "  ${CYAN}curl --cacert ${CERTS_DIR}/ca.crt -x http://127.0.0.1:1488 https://httpbin.org/get${NC}"
-  echo ""
+  echo "BSDM-Proxy binary installer"
+  echo "Default proxy endpoint: http://127.0.0.1:3128"
+  echo "Metrics endpoint: http://127.0.0.1:9090"
+  echo "Repository: ${REPO}"
+  echo "Install prefix: ${PREFIX}"
+  echo "Config: ${ETC_DIR}"
+  echo "Certificates: ${CERTS_DIR}"
 }
 
 main "$@"

--- a/scripts/installer/common.sh
+++ b/scripts/installer/common.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
@@ -87,7 +86,7 @@ backup_file_if_present() {
   local timestamp backup
   timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
   backup="${path}.bak.${timestamp}"
-  cp -a -- "$path" "$backup"
+  cp -p "$path" "$backup"
   info "Backed up $path -> $backup"
 }
 
@@ -95,8 +94,15 @@ upsert_env() {
   local file="$1"
   local key="$2"
   local value="$3"
-  local tmp
+  local tmp rendered
+
+  if [[ ! -f "$file" ]]; then
+    : > "$file"
+    chmod 0640 "$file"
+  fi
+
   tmp="$(mktemp "${file}.tmp.XXXXXX")"
+  rendered="${tmp}.rendered"
 
   awk -v key="$key" -v value="$value" '
     BEGIN { replaced = 0 }
@@ -107,10 +113,17 @@ upsert_env() {
     }
     { print }
     END { if (!replaced) print key "=" value }
-  ' "$file" > "$tmp"
-  chmod --reference="$file" "$tmp" 2>/dev/null || chmod 0640 "$tmp"
-  chown --reference="$file" "$tmp" 2>/dev/null || true
-  mv -f -- "$tmp" "$file"
+  ' "$file" > "$rendered"
+
+  if cp -p "$file" "$tmp" 2>/dev/null; then
+    :
+  else
+    cp "$file" "$tmp"
+    chmod 0640 "$tmp"
+  fi
+  cat "$rendered" > "$tmp"
+  rm -f "$rendered"
+  mv -f "$tmp" "$file"
 }
 
 ensure_ca() {


### PR DESCRIPTION
Harden the installer path after the interactive installer refactor.

Changes:
- defer root requirements to the selected installation backend
- add dedicated installer CI with bash syntax, shellcheck, and sanity checks
- restore and harden the zero-compilation binary installer
- verify release tarball checksums
- remove stale port 1488 and use the canonical proxy port 3128
- fail closed when latest release lookup or CA generation fails
- reject incomplete CA state

Follow-up after merge: prepare v0.9.13 release metadata and tag.