### PR TITLE
feat(threat-intel): add IOC feed collector framework (TASK-TI-001)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Cargo workspace members (see `Cargo.toml`):
 - `alert-worker/` — security incident handling, dedup, webhooks; bin `alert-worker`.
 - `ml-worker/` — UEBA / threat scoring against ClickHouse; bin `ml-worker`.
 - `dns-sinkhole/` — UDP RPZ-lite sidecar, bin `dns-sinkhole`.
+- `threat-intel/` — IOC feed collector, bin `threat-intel` (experimental).
 - `bsdm-events/` — shared event types.
 - `e2e/` — test harness.
 - `bsdm-wasm-sdk/`, `examples/wasm/rust_plugin/`, `examples/agent-spike/` — WASM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Threat intelligence feed collector** (`threat-intel`, TASK-TI-001) — optional
+  worker that ingests OpenPhish, PhishStats, Phishing.Database and URLhaus on a
+  schedule through per-source plugins, with per-source retry/backoff, intra-batch
+  deduplication, response-size and per-fetch caps, Prometheus metrics on
+  `:8093/metrics`, JSONL snapshots plus `report.json`, and a `TI_RUN_ONCE`
+  one-shot mode. Ships as a Compose profile (`--profile threat-intel`), a Helm
+  toggle (`threatIntel.enabled`), a systemd unit and a packaged env example.
+  Collection is metadata-only: the collector never requests a collected
+  indicator. Storage, scoring and ACL/RPZ enforcement are not part of this
+  change. See
+  [docs/features/threat-intel-collector.md](docs/features/threat-intel-collector.md).
+
 ## [0.9.12] - 2026-08-12
 
 Patch after **0.9.11**: hardened RKN registry ACL enforcement and registry-source resilience.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,6 +4115,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "threat-intel"
+version = "0.9.12"
+dependencies = [
+ "chrono",
+ "prometheus",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "time"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "alert-worker",
     "ml-worker",
     "dns-sinkhole",
+    "threat-intel",
     "e2e", "bsdm-wasm-sdk", "examples/wasm/rust_plugin", "examples/agent-spike",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,12 +58,14 @@ COPY cache-indexer/Cargo.toml ./cache-indexer/Cargo.toml
 COPY alert-worker/Cargo.toml ./alert-worker/Cargo.toml
 COPY ml-worker/Cargo.toml ./ml-worker/Cargo.toml
 COPY dns-sinkhole/Cargo.toml ./dns-sinkhole/Cargo.toml
+COPY threat-intel/Cargo.toml ./threat-intel/Cargo.toml
 COPY e2e/Cargo.toml ./e2e/Cargo.toml
 COPY bsdm-wasm-sdk/Cargo.toml ./bsdm-wasm-sdk/Cargo.toml
 
 # Создаём минимальные lib.rs/main.rs-заглушки чтобы cargo fetch + build deps
 RUN mkdir -p bsdm-events/src proxy/src cache-indexer/src \
              alert-worker/src ml-worker/src dns-sinkhole/src \
+             threat-intel/src \
              e2e/src bsdm-wasm-sdk/src && \
     echo "pub fn _stub() {}" > bsdm-events/src/lib.rs && \
     echo "fn main() {}" > proxy/src/main.rs && \
@@ -72,6 +74,7 @@ RUN mkdir -p bsdm-events/src proxy/src cache-indexer/src \
     echo "fn main() {}" > alert-worker/src/main.rs && \
     echo "fn main() {}" > ml-worker/src/main.rs && \
     echo "fn main() {}" > dns-sinkhole/src/main.rs && \
+    echo "fn main() {}" > threat-intel/src/main.rs && \
     echo "pub fn _stub() {}" > e2e/src/lib.rs && \
     echo "pub fn _stub() {}" > bsdm-wasm-sdk/src/lib.rs
 
@@ -84,7 +87,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/build/target,sharing=locked \
     cargo build --release --locked --target $(cat /rust_target.txt) \
       -p bsdm-events -p bsdm-proxy -p cache-indexer \
-      -p alert-worker -p ml-worker -p dns-sinkhole 2>/dev/null || true
+      -p alert-worker -p ml-worker -p dns-sinkhole -p threat-intel 2>/dev/null || true
 
 # ---- Source copy (invalidates cache only when source changes) ----
 COPY bsdm-events ./bsdm-events
@@ -93,6 +96,7 @@ COPY cache-indexer ./cache-indexer
 COPY alert-worker ./alert-worker
 COPY ml-worker ./ml-worker
 COPY dns-sinkhole ./dns-sinkhole
+COPY threat-intel ./threat-intel
 COPY e2e ./e2e
 COPY bsdm-wasm-sdk ./bsdm-wasm-sdk
 COPY examples ./examples
@@ -112,10 +116,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         --no-default-features -p cache-indexer; \
     else \
       cargo build --release --locked --target $(cat /rust_target.txt) \
-        -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker -p dns-sinkhole; \
+        -p bsdm-proxy -p cache-indexer -p alert-worker -p ml-worker -p dns-sinkhole \
+        -p threat-intel; \
     fi; \
     mkdir -p /dist; \
-    for bin in proxy cache-indexer alert-worker ml-worker dns-sinkhole; do \
+    for bin in proxy cache-indexer alert-worker ml-worker dns-sinkhole threat-intel; do \
       cp "/build/target/$(cat /rust_target.txt)/release/$bin" /dist/ 2>/dev/null || true; \
     done
 
@@ -225,6 +230,27 @@ EXPOSE 53/udp 8092
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD wget -q -O- --spider http://127.0.0.1:8092/health || exit 1
 CMD ["dns-sinkhole"]
+
+# ============================================================
+# Threat-intel collector (IOC feed ingestion, TASK-TI-001)
+# ============================================================
+FROM runtime-base AS threat-intel
+
+# runtime-base runs as USER bsdm; create the snapshot dir as root so the
+# collector can write it after privileges are dropped again.
+USER root
+COPY --from=builder --chmod=755 /dist/threat-intel /usr/local/bin/threat-intel
+RUN mkdir -p /var/lib/bsdm-proxy/threat-intel && \
+    chown -R bsdm:bsdm /var/lib/bsdm-proxy/threat-intel
+USER bsdm
+
+ENV TI_OUTPUT_DIR=/var/lib/bsdm-proxy/threat-intel \
+    METRICS_PORT=8093
+
+EXPOSE 8093
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q -O- --spider http://127.0.0.1:8093/health || exit 1
+CMD ["threat-intel"]
 
 # ============================================================
 # Experimental legacy Trust-UI reference (not part of default deployments)

--- a/charts/bsdm/templates/_helpers.tpl
+++ b/charts/bsdm/templates/_helpers.tpl
@@ -65,6 +65,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: ml-worker
 {{- end }}
 
+{{- define "bsdm.threatIntelSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "bsdm.name" . }}-threat-intel
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: threat-intel
+{{- end }}
+
 {{- define "bsdm.dnsSinkholeSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "bsdm.name" . }}-dns-sinkhole
 app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/bsdm/templates/threat-intel-deployment.yaml
+++ b/charts/bsdm/templates/threat-intel-deployment.yaml
@@ -1,0 +1,72 @@
+{{- if and .Values.threatIntel .Values.threatIntel.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bsdm.fullname" . }}-threat-intel
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: threat-intel
+spec:
+  replicas: {{ .Values.threatIntel.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "bsdm.threatIntelSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "bsdm.threatIntelSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "bsdm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: threat-intel
+          image: "{{ .Values.threatIntel.image.repository }}:{{ .Values.threatIntel.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.threatIntel.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: admin
+              containerPort: {{ .Values.threatIntel.service.port }}
+              protocol: TCP
+          env:
+            - name: TI_SOURCES
+              value: {{ .Values.threatIntel.sources | quote }}
+            - name: TI_POLL_INTERVAL_SECS
+              value: {{ .Values.threatIntel.pollIntervalSecs | quote }}
+            - name: TI_HTTP_TIMEOUT_SECS
+              value: {{ .Values.threatIntel.httpTimeoutSecs | quote }}
+            - name: TI_MAX_ATTEMPTS
+              value: {{ .Values.threatIntel.maxAttempts | quote }}
+            - name: TI_OUTPUT_DIR
+              value: {{ .Values.threatIntel.outputDir | quote }}
+            - name: METRICS_PORT
+              value: {{ .Values.threatIntel.service.port | quote }}
+            - name: RUST_LOG
+              value: {{ .Values.threatIntel.rustLog | quote }}
+          volumeMounts:
+            - name: snapshots
+              mountPath: {{ .Values.threatIntel.outputDir }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: admin
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: admin
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.threatIntel.resources | nindent 12 }}
+      volumes:
+        - name: snapshots
+        {{- if .Values.threatIntel.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "bsdm.fullname" . }}-threat-intel
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+{{- end }}

--- a/charts/bsdm/templates/threat-intel-service.yaml
+++ b/charts/bsdm/templates/threat-intel-service.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.threatIntel .Values.threatIntel.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bsdm.fullname" . }}-threat-intel
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: threat-intel
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.threatIntel.service.port }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
+  selector:
+    {{- include "bsdm.threatIntelSelectorLabels" . | nindent 4 }}
+{{- end }}
+{{- if and .Values.threatIntel .Values.threatIntel.enabled .Values.threatIntel.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "bsdm.fullname" . }}-threat-intel
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: threat-intel
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.threatIntel.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.threatIntel.persistence.size | quote }}
+{{- end }}

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -219,6 +219,36 @@ mlWorker:
   clickhouseUrl: "http://clickhouse-bsdm.bsdm-analytics.svc.cluster.local:8123"
   rustLog: "info,ml_worker=info"
 
+# Optional threat-intel collector (IOC feed ingestion)
+threatIntel:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ghcr.io/onixus/bsdm-threat-intel
+    tag: "0.6.1-1"
+    pullPolicy: IfNotPresent
+  resources:
+    requests:
+      cpu: "50m"
+      memory: 64Mi
+    limits:
+      cpu: "500m"
+      memory: 512Mi
+  service:
+    port: 8093
+  sources: "openphish,phishstats,phishing_database,urlhaus"
+  pollIntervalSecs: 900
+  httpTimeoutSecs: 30
+  maxAttempts: 3
+  outputDir: /var/lib/bsdm-proxy/threat-intel
+  # Snapshots are rebuilt on every cycle, so an emptyDir is enough unless the
+  # IOC store (TASK-TI-002) needs them to survive a restart.
+  persistence:
+    enabled: false
+    size: 1Gi
+    storageClass: ""
+  rustLog: "info,threat_intel=info"
+
 # Optional DNS sinkhole sidecar (RPZ-lite UDP proxy)
 dnsSinkhole:
   enabled: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -480,6 +480,49 @@ services:
         reservations:
           memory: 128M
 
+  # IOC feed collector (TASK-TI-001). Opt-in: `--profile threat-intel`.
+  # Needs egress to the configured feeds; writes snapshots to a local volume
+  # for the IOC store and the scoring engine.
+  threat-intel:
+    profiles: ["threat-intel"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: threat-intel
+      cache_from:
+        - type=registry,ref=ghcr.io/onixus/bsdm-proxy:threat-intel
+    ports:
+      - "8093:8093"
+    environment:
+      - TI_SOURCES=${TI_SOURCES:-openphish,phishstats,phishing_database,urlhaus}
+      - TI_POLL_INTERVAL_SECS=${TI_POLL_INTERVAL_SECS:-900}
+      - TI_HTTP_TIMEOUT_SECS=${TI_HTTP_TIMEOUT_SECS:-30}
+      - TI_MAX_ATTEMPTS=${TI_MAX_ATTEMPTS:-3}
+      - TI_RETRY_BACKOFF_SECS=${TI_RETRY_BACKOFF_SECS:-5}
+      - TI_MAX_BODY_MB=${TI_MAX_BODY_MB:-64}
+      - TI_MAX_INDICATORS_PER_FETCH=${TI_MAX_INDICATORS_PER_FETCH:-500000}
+      - TI_OUTPUT_DIR=/var/lib/bsdm-proxy/threat-intel
+      - METRICS_PORT=8093
+      - RUST_LOG=info,threat_intel=info
+    volumes:
+      - threat-intel-data:/var/lib/bsdm-proxy/threat-intel
+    networks:
+      - bsdm-net
+    restart: unless-stopped
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8093/health | grep -q ok"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
 networks:
   bsdm-net:
     driver: bridge
@@ -499,4 +542,6 @@ volumes:
   pinning-audit:
     driver: local
   agent-devices:
+    driver: local
+  threat-intel-data:
     driver: local

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@
 | [Admin Console security](features/admin-console-security.md) | Trust boundaries и mutation token gate |
 | [Semantic cache](features/semantic-cache.md) | beta |
 | [DNS sinkhole, DoH, DoT](features/dns-sinkhole.md) | основной |
+| [Threat intel collector](features/threat-intel-collector.md) | experimental |
 | [WASM plugins](features/wasm-plugins.md) | experimental |
 | [ICAP](features/icap-inspection.md) | experimental |
 

--- a/docs/architecture/structure.md
+++ b/docs/architecture/structure.md
@@ -11,6 +11,7 @@
 | `alert-worker` | `alert-worker/` | ClickHouse rules → webhook |
 | `ml-worker` | `ml-worker/` | Feature extraction и scoring |
 | `dns-sinkhole` | `dns-sinkhole/` | Core UDP DNS, DoH/DoT и RPZ-lite |
+| `threat-intel` | `threat-intel/` | Сбор IOC-фидов по расписанию (experimental) |
 | `bsdm-events` | `bsdm-events/` | Общая event schema |
 | `bsdm-proxy-e2e` | `e2e/` | Test harness |
 | `bsdm-wasm-sdk` | `bsdm-wasm-sdk/` | WASM guest ABI helpers |
@@ -28,6 +29,7 @@ bsdm-proxy/
 ├── alert-worker/           # Detection rules
 ├── ml-worker/              # Feature store и scoring
 ├── dns-sinkhole/           # Core DNS security sidecar (DoH/DoT/RPZ)
+├── threat-intel/           # IOC feed collector (experimental)
 ├── bsdm-events/            # Shared event schema
 ├── bsdm-wasm-sdk/          # WASM SDK
 ├── e2e/                    # Integration test harness
@@ -61,7 +63,7 @@ bsdm-proxy/
 | `deploy/compose/docker-compose.awg.yml` | Experimental AWG sidecar |
 
 Основной Compose включает `dns-sinkhole` в базовом стеке; профили опциональных
-компонентов: `alerts`, `ml`, `icap`. Legacy Trust-UI запускается только явным
+компонентов: `alerts`, `ml`, `icap`, `threat-intel`. Legacy Trust-UI запускается только явным
 профилем `experimental-trust-ui`; поддерживаемая операторская UI — Admin Console.
 
 ## Конфигурация и данные

--- a/docs/features/threat-intel-collector.md
+++ b/docs/features/threat-intel-collector.md
@@ -1,0 +1,128 @@
+# Threat intelligence collector (TASK-TI-001)
+
+Optional `threat-intel` worker that pulls phishing/malware IOC feeds on a
+schedule, parses them through per-source plugins, and writes a snapshot per feed
+plus a run report. This is the collector framework from the
+[TI backlog](../threat-intelligence/AI_Agent_Backlog.md): the IOC database
+(TASK-TI-002), full normalization (TASK-TI-003) and confidence scoring
+(TASK-TI-010) are **not** part of it, and nothing here is wired into ACL or RPZ
+enforcement yet.
+
+Status: **Experimental**. Treat the output as an input to a review pipeline, not
+as a block list.
+
+## Quick start
+
+```bash
+TI_RUN_ONCE=true TI_OUTPUT_DIR=./data/threat-intel cargo run -p threat-intel
+ls ./data/threat-intel   # openphish.jsonl phishstats.jsonl ... report.json
+```
+
+Long-running (default) mode refreshes every source every
+`TI_POLL_INTERVAL_SECS` and serves `/metrics` and `/health` on `METRICS_PORT`:
+
+```bash
+cargo run -p threat-intel
+curl http://127.0.0.1:8093/health
+curl http://127.0.0.1:8093/metrics | grep threat_intel_
+```
+
+Compose profile:
+
+```bash
+docker compose --profile threat-intel up -d --build threat-intel
+```
+
+Helm: `--set threatIntel.enabled=true` (see `charts/bsdm/values.yaml`).
+
+## Sources
+
+Each source is a plugin: an endpoint plus a parser. The framework owns fetching,
+scheduling, retries, deduplication and metrics, so adding a feed means
+implementing `FeedSource` in `threat-intel/src/sources/` and registering it in
+`sources::build`.
+
+| `TI_SOURCES` name | Feed | IOC kinds | Weight |
+|---|---|---|---:|
+| `openphish` | OpenPhish community feed | url | 90 |
+| `phishstats` | PhishStats scored CSV | url, ip | 80 |
+| `phishing_database` | Phishing.Database active domains | domain | 75 |
+| `urlhaus` | URLhaus recent URLs (online only) | url | 70 |
+
+Weights come from the [collector spec](../threat-intelligence/Threat_Intelligence_Collector_Agent.md)
+and are carried on every indicator (`source_weight`) for the scoring engine.
+Any endpoint can be overridden with `TI_<SOURCE>_URL`, which is also how the
+collector is pointed at a local fixture in tests.
+
+## Output
+
+`TI_OUTPUT_DIR/<source>.jsonl` is a full snapshot of the last successful fetch —
+one JSON object per line, replaced atomically on every cycle:
+
+```json
+{"value":"https://a.example/login","kind":"url","source":"openphish","source_weight":90,
+ "collected_at":"2026-08-20T03:52:21Z","reported_at":null,"reference":null,"tags":[]}
+```
+
+`TI_OUTPUT_DIR/report.json` holds the latest result per source — status,
+indicator count, attempts, duration and the last error, if any.
+
+The exported `domains.txt` / `urls.txt` / `ips.txt` artifacts described in the
+collector spec belong to the export stage (TASK-TI-020) and are not produced
+here.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TI_SOURCES` | `openphish,phishstats,phishing_database,urlhaus` | Enabled feeds, in collection order |
+| `TI_<SOURCE>_URL` | vendor default | Per-source endpoint override |
+| `TI_POLL_INTERVAL_SECS` | `900` | Refresh interval per source (floor 60) |
+| `TI_HTTP_TIMEOUT_SECS` | `30` | Per-request timeout |
+| `TI_MAX_ATTEMPTS` | `3` | Attempts per cycle, including the first |
+| `TI_RETRY_BACKOFF_SECS` | `5` | Base of the exponential backoff (capped at 600s) |
+| `TI_MAX_BODY_MB` | `64` | Hard cap on a feed response body |
+| `TI_MAX_INDICATORS_PER_FETCH` | `500000` | Hard cap on indicators kept per fetch |
+| `TI_OUTPUT_DIR` | `./data/threat-intel` | Snapshot directory |
+| `TI_USER_AGENT` | `bsdm-threat-intel/<version>` | Feed request User-Agent |
+| `TI_RUN_ONCE` | `false` | Collect every source once and exit |
+| `METRICS_PORT` | `8093` | `/metrics` and `/health` |
+
+Packaged example: `packaging/config/threat-intel.env.example`.
+
+## Error handling
+
+Each source runs in its own scheduled task, so a slow or broken feed never
+delays the others. Within a cycle, transport errors, `429` and `5xx` are retried
+with exponential backoff up to `TI_MAX_ATTEMPTS`; `4xx`, parse errors, oversized
+bodies and empty feeds fail the cycle immediately, since retrying them would
+fail the same way. A failed cycle keeps the previous snapshot on disk and is
+recorded in `report.json` and in the metrics; the next tick retries the feed.
+
+`TI_RUN_ONCE=true` exits non-zero if any source failed, which makes it usable as
+a cron job or a CI smoke check.
+
+## Metrics
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `threat_intel_fetches_total` | `source`, `result` | Cycles by outcome (`ok`, `http_error`, `parse_error`, `transport_error`, `too_large`, `empty`) |
+| `threat_intel_retries_total` | `source` | Retried attempts |
+| `threat_intel_indicators_total` | `source`, `kind` | Indicators accepted |
+| `threat_intel_indicators_dropped_total` | `source`, `reason` | Dropped as `duplicate` or `over_cap` |
+| `threat_intel_last_batch_indicators` | `source` | Size of the latest snapshot |
+| `threat_intel_last_success_timestamp_seconds` | `source` | Unix time of the last success — alert on staleness |
+| `threat_intel_fetch_duration_seconds` | `source` | Cycle duration histogram |
+| `threat_intel_sink_errors_total` | `source` | Snapshot write failures |
+
+## Security
+
+Processing is metadata-only by construction: the collector issues `GET` requests
+against the configured feed endpoints and never requests a collected indicator,
+so it does not visit phishing pages or download payloads. Response bodies are
+capped (`TI_MAX_BODY_MB`) before buffering, redirects are limited, and non-HTTP
+feed URLs are rejected.
+
+The container runs as a non-root user and needs egress to the feed vendors. In
+an air-gapped deployment, mirror the feeds internally and point `TI_<SOURCE>_URL`
+at the mirror.

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -299,6 +299,27 @@ ML worker:
 
 Подробнее: [DNS sinkhole](../features/dns-sinkhole.md).
 
+## Threat intel collector
+
+Отдельный опциональный worker `threat-intel` (профиль Compose `threat-intel`).
+
+| Переменная | Default |
+|---|---|
+| `TI_SOURCES` | `openphish,phishstats,phishing_database,urlhaus` |
+| `TI_<SOURCE>_URL` | endpoint вендора |
+| `TI_POLL_INTERVAL_SECS` | `900` |
+| `TI_HTTP_TIMEOUT_SECS` | `30` |
+| `TI_MAX_ATTEMPTS` | `3` |
+| `TI_RETRY_BACKOFF_SECS` | `5` |
+| `TI_MAX_BODY_MB` | `64` |
+| `TI_MAX_INDICATORS_PER_FETCH` | `500000` |
+| `TI_OUTPUT_DIR` | `./data/threat-intel` |
+| `TI_RUN_ONCE` | `false` |
+| `METRICS_PORT` | `8093` |
+
+Полный пример: `packaging/config/threat-intel.env.example`. Подробнее:
+[Threat intel collector](../features/threat-intel-collector.md).
+
 ## Experimental modules
 
 ### WASM

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -30,6 +30,7 @@
 | Detection | alert-worker | Beta | Запросы правил выполняются периодически; нужен контроль ClickHouse latency. |
 | ML | UEBA, phishing, beacon, threat-score write-back | Beta | Один процесс `ml-worker` = одна модель. Пилот: UEBA `ueba_zscore_v0` + write-back ([pilot-ml.md](getting-started/pilot-ml.md)); proxy `THREAT_SCORE_*` opt-in, block off. |
 | DNS | DNS Sinkhole + RPZ (Core component) | Основной | DoH/DoT gateways; control-plane **RPZ API** (`/api/dns/rpz/*`) + zone reload. |
+| Threat Intelligence | IOC feed collector (`threat-intel`) | Experimental | TASK-TI-001: плагины источников, расписание, retry и метрики. Пишет JSONL-снапшоты; хранилище, scoring и enforcement не реализованы ([threat-intel-collector.md](features/threat-intel-collector.md)). |
 | AI cache | Exact LLM POST cache, local/Qdrant near-hit | Beta | Поддерживает векторный бэкенд Qdrant (`SEMANTIC_VECTOR_BACKEND=qdrant`) и квотирование по API ключам. |
 | Extensions | WASM request hook | Experimental (Frozen) | Заморожено. PoC hook с fuel limits. |
 | Inspection | ICAP REQMOD/RESPMOD | Experimental (Frozen) | Заморожено. RESPMOD требует buffered MISS (`STREAMING_MISS_ENABLED=false`). |
@@ -57,7 +58,11 @@
 6. Native DLP выключен по умолчанию (`DLP_ENABLED=false` / unset). Для lab-оценки
    сигнатур: `DLP_ENABLED=true`. Runtime: `POST /api/security/dlp` с `[]` очищает
    паттерны (требует Bearer); состояние не персистится между рестартами.
-7. `GlobalSessionStore`, Redis rate-limit path и `ThreatSyncEngine` добавлены как
+7. `threat-intel` только собирает фиды в файловые снапшоты. IOC-база
+   (TASK-TI-002), нормализация (TASK-TI-003), confidence scoring (TASK-TI-010) и
+   применение в ACL/RPZ (TASK-TI-020/021) не реализованы — вывод коллектора не
+   влияет на решения проксирования.
+8. `GlobalSessionStore`, Redis rate-limit path и `ThreatSyncEngine` добавлены как
    scaffolding. Текущий `main.rs` создаёт session/threat stores без Redis, а
    proxy request path не вызывает distributed rate-limit check. Название
    «global/real-time sync» пока не означает рабочий multi-node сценарий.

--- a/docs/threat-intelligence/AI_Agent_Backlog.md
+++ b/docs/threat-intelligence/AI_Agent_Backlog.md
@@ -10,6 +10,9 @@ Implement automated Threat Intelligence pipeline integrated with BSDM Proxy.
 
 ## TASK-TI-001 Feed Collector Framework
 
+**Status: implemented** — `threat-intel` crate,
+[docs/features/threat-intel-collector.md](../features/threat-intel-collector.md).
+
 Create modular feed collector architecture.
 
 Requirements:

--- a/packaging/config/threat-intel.env.example
+++ b/packaging/config/threat-intel.env.example
@@ -1,0 +1,33 @@
+# BSDM-Proxy threat-intel collector configuration
+# Copy to /etc/bsdm-proxy/threat-intel.env.
+# Docs: docs/features/threat-intel-collector.md
+
+# Enabled feeds, in collection order.
+TI_SOURCES=openphish,phishstats,phishing_database,urlhaus
+
+# Per-source endpoint overrides (defaults come from the feed vendors).
+# TI_OPENPHISH_URL=https://openphish.com/feed.txt
+# TI_PHISHSTATS_URL=https://phishstats.info/phish_score.csv
+# TI_PHISHING_DATABASE_URL=https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/phishing-domains-ACTIVE.txt
+# TI_URLHAUS_URL=https://urlhaus.abuse.ch/downloads/csv_recent/
+
+# Scheduling and error handling. Minimum poll interval is 60s.
+TI_POLL_INTERVAL_SECS=900
+TI_HTTP_TIMEOUT_SECS=30
+TI_MAX_ATTEMPTS=3
+TI_RETRY_BACKOFF_SECS=5
+
+# Safety caps on a single fetch.
+TI_MAX_BODY_MB=64
+TI_MAX_INDICATORS_PER_FETCH=500000
+
+# Snapshot output: <dir>/<source>.jsonl plus <dir>/report.json.
+TI_OUTPUT_DIR=/var/lib/bsdm-proxy/threat-intel
+# TI_USER_AGENT=bsdm-threat-intel/0.9.12
+
+# Collect every source once and exit (cron-style runs, CI smoke).
+# TI_RUN_ONCE=false
+
+METRICS_PORT=8093
+RUST_LOG=info,threat_intel=info
+RUST_BACKTRACE=0

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -91,6 +91,9 @@ fi
 if [[ -x "${SCRIPT_DIR}/bin/dns-sinkhole" ]]; then
   install -m 0755 "${SCRIPT_DIR}/bin/dns-sinkhole" "${PREFIX}/bin/dns-sinkhole"
 fi
+if [[ -x "${SCRIPT_DIR}/bin/threat-intel" ]]; then
+  install -m 0755 "${SCRIPT_DIR}/bin/threat-intel" "${PREFIX}/bin/threat-intel"
+fi
 
 install -d -m 0755 "${ETC_DIR}"
 if [[ ! -f "${ETC_DIR}/bsdm-proxy.env" ]]; then
@@ -113,6 +116,10 @@ if [[ -f "${SCRIPT_DIR}/config/ml-worker.env.example" && ! -f "${ETC_DIR}/ml-wor
   install -m 0640 "${SCRIPT_DIR}/config/ml-worker.env.example" "${ETC_DIR}/ml-worker.env"
   echo "Installed ${ETC_DIR}/ml-worker.env"
 fi
+if [[ -f "${SCRIPT_DIR}/config/threat-intel.env.example" && ! -f "${ETC_DIR}/threat-intel.env" ]]; then
+  install -m 0640 "${SCRIPT_DIR}/config/threat-intel.env.example" "${ETC_DIR}/threat-intel.env"
+  echo "Installed ${ETC_DIR}/threat-intel.env"
+fi
 if [[ ! -f "${ETC_DIR}/acl-rules.json" ]]; then
   install -m 0644 "${SCRIPT_DIR}/config/acl-rules.example.json" "${ETC_DIR}/acl-rules.json"
   echo "Installed ${ETC_DIR}/acl-rules.json"
@@ -125,7 +132,7 @@ if $CREATE_USER; then
 fi
 
 if $INSTALL_SYSTEMD; then
-  for unit in bsdm-proxy bsdm-cache-indexer bsdm-alert-worker bsdm-ml-worker bsdm-dns-sinkhole; do
+  for unit in bsdm-proxy bsdm-cache-indexer bsdm-alert-worker bsdm-ml-worker bsdm-dns-sinkhole bsdm-threat-intel; do
     if [[ -f "${SCRIPT_DIR}/systemd/${unit}.service" ]]; then
       sed "s|/opt/bsdm-proxy|${PREFIX}|g" \
         "${SCRIPT_DIR}/systemd/${unit}.service" \
@@ -139,6 +146,7 @@ if $INSTALL_SYSTEMD; then
   echo "  systemctl enable --now bsdm-alert-worker   # optional; set ALERT_WEBHOOK_URL first"
   echo "  systemctl enable --now bsdm-ml-worker      # optional; M5 feature store"
   echo "  systemctl enable --now bsdm-dns-sinkhole   # optional; DoH/DoT DNS gateway"
+  echo "  systemctl enable --now bsdm-threat-intel   # optional; IOC feed collector"
 fi
 
 cat <<EOF

--- a/packaging/systemd/bsdm-threat-intel.service
+++ b/packaging/systemd/bsdm-threat-intel.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=BSDM-Proxy threat-intel collector (IOC feed ingestion)
+Documentation=https://github.com/onixus/bsdm-proxy/blob/main/docs/features/threat-intel-collector.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=bsdm-proxy
+Group=bsdm-proxy
+EnvironmentFile=-/etc/bsdm-proxy/threat-intel.env
+ExecStart=/opt/bsdm-proxy/bin/threat-intel
+StateDirectory=bsdm-proxy/threat-intel
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -21,7 +21,8 @@ cargo build --release \
   -p cache-indexer --bin cache-indexer \
   -p alert-worker --bin alert-worker \
   -p ml-worker --bin ml-worker \
-  -p dns-sinkhole --bin dns-sinkhole
+  -p dns-sinkhole --bin dns-sinkhole \
+  -p threat-intel --bin threat-intel
 
 echo "==> Assembling package ${PACKAGE_NAME}"
 rm -rf "$STAGING"
@@ -29,7 +30,7 @@ mkdir -p "$STAGING"/{bin,config,systemd}
 
 cp target/release/proxy target/release/cache-indexer \
   target/release/alert-worker target/release/ml-worker \
-  target/release/dns-sinkhole "$STAGING/bin/"
+  target/release/dns-sinkhole target/release/threat-intel "$STAGING/bin/"
 cp packaging/config/*.example "$STAGING/config/"
 cp config/acl-rules.example.json "$STAGING/config/"
 cp packaging/systemd/*.service "$STAGING/systemd/"

--- a/scripts/sync-wiki.py
+++ b/scripts/sync-wiki.py
@@ -59,6 +59,7 @@ PAGES: tuple[Page, ...] = (
     Page("docs/features/acl-policy.md", "ACL-Policy.md", "Security & policy", "ACL", "Правила доступа, reload и persist."),
     Page("docs/features/categorization.md", "Domain-Categorization.md", "Security & policy", "Categorization", "UT1, локальные и online threat feeds."),
     Page("docs/features/certificate-pinning.md", "Certificate-Pinning-Exceptions.md", "Security & policy", "Certificate pinning", "Управляемые MITM bypass-исключения."),
+    Page("docs/features/threat-intel-collector.md", "Threat-Intelligence-Collector.md", "Security & policy", "TI collector", "Сбор IOC-фидов: плагины источников, расписание, метрики."),
     Page("docs/features/control-plane.md", "Control-Plane-API.md", "Security & policy", "Control plane API", "REST/gRPC endpoints и auth model."),
     Page("docs/features/admin-console-security.md", "Admin-Console-Security.md", "Security & policy", "Admin Console security", "Trust boundaries и mutation token gate."),
     Page("docs/features/dns-sinkhole.md", "DNS-Sinkhole.md", "Security & policy", "DNS sinkhole", "RPZ filtering, UDP, DoH и DoT."),

--- a/threat-intel/Cargo.toml
+++ b/threat-intel/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "threat-intel"
+version = "0.9.12"
+edition = "2021"
+license = "MIT"
+authors = ["BSDM-Proxy Contributors"]
+description = "Threat intelligence feed collector: scheduled IOC ingestion from phishing/malware feeds"
+repository = "https://github.com/onixus/bsdm-proxy"
+keywords = ["threat-intelligence", "ioc", "phishing", "security"]
+categories = ["network-programming"]
+
+[[bin]]
+name = "threat-intel"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+prometheus = "0.14"
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { workspace = true }
+tempfile = "3.14"

--- a/threat-intel/src/collector.rs
+++ b/threat-intel/src/collector.rs
@@ -1,0 +1,383 @@
+//! Scheduling and error handling around the feed source plugins.
+
+use crate::config::Config;
+use crate::http::FeedHttpClient;
+use crate::indicator::RawIndicator;
+use crate::metrics::CollectorMetrics;
+use crate::sink::{CollectionReport, IndicatorSink, SourceReport};
+use crate::source::{dedupe_batch, FeedError, FeedSource};
+use chrono::Utc;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tracing::{info, warn};
+
+/// Everything a collection task needs, shared across per-source tasks.
+pub struct Collector {
+    config: Config,
+    http: FeedHttpClient,
+    sink: Arc<dyn IndicatorSink>,
+    metrics: Arc<CollectorMetrics>,
+    report: Mutex<CollectionReport>,
+}
+
+impl Collector {
+    pub fn new(
+        config: Config,
+        http: FeedHttpClient,
+        sink: Arc<dyn IndicatorSink>,
+        metrics: Arc<CollectorMetrics>,
+    ) -> Self {
+        Self {
+            config,
+            http,
+            sink,
+            metrics,
+            report: Mutex::new(CollectionReport::default()),
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Fetch, parse and persist one source. A failing source never aborts the
+    /// run: the error is recorded and the next cycle retries it.
+    pub async fn collect(&self, source: &dyn FeedSource) -> Result<usize, FeedError> {
+        let name = source.name();
+        let started = Instant::now();
+        let mut attempts = 0u32;
+
+        let outcome = loop {
+            attempts += 1;
+            match self.attempt(source).await {
+                Ok(indicators) => break Ok(indicators),
+                Err(err) => {
+                    if attempts >= self.config.max_attempts || !err.is_retryable() {
+                        break Err(err);
+                    }
+                    let delay = self.config.backoff_for(attempts);
+                    warn!(
+                        source = name,
+                        attempt = attempts,
+                        backoff_secs = delay.as_secs(),
+                        "feed fetch failed, retrying: {err}"
+                    );
+                    self.metrics.retries.with_label_values(&[name]).inc();
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        };
+
+        let elapsed = started.elapsed();
+        self.metrics
+            .fetch_duration
+            .with_label_values(&[name])
+            .observe(elapsed.as_secs_f64());
+
+        let result = match outcome {
+            Ok(indicators) => {
+                let count = indicators.len();
+                for indicator in &indicators {
+                    self.metrics
+                        .indicators
+                        .with_label_values(&[name, indicator.kind.as_str()])
+                        .inc();
+                }
+                if let Err(e) = self.sink.write_batch(name, &indicators) {
+                    self.metrics.sink_errors.with_label_values(&[name]).inc();
+                    warn!(source = name, "failed to write snapshot: {e}");
+                    Err(FeedError::Parse(format!("sink write failed: {e}")))
+                } else {
+                    self.metrics
+                        .last_batch_size
+                        .with_label_values(&[name])
+                        .set(count as i64);
+                    self.metrics
+                        .last_success_timestamp
+                        .with_label_values(&[name])
+                        .set(Utc::now().timestamp());
+                    info!(
+                        source = name,
+                        indicators = count,
+                        attempts,
+                        duration_ms = elapsed.as_millis() as u64,
+                        "collected feed"
+                    );
+                    Ok(count)
+                }
+            }
+            Err(err) => Err(err),
+        };
+
+        let (status, indicators, error) = match &result {
+            Ok(count) => ("ok", *count, None),
+            Err(err) => (err.metric_label(), 0, Some(err.to_string())),
+        };
+        self.metrics
+            .fetches
+            .with_label_values(&[name, status])
+            .inc();
+        if let Err(err) = &result {
+            warn!(source = name, attempts, "feed collection failed: {err}");
+        }
+
+        self.record(SourceReport {
+            source: name.to_string(),
+            url: source.url().to_string(),
+            status,
+            indicators,
+            duration_ms: elapsed.as_millis(),
+            attempts,
+            finished_at: Utc::now(),
+            error,
+        });
+
+        result
+    }
+
+    async fn attempt(&self, source: &dyn FeedSource) -> Result<Vec<RawIndicator>, FeedError> {
+        let body = self.http.fetch(source).await?;
+        let parsed = source.parse(&body)?;
+        Ok(self.post_process(source.name(), parsed))
+    }
+
+    /// Intra-batch dedupe plus the per-fetch cap that keeps a runaway feed from
+    /// filling the disk.
+    fn post_process(&self, name: &str, parsed: Vec<RawIndicator>) -> Vec<RawIndicator> {
+        let parsed_len = parsed.len();
+        let mut indicators = dedupe_batch(parsed);
+        let duplicates = parsed_len - indicators.len();
+        if duplicates > 0 {
+            self.metrics
+                .dropped
+                .with_label_values(&[name, "duplicate"])
+                .inc_by(duplicates as u64);
+        }
+        if indicators.len() > self.config.max_indicators_per_fetch {
+            let overflow = indicators.len() - self.config.max_indicators_per_fetch;
+            warn!(
+                source = name,
+                cap = self.config.max_indicators_per_fetch,
+                dropped = overflow,
+                "feed exceeded the per-fetch indicator cap"
+            );
+            indicators.truncate(self.config.max_indicators_per_fetch);
+            self.metrics
+                .dropped
+                .with_label_values(&[name, "over_cap"])
+                .inc_by(overflow as u64);
+        }
+        indicators
+    }
+
+    fn record(&self, entry: SourceReport) {
+        let snapshot = {
+            let mut report = match self.report.lock() {
+                Ok(report) => report,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            report.record(entry);
+            report.clone()
+        };
+        if let Err(e) = self.sink.write_report(&snapshot) {
+            warn!("failed to write collector report: {e}");
+        }
+    }
+
+    pub fn report(&self) -> CollectionReport {
+        match self.report.lock() {
+            Ok(report) => report.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
+    }
+}
+
+/// Collect every source once, sequentially, so a one-shot run has a
+/// deterministic exit code: `Ok(())` only when every source succeeded.
+pub async fn run_once(
+    collector: Arc<Collector>,
+    sources: Vec<Box<dyn FeedSource>>,
+) -> Result<(), String> {
+    let mut failed = Vec::new();
+    for source in &sources {
+        if collector.collect(source.as_ref()).await.is_err() {
+            failed.push(source.name());
+        }
+    }
+
+    let report = collector.report();
+    let total: usize = report.sources.iter().map(|s| s.indicators).sum();
+    info!(
+        sources = report.sources.len(),
+        indicators = total,
+        failed = failed.len(),
+        "one-shot collection finished"
+    );
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("sources failed: {}", failed.join(", ")))
+    }
+}
+
+/// Spawn one scheduled task per source. Sources run independently so a slow or
+/// broken feed cannot delay the others.
+pub fn spawn_scheduled(
+    collector: Arc<Collector>,
+    sources: Vec<Box<dyn FeedSource>>,
+) -> Vec<tokio::task::JoinHandle<()>> {
+    let interval = collector.config().poll_interval;
+    sources
+        .into_iter()
+        .map(|source| {
+            let collector = collector.clone();
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(interval);
+                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                loop {
+                    ticker.tick().await;
+                    let _ = collector.collect(source.as_ref()).await;
+                }
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indicator::{IndicatorKind, RawIndicator};
+    use crate::sink::JsonlFileSink;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    struct StaticSource {
+        url: String,
+    }
+
+    impl FeedSource for StaticSource {
+        fn name(&self) -> &'static str {
+            "openphish"
+        }
+        fn url(&self) -> &str {
+            &self.url
+        }
+        fn weight(&self) -> u8 {
+            90
+        }
+        fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError> {
+            let out: Vec<RawIndicator> = body
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| RawIndicator::new(l.trim(), IndicatorKind::Url, self))
+                .collect();
+            if out.is_empty() {
+                return Err(FeedError::Empty);
+            }
+            Ok(out)
+        }
+    }
+
+    fn test_config(dir: &std::path::Path, cap: usize) -> Config {
+        Config {
+            sources: vec!["openphish".into()],
+            poll_interval: Duration::from_secs(900),
+            http_timeout: Duration::from_secs(5),
+            max_attempts: 1,
+            retry_backoff: Duration::from_secs(1),
+            max_body_bytes: 1024 * 1024,
+            max_indicators_per_fetch: cap,
+            output_dir: PathBuf::from(dir),
+            user_agent: "test".into(),
+            metrics_port: 0,
+            run_once: true,
+        }
+    }
+
+    fn collector(dir: &std::path::Path, cap: usize) -> Collector {
+        let sink = Arc::new(JsonlFileSink::new(dir).unwrap());
+        Collector::new(
+            test_config(dir, cap),
+            FeedHttpClient::new(Duration::from_secs(5), 1024 * 1024, "test").unwrap(),
+            sink,
+            CollectorMetrics::new().unwrap(),
+        )
+    }
+
+    /// Minimal HTTP server serving one fixed body, so the collector path can be
+    /// exercised without reaching a real feed.
+    async fn serve(body: &'static str, status_line: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = vec![0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                let response = format!(
+                    "{status_line}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}/feed.txt")
+    }
+
+    #[tokio::test]
+    async fn collects_writes_snapshot_and_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let collector = collector(dir.path(), 100);
+        let url = serve(
+            "https://a.example/\nhttps://b.example/\n",
+            "HTTP/1.1 200 OK",
+        )
+        .await;
+        let source = StaticSource { url };
+
+        let count = collector.collect(&source).await.unwrap();
+        assert_eq!(count, 2);
+
+        let snapshot = std::fs::read_to_string(dir.path().join("openphish.jsonl")).unwrap();
+        assert_eq!(snapshot.lines().count(), 2);
+
+        let report = collector.report();
+        assert_eq!(report.sources.len(), 1);
+        assert_eq!(report.sources[0].status, "ok");
+        assert_eq!(report.sources[0].attempts, 1);
+        assert!(dir.path().join("report.json").exists());
+    }
+
+    #[tokio::test]
+    async fn http_error_is_recorded_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let collector = collector(dir.path(), 100);
+        let url = serve("nope", "HTTP/1.1 503 Service Unavailable").await;
+        let source = StaticSource { url };
+
+        let err = collector.collect(&source).await.unwrap_err();
+        assert!(matches!(err, FeedError::Status(503)));
+        let report = collector.report();
+        assert_eq!(report.sources[0].status, "http_error");
+        assert!(report.sources[0].error.is_some());
+        assert!(!dir.path().join("openphish.jsonl").exists());
+    }
+
+    #[tokio::test]
+    async fn enforces_dedupe_and_per_fetch_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let collector = collector(dir.path(), 2);
+        let url = serve(
+            "https://a.example/\nhttps://a.example/\nhttps://b.example/\nhttps://c.example/\n",
+            "HTTP/1.1 200 OK",
+        )
+        .await;
+        let source = StaticSource { url };
+
+        let count = collector.collect(&source).await.unwrap();
+        assert_eq!(count, 2);
+        let snapshot = std::fs::read_to_string(dir.path().join("openphish.jsonl")).unwrap();
+        assert_eq!(snapshot.lines().count(), 2);
+    }
+}

--- a/threat-intel/src/config.rs
+++ b/threat-intel/src/config.rs
@@ -1,0 +1,147 @@
+//! Runtime configuration from environment variables.
+
+use crate::sources::KNOWN_SOURCES;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Enabled feed sources, in collection order.
+    pub sources: Vec<String>,
+    /// How often each source is refreshed.
+    pub poll_interval: Duration,
+    /// Per-request timeout for a feed fetch.
+    pub http_timeout: Duration,
+    /// Attempts per collection cycle, including the first one.
+    pub max_attempts: u32,
+    /// Base delay for the exponential retry backoff.
+    pub retry_backoff: Duration,
+    /// Hard cap on a feed response body.
+    pub max_body_bytes: usize,
+    /// Hard cap on indicators kept from a single fetch.
+    pub max_indicators_per_fetch: usize,
+    pub output_dir: PathBuf,
+    pub user_agent: String,
+    pub metrics_port: u16,
+    /// Collect every source once and exit (CI smoke, cron-style runs).
+    pub run_once: bool,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self, String> {
+        let sources = parse_sources(
+            &std::env::var("TI_SOURCES").unwrap_or_else(|_| KNOWN_SOURCES.join(",")),
+        )?;
+
+        let max_attempts = env_u64("TI_MAX_ATTEMPTS", 3).max(1) as u32;
+        let poll_interval = Duration::from_secs(env_u64("TI_POLL_INTERVAL_SECS", 900).max(60));
+
+        Ok(Self {
+            sources,
+            poll_interval,
+            http_timeout: Duration::from_secs(env_u64("TI_HTTP_TIMEOUT_SECS", 30).max(1)),
+            max_attempts,
+            retry_backoff: Duration::from_secs(env_u64("TI_RETRY_BACKOFF_SECS", 5).max(1)),
+            max_body_bytes: env_u64("TI_MAX_BODY_MB", 64).max(1) as usize * 1024 * 1024,
+            max_indicators_per_fetch: env_u64("TI_MAX_INDICATORS_PER_FETCH", 500_000) as usize,
+            output_dir: PathBuf::from(
+                std::env::var("TI_OUTPUT_DIR").unwrap_or_else(|_| "./data/threat-intel".into()),
+            ),
+            user_agent: std::env::var("TI_USER_AGENT")
+                .unwrap_or_else(|_| format!("bsdm-threat-intel/{}", env!("CARGO_PKG_VERSION"))),
+            metrics_port: env_u64("METRICS_PORT", 8093) as u16,
+            run_once: env_bool("TI_RUN_ONCE", false),
+        })
+    }
+
+    /// Per-source endpoint override, e.g. `TI_OPENPHISH_URL`.
+    pub fn source_url(name: &str) -> Option<String> {
+        std::env::var(format!("TI_{}_URL", name.to_ascii_uppercase()))
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
+    /// Delay before attempt `attempt` (1-based), capped at ten minutes.
+    pub fn backoff_for(&self, attempt: u32) -> Duration {
+        let factor = 1u64 << attempt.saturating_sub(1).min(6);
+        let secs = self.retry_backoff.as_secs().saturating_mul(factor);
+        Duration::from_secs(secs.min(600))
+    }
+}
+
+fn parse_sources(raw: &str) -> Result<Vec<String>, String> {
+    let sources: Vec<String> = raw
+        .split(',')
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if sources.is_empty() {
+        return Err("TI_SOURCES must list at least one feed source".into());
+    }
+    let mut seen = std::collections::HashSet::new();
+    for source in &sources {
+        if !seen.insert(source.clone()) {
+            return Err(format!("TI_SOURCES lists '{source}' twice"));
+        }
+    }
+    Ok(sources)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_bool(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Config {
+        Config {
+            sources: vec!["openphish".into()],
+            poll_interval: Duration::from_secs(900),
+            http_timeout: Duration::from_secs(30),
+            max_attempts: 3,
+            retry_backoff: Duration::from_secs(5),
+            max_body_bytes: 1024,
+            max_indicators_per_fetch: 10,
+            output_dir: PathBuf::from("/tmp"),
+            user_agent: "test".into(),
+            metrics_port: 8093,
+            run_once: true,
+        }
+    }
+
+    #[test]
+    fn parses_and_normalizes_source_list() {
+        assert_eq!(
+            parse_sources(" OpenPhish , urlhaus ").unwrap(),
+            vec!["openphish", "urlhaus"]
+        );
+    }
+
+    #[test]
+    fn rejects_empty_and_duplicate_source_lists() {
+        assert!(parse_sources("  ,  ").is_err());
+        assert!(parse_sources("urlhaus,urlhaus").is_err());
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_and_caps() {
+        let config = config();
+        assert_eq!(config.backoff_for(1), Duration::from_secs(5));
+        assert_eq!(config.backoff_for(2), Duration::from_secs(10));
+        assert_eq!(config.backoff_for(3), Duration::from_secs(20));
+        assert!(config.backoff_for(20) <= Duration::from_secs(600));
+    }
+}

--- a/threat-intel/src/http.rs
+++ b/threat-intel/src/http.rs
@@ -1,0 +1,70 @@
+//! Feed fetching.
+//!
+//! The collector is metadata-only by construction: it issues `GET` requests
+//! against configured feed endpoints, refuses redirects to non-HTTP schemes,
+//! and never requests an indicator value it has collected.
+
+use crate::source::{FeedError, FeedSource};
+use std::time::Duration;
+
+pub struct FeedHttpClient {
+    client: reqwest::Client,
+    max_body_bytes: usize,
+}
+
+impl FeedHttpClient {
+    pub fn new(timeout: Duration, max_body_bytes: usize, user_agent: &str) -> Result<Self, String> {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .user_agent(user_agent.to_string())
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .build()
+            .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+        Ok(Self {
+            client,
+            max_body_bytes,
+        })
+    }
+
+    pub async fn fetch(&self, source: &dyn FeedSource) -> Result<String, FeedError> {
+        let url = source.url();
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            return Err(FeedError::Parse(format!("feed URL must be http(s): {url}")));
+        }
+
+        let response = self
+            .client
+            .get(url)
+            .header(reqwest::header::ACCEPT, source.accept())
+            .send()
+            .await
+            .map_err(|e| FeedError::Transport(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(FeedError::Status(status.as_u16()));
+        }
+
+        // Reject oversized feeds before buffering them when the server is honest
+        // about the length, and again after reading when it is not.
+        if let Some(len) = response.content_length() {
+            if len as usize > self.max_body_bytes {
+                return Err(FeedError::TooLarge {
+                    limit: self.max_body_bytes,
+                });
+            }
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| FeedError::Transport(e.to_string()))?;
+        if bytes.len() > self.max_body_bytes {
+            return Err(FeedError::TooLarge {
+                limit: self.max_body_bytes,
+            });
+        }
+
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+}

--- a/threat-intel/src/indicator.rs
+++ b/threat-intel/src/indicator.rs
@@ -1,0 +1,134 @@
+//! IOC value types shared by every feed source.
+//!
+//! Full normalization (punycode, URL canonicalization, cross-run deduplication)
+//! is TASK-TI-003 and deliberately not implemented here: the collector keeps the
+//! feed value as published and only trims obvious transport noise.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IndicatorKind {
+    Url,
+    Domain,
+    Ip,
+}
+
+impl IndicatorKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IndicatorKind::Url => "url",
+            IndicatorKind::Domain => "domain",
+            IndicatorKind::Ip => "ip",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawIndicator {
+    pub value: String,
+    pub kind: IndicatorKind,
+    /// Feed that published the indicator (`source.name()`).
+    pub source: String,
+    /// Source reputation weight from the collector spec, carried through for the
+    /// scoring engine (TASK-TI-010).
+    pub source_weight: u8,
+    /// When the collector observed the value in the feed.
+    pub collected_at: DateTime<Utc>,
+    /// Publication timestamp reported by the feed, when it provides one.
+    pub reported_at: Option<DateTime<Utc>>,
+    /// Feed-specific reference (report link, entry id) for audit.
+    pub reference: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+}
+
+impl RawIndicator {
+    pub fn new(value: impl Into<String>, kind: IndicatorKind, source: &dyn FeedMeta) -> Self {
+        Self {
+            value: value.into(),
+            kind,
+            source: source.name().to_string(),
+            source_weight: source.weight(),
+            collected_at: Utc::now(),
+            reported_at: None,
+            reference: None,
+            tags: Vec::new(),
+        }
+    }
+
+    pub fn with_reference(mut self, reference: impl Into<String>) -> Self {
+        let reference = reference.into();
+        if !reference.is_empty() {
+            self.reference = Some(reference);
+        }
+        self
+    }
+
+    pub fn with_reported_at(mut self, reported_at: Option<DateTime<Utc>>) -> Self {
+        self.reported_at = reported_at;
+        self
+    }
+
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags = tags;
+        self
+    }
+}
+
+/// The parts of a source a [`RawIndicator`] needs to attribute itself.
+pub trait FeedMeta {
+    fn name(&self) -> &'static str;
+    fn weight(&self) -> u8;
+}
+
+/// True for syntactically valid IPv4/IPv6 literals.
+pub fn is_ip_literal(value: &str) -> bool {
+    value.parse::<IpAddr>().is_ok()
+}
+
+/// Cheap sanity check for feed-published hostnames. This is not normalization —
+/// it only rejects values that clearly are not domains so obvious junk lines do
+/// not reach storage.
+pub fn looks_like_domain(value: &str) -> bool {
+    if value.is_empty() || value.len() > 253 || is_ip_literal(value) {
+        return false;
+    }
+    if !value.contains('.') || value.starts_with('.') || value.ends_with('.') {
+        return false;
+    }
+    value.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_ip_literals() {
+        assert!(is_ip_literal("203.0.113.7"));
+        assert!(is_ip_literal("2001:db8::1"));
+        assert!(!is_ip_literal("example.com"));
+    }
+
+    #[test]
+    fn filters_obvious_non_domains() {
+        assert!(looks_like_domain("login.example.com"));
+        assert!(looks_like_domain("xn--80ak6aa92e.com"));
+        assert!(!looks_like_domain("example"));
+        assert!(!looks_like_domain("203.0.113.7"));
+        assert!(!looks_like_domain("-bad.example.com"));
+        assert!(!looks_like_domain("http://example.com/a"));
+        assert!(!looks_like_domain(""));
+    }
+}

--- a/threat-intel/src/main.rs
+++ b/threat-intel/src/main.rs
@@ -1,0 +1,173 @@
+//! Threat intelligence feed collector (TASK-TI-001).
+//!
+//! Fetches phishing/malware IOC feeds on a schedule, parses them through
+//! per-source plugins, and writes normalized snapshots plus a run report for the
+//! downstream IOC store (TASK-TI-002) and scoring engine (TASK-TI-010).
+
+mod collector;
+mod config;
+mod http;
+mod indicator;
+mod metrics;
+mod sink;
+mod source;
+mod sources;
+
+use collector::Collector;
+use config::Config;
+use http::FeedHttpClient;
+use metrics::CollectorMetrics;
+use prometheus::{Encoder, TextEncoder};
+use sink::JsonlFileSink;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "info,threat_intel=info".into()),
+        )
+        .init();
+
+    let config = Config::from_env().map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+    let feeds = sources::build(&config.sources, &Config::source_url).map_err(|e| {
+        error!("{e}");
+        e
+    })?;
+
+    let metrics = CollectorMetrics::new()?;
+    let sink = Arc::new(JsonlFileSink::new(&config.output_dir)?);
+    let http = FeedHttpClient::new(
+        config.http_timeout,
+        config.max_body_bytes,
+        &config.user_agent,
+    )?;
+
+    info!(
+        sources = ?config.sources,
+        output_dir = %sink.dir().display(),
+        poll_secs = config.poll_interval.as_secs(),
+        max_attempts = config.max_attempts,
+        run_once = config.run_once,
+        "threat-intel collector started"
+    );
+
+    let run_once = config.run_once;
+    let metrics_port = config.metrics_port;
+    let collector = Arc::new(Collector::new(config, http, sink, metrics.clone()));
+
+    if run_once {
+        return collector::run_once(collector, feeds)
+            .await
+            .map_err(|e| e.into());
+    }
+
+    tokio::spawn(async move {
+        run_admin_server(metrics_port, metrics).await;
+    });
+
+    let handles = collector::spawn_scheduled(collector, feeds);
+    for handle in handles {
+        let _ = handle.await;
+    }
+    Ok(())
+}
+
+async fn run_admin_server(port: u16, metrics: Arc<CollectorMetrics>) {
+    let bind_addr = format!("0.0.0.0:{port}");
+    let listener = match TcpListener::bind(&bind_addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            error!("Failed to bind threat-intel admin on {bind_addr}: {e}");
+            return;
+        }
+    };
+    info!("threat-intel admin on {bind_addr} (/metrics, /health)");
+
+    loop {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            continue;
+        };
+        let metrics = metrics.clone();
+        tokio::spawn(async move {
+            let mut buf = vec![0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap_or(0);
+            if n == 0 {
+                return;
+            }
+            let req = String::from_utf8_lossy(&buf[..n]);
+            let response = handle_admin(&req, &metrics);
+            let _ = socket.write_all(&response).await;
+        });
+    }
+}
+
+fn handle_admin(req: &str, metrics: &CollectorMetrics) -> Vec<u8> {
+    let request_line = req.lines().next().unwrap_or("");
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("/");
+
+    if method == "GET" && path.starts_with("/metrics") {
+        let encoder = TextEncoder::new();
+        let mut buffer = Vec::new();
+        if encoder
+            .encode(&metrics.registry().gather(), &mut buffer)
+            .is_err()
+        {
+            return http_response(500, "text/plain", b"encode error");
+        }
+        return http_response(200, "text/plain; version=0.0.4", &buffer);
+    }
+    if method == "GET" && (path == "/health" || path.starts_with("/health?")) {
+        return http_response(200, "text/plain", b"ok");
+    }
+    http_response(404, "text/plain", b"not found")
+}
+
+fn http_response(status: u16, content_type: &str, body: &[u8]) -> Vec<u8> {
+    let reason = match status {
+        200 => "OK",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Error",
+    };
+    let header = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    let mut out = header.into_bytes();
+    out.extend_from_slice(body);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serves_health_and_metrics() {
+        let metrics = CollectorMetrics::new().unwrap();
+        metrics
+            .fetches
+            .with_label_values(&["openphish", "ok"])
+            .inc();
+
+        let health = String::from_utf8(handle_admin("GET /health HTTP/1.1", &metrics)).unwrap();
+        assert!(health.starts_with("HTTP/1.1 200 OK"));
+        assert!(health.ends_with("ok"));
+
+        let scraped = String::from_utf8(handle_admin("GET /metrics HTTP/1.1", &metrics)).unwrap();
+        assert!(scraped.contains("threat_intel_fetches_total"));
+
+        let missing = String::from_utf8(handle_admin("GET /nope HTTP/1.1", &metrics)).unwrap();
+        assert!(missing.starts_with("HTTP/1.1 404"));
+    }
+}

--- a/threat-intel/src/metrics.rs
+++ b/threat-intel/src/metrics.rs
@@ -1,0 +1,109 @@
+//! Prometheus metrics for the threat intelligence collector.
+
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry};
+use std::sync::Arc;
+
+pub struct CollectorMetrics {
+    registry: Registry,
+    /// Completed fetch cycles by outcome (`ok`, `parse_error`, `http_error`, …).
+    pub fetches: IntCounterVec,
+    /// Retried attempts, per source.
+    pub retries: IntCounterVec,
+    /// Indicators accepted, per source and IOC kind.
+    pub indicators: IntCounterVec,
+    /// Indicators dropped as intra-batch duplicates or over the per-fetch cap.
+    pub dropped: IntCounterVec,
+    /// Size of the latest snapshot, per source.
+    pub last_batch_size: IntGaugeVec,
+    /// Unix timestamp of the last successful collection, per source.
+    pub last_success_timestamp: IntGaugeVec,
+    /// Wall-clock duration of a collection cycle, per source.
+    pub fetch_duration: HistogramVec,
+    /// Sink write failures, per source.
+    pub sink_errors: IntCounterVec,
+}
+
+impl CollectorMetrics {
+    pub fn new() -> Result<Arc<Self>, Box<dyn std::error::Error>> {
+        let registry = Registry::new();
+        let fetches = IntCounterVec::new(
+            Opts::new(
+                "threat_intel_fetches_total",
+                "Feed collection cycles by outcome",
+            ),
+            &["source", "result"],
+        )?;
+        let retries = IntCounterVec::new(
+            Opts::new("threat_intel_retries_total", "Retried feed fetch attempts"),
+            &["source"],
+        )?;
+        let indicators = IntCounterVec::new(
+            Opts::new(
+                "threat_intel_indicators_total",
+                "Indicators accepted from feeds",
+            ),
+            &["source", "kind"],
+        )?;
+        let dropped = IntCounterVec::new(
+            Opts::new(
+                "threat_intel_indicators_dropped_total",
+                "Indicators dropped as duplicates or over the per-fetch cap",
+            ),
+            &["source", "reason"],
+        )?;
+        let last_batch_size = IntGaugeVec::new(
+            Opts::new(
+                "threat_intel_last_batch_indicators",
+                "Indicators in the latest snapshot of a source",
+            ),
+            &["source"],
+        )?;
+        let last_success_timestamp = IntGaugeVec::new(
+            Opts::new(
+                "threat_intel_last_success_timestamp_seconds",
+                "Unix time of the last successful collection of a source",
+            ),
+            &["source"],
+        )?;
+        let fetch_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "threat_intel_fetch_duration_seconds",
+                "Duration of a feed collection cycle",
+            )
+            .buckets(vec![0.05, 0.25, 1.0, 5.0, 15.0, 60.0, 300.0]),
+            &["source"],
+        )?;
+        let sink_errors = IntCounterVec::new(
+            Opts::new(
+                "threat_intel_sink_errors_total",
+                "Failures writing collector output",
+            ),
+            &["source"],
+        )?;
+
+        registry.register(Box::new(fetches.clone()))?;
+        registry.register(Box::new(retries.clone()))?;
+        registry.register(Box::new(indicators.clone()))?;
+        registry.register(Box::new(dropped.clone()))?;
+        registry.register(Box::new(last_batch_size.clone()))?;
+        registry.register(Box::new(last_success_timestamp.clone()))?;
+        registry.register(Box::new(fetch_duration.clone()))?;
+        registry.register(Box::new(sink_errors.clone()))?;
+
+        Ok(Arc::new(Self {
+            registry,
+            fetches,
+            retries,
+            indicators,
+            dropped,
+            last_batch_size,
+            last_success_timestamp,
+            fetch_duration,
+            sink_errors,
+        }))
+    }
+
+    pub fn registry(&self) -> &Registry {
+        &self.registry
+    }
+}

--- a/threat-intel/src/sink.rs
+++ b/threat-intel/src/sink.rs
@@ -1,0 +1,179 @@
+//! Collector output.
+//!
+//! TASK-TI-001 stops at a file snapshot per source plus a run report; the
+//! database layer is TASK-TI-002 and plugs in behind the same trait.
+
+use crate::indicator::RawIndicator;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub trait IndicatorSink: Send + Sync {
+    /// Replace the snapshot for `source` with `indicators`.
+    fn write_batch(&self, source: &str, indicators: &[RawIndicator]) -> std::io::Result<()>;
+
+    /// Persist the aggregated state of the last run of every source.
+    fn write_report(&self, report: &CollectionReport) -> std::io::Result<()>;
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceReport {
+    pub source: String,
+    pub url: String,
+    pub status: &'static str,
+    pub indicators: usize,
+    pub duration_ms: u128,
+    pub attempts: u32,
+    pub finished_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct CollectionReport {
+    pub generated_at: Option<DateTime<Utc>>,
+    pub sources: Vec<SourceReport>,
+}
+
+impl CollectionReport {
+    /// Record the newest result for a source, replacing the previous one.
+    pub fn record(&mut self, entry: SourceReport) {
+        self.generated_at = Some(Utc::now());
+        match self.sources.iter_mut().find(|s| s.source == entry.source) {
+            Some(existing) => *existing = entry,
+            None => self.sources.push(entry),
+        }
+    }
+}
+
+/// Writes `<dir>/<source>.jsonl` snapshots and `<dir>/report.json`.
+pub struct JsonlFileSink {
+    dir: PathBuf,
+}
+
+impl JsonlFileSink {
+    pub fn new(dir: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Write via a temp file so readers never observe a half-written snapshot.
+    fn write_atomic(&self, file_name: &str, contents: &[u8]) -> std::io::Result<()> {
+        let target = self.dir.join(file_name);
+        let tmp = self.dir.join(format!("{file_name}.tmp"));
+        {
+            let mut file = std::fs::File::create(&tmp)?;
+            file.write_all(contents)?;
+            file.sync_all()?;
+        }
+        std::fs::rename(&tmp, &target)
+    }
+}
+
+impl IndicatorSink for JsonlFileSink {
+    fn write_batch(&self, source: &str, indicators: &[RawIndicator]) -> std::io::Result<()> {
+        let mut buffer = Vec::with_capacity(indicators.len() * 128);
+        for indicator in indicators {
+            serde_json::to_writer(&mut buffer, indicator)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            buffer.push(b'\n');
+        }
+        self.write_atomic(&format!("{source}.jsonl"), &buffer)
+    }
+
+    fn write_report(&self, report: &CollectionReport) -> std::io::Result<()> {
+        let json = serde_json::to_vec_pretty(report)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        self.write_atomic("report.json", &json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indicator::IndicatorKind;
+
+    fn indicator(value: &str) -> RawIndicator {
+        RawIndicator {
+            value: value.into(),
+            kind: IndicatorKind::Url,
+            source: "openphish".into(),
+            source_weight: 90,
+            collected_at: Utc::now(),
+            reported_at: None,
+            reference: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn writes_one_json_object_per_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = JsonlFileSink::new(dir.path()).unwrap();
+        sink.write_batch(
+            "openphish",
+            &[
+                indicator("https://a.example/"),
+                indicator("https://b.example/"),
+            ],
+        )
+        .unwrap();
+
+        let body = std::fs::read_to_string(dir.path().join("openphish.jsonl")).unwrap();
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let parsed: RawIndicator = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed.value, "https://a.example/");
+        assert!(!dir.path().join("openphish.jsonl.tmp").exists());
+    }
+
+    #[test]
+    fn snapshot_replaces_previous_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = JsonlFileSink::new(dir.path()).unwrap();
+        sink.write_batch(
+            "openphish",
+            &[
+                indicator("https://a.example/"),
+                indicator("https://b.example/"),
+            ],
+        )
+        .unwrap();
+        sink.write_batch("openphish", &[indicator("https://c.example/")])
+            .unwrap();
+        let body = std::fs::read_to_string(dir.path().join("openphish.jsonl")).unwrap();
+        assert_eq!(body.lines().count(), 1);
+    }
+
+    #[test]
+    fn report_keeps_one_entry_per_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let sink = JsonlFileSink::new(dir.path()).unwrap();
+        let mut report = CollectionReport::default();
+        for indicators in [1usize, 5] {
+            report.record(SourceReport {
+                source: "openphish".into(),
+                url: "https://openphish.com/feed.txt".into(),
+                status: "ok",
+                indicators,
+                duration_ms: 3,
+                attempts: 1,
+                finished_at: Utc::now(),
+                error: None,
+            });
+        }
+        sink.write_report(&report).unwrap();
+
+        let body = std::fs::read_to_string(dir.path().join("report.json")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let sources = value["sources"].as_array().unwrap();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0]["indicators"], 5);
+    }
+}

--- a/threat-intel/src/source.rs
+++ b/threat-intel/src/source.rs
@@ -1,0 +1,156 @@
+//! Feed source plugin contract.
+//!
+//! A source is a pure description of *where* a feed lives plus a *parser* for
+//! its payload. Fetching, scheduling, retrying, deduplication and metrics stay
+//! in the framework, which keeps sources trivial to add and to unit-test, and
+//! guarantees the collector only ever performs `GET` requests against feed
+//! endpoints — never against the indicators themselves.
+
+use crate::indicator::{FeedMeta, RawIndicator};
+
+#[derive(Debug, thiserror::Error)]
+pub enum FeedError {
+    #[error("transport error: {0}")]
+    Transport(String),
+    #[error("unexpected HTTP status {0}")]
+    Status(u16),
+    #[error("response exceeds {limit} bytes")]
+    TooLarge { limit: usize },
+    #[error("parse error: {0}")]
+    Parse(String),
+    #[error("feed returned no usable indicators")]
+    Empty,
+}
+
+impl FeedError {
+    /// Retrying a transport hiccup or a 5xx makes sense; a malformed payload or
+    /// a 4xx will fail the same way on the next attempt.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            FeedError::Transport(_) => true,
+            FeedError::Status(code) => *code >= 500 || *code == 429,
+            FeedError::TooLarge { .. } | FeedError::Parse(_) | FeedError::Empty => false,
+        }
+    }
+
+    /// Stable label for the `result` metric dimension.
+    pub fn metric_label(&self) -> &'static str {
+        match self {
+            FeedError::Transport(_) => "transport_error",
+            FeedError::Status(_) => "http_error",
+            FeedError::TooLarge { .. } => "too_large",
+            FeedError::Parse(_) => "parse_error",
+            FeedError::Empty => "empty",
+        }
+    }
+}
+
+/// One threat feed the collector knows how to ingest.
+pub trait FeedSource: Send + Sync {
+    /// Stable identifier used in config, metrics labels and output file names.
+    fn name(&self) -> &'static str;
+
+    /// Endpoint the collector fetches. Must be `http`/`https`.
+    fn url(&self) -> &str;
+
+    /// Source reputation weight from the collector spec (0–100).
+    fn weight(&self) -> u8;
+
+    /// `Accept` header the feed expects.
+    fn accept(&self) -> &'static str {
+        "text/plain, */*"
+    }
+
+    /// Turn a fetched payload into indicators.
+    fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError>;
+}
+
+impl<T: FeedSource + ?Sized> FeedMeta for T {
+    fn name(&self) -> &'static str {
+        FeedSource::name(self)
+    }
+
+    fn weight(&self) -> u8 {
+        FeedSource::weight(self)
+    }
+}
+
+/// Drop repeats inside a single fetch, preserving feed order.
+pub fn dedupe_batch(mut indicators: Vec<RawIndicator>) -> Vec<RawIndicator> {
+    let mut seen = std::collections::HashSet::new();
+    indicators.retain(|ind| seen.insert((ind.kind, ind.value.clone())));
+    indicators
+}
+
+/// Strip a CSV field of surrounding quotes and whitespace.
+pub(crate) fn unquote(field: &str) -> &str {
+    field
+        .trim()
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .trim()
+}
+
+/// Split one CSV record, honouring double-quoted fields (feeds quote URLs that
+/// contain commas).
+pub(crate) fn split_csv(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+    for ch in line.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => fields.push(std::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    fields.push(current);
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::indicator::IndicatorKind;
+    use chrono::Utc;
+
+    fn ind(value: &str, kind: IndicatorKind) -> RawIndicator {
+        RawIndicator {
+            value: value.into(),
+            kind,
+            source: "test".into(),
+            source_weight: 50,
+            collected_at: Utc::now(),
+            reported_at: None,
+            reference: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn dedupes_by_kind_and_value() {
+        let out = dedupe_batch(vec![
+            ind("example.com", IndicatorKind::Domain),
+            ind("example.com", IndicatorKind::Domain),
+            ind("example.com", IndicatorKind::Url),
+        ]);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn splits_quoted_csv_fields() {
+        let fields = split_csv(r#"1,"http://a.example/x,y",online,"tag,tag2""#);
+        assert_eq!(fields.len(), 4);
+        assert_eq!(fields[1], "http://a.example/x,y");
+        assert_eq!(fields[3], "tag,tag2");
+    }
+
+    #[test]
+    fn classifies_retryable_errors() {
+        assert!(FeedError::Transport("timeout".into()).is_retryable());
+        assert!(FeedError::Status(503).is_retryable());
+        assert!(FeedError::Status(429).is_retryable());
+        assert!(!FeedError::Status(404).is_retryable());
+        assert!(!FeedError::Parse("bad".into()).is_retryable());
+    }
+}

--- a/threat-intel/src/sources/mod.rs
+++ b/threat-intel/src/sources/mod.rs
@@ -1,0 +1,77 @@
+//! Built-in feed sources and the registry that turns config names into plugins.
+
+mod openphish;
+mod phishing_database;
+mod phishstats;
+mod urlhaus;
+
+pub use openphish::OpenPhish;
+pub use phishing_database::PhishingDatabase;
+pub use phishstats::PhishStats;
+pub use urlhaus::UrlHaus;
+
+use crate::source::FeedSource;
+
+/// Names accepted by `TI_SOURCES`, in the order they are collected by default.
+pub const KNOWN_SOURCES: [&str; 4] = ["openphish", "phishstats", "phishing_database", "urlhaus"];
+
+/// Build the enabled plugins. `url_override` supplies a per-source endpoint from
+/// configuration (`TI_<SOURCE>_URL`), which also makes the sources testable
+/// against a local fixture server.
+pub fn build(
+    names: &[String],
+    url_override: &dyn Fn(&str) -> Option<String>,
+) -> Result<Vec<Box<dyn FeedSource>>, String> {
+    let mut sources: Vec<Box<dyn FeedSource>> = Vec::with_capacity(names.len());
+    for name in names {
+        let url = url_override(name);
+        let source: Box<dyn FeedSource> = match name.as_str() {
+            "openphish" => Box::new(OpenPhish::new(url)),
+            "phishstats" => Box::new(PhishStats::new(url)),
+            "phishing_database" => Box::new(PhishingDatabase::new(url)),
+            "urlhaus" => Box::new(UrlHaus::new(url)),
+            other => {
+                return Err(format!(
+                    "unknown feed source '{other}' (known: {})",
+                    KNOWN_SOURCES.join(", ")
+                ))
+            }
+        };
+        sources.push(source);
+    }
+    Ok(sources)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_every_known_source() {
+        let names: Vec<String> = KNOWN_SOURCES.iter().map(|s| s.to_string()).collect();
+        let sources = build(&names, &|_| None).expect("known sources build");
+        assert_eq!(sources.len(), KNOWN_SOURCES.len());
+        for source in &sources {
+            assert!(source.url().starts_with("https://"), "{}", source.name());
+            assert!(source.weight() > 0 && source.weight() <= 100);
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_source() {
+        let err = match build(&["nope".to_string()], &|_| None) {
+            Ok(_) => panic!("unknown source must be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("unknown feed source"));
+    }
+
+    #[test]
+    fn applies_url_override() {
+        let sources = build(&["openphish".to_string()], &|name| {
+            (name == "openphish").then(|| "http://127.0.0.1:9/feed.txt".to_string())
+        })
+        .unwrap();
+        assert_eq!(sources[0].url(), "http://127.0.0.1:9/feed.txt");
+    }
+}

--- a/threat-intel/src/sources/openphish.rs
+++ b/threat-intel/src/sources/openphish.rs
@@ -1,0 +1,71 @@
+//! OpenPhish community feed: one phishing URL per line.
+
+use crate::indicator::{IndicatorKind, RawIndicator};
+use crate::source::{FeedError, FeedSource};
+
+const DEFAULT_URL: &str = "https://openphish.com/feed.txt";
+
+pub struct OpenPhish {
+    url: String,
+}
+
+impl OpenPhish {
+    pub fn new(url: Option<String>) -> Self {
+        Self {
+            url: url.unwrap_or_else(|| DEFAULT_URL.to_string()),
+        }
+    }
+}
+
+impl FeedSource for OpenPhish {
+    fn name(&self) -> &'static str {
+        "openphish"
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn weight(&self) -> u8 {
+        90
+    }
+
+    fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError> {
+        let indicators: Vec<RawIndicator> = body
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .filter(|line| line.starts_with("http://") || line.starts_with("https://"))
+            .map(|line| RawIndicator::new(line, IndicatorKind::Url, self))
+            .collect();
+
+        if indicators.is_empty() {
+            return Err(FeedError::Empty);
+        }
+        Ok(indicators)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_url_lines_and_skips_noise() {
+        let source = OpenPhish::new(None);
+        let body = "# comment\nhttps://a.example/login\n\n  http://b.example/verify \nnot-a-url\n";
+        let out = source.parse(body).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].value, "https://a.example/login");
+        assert_eq!(out[1].value, "http://b.example/verify");
+        assert_eq!(out[0].kind, IndicatorKind::Url);
+        assert_eq!(out[0].source, "openphish");
+        assert_eq!(out[0].source_weight, 90);
+    }
+
+    #[test]
+    fn empty_feed_is_an_error() {
+        let source = OpenPhish::new(None);
+        assert!(matches!(source.parse("# nothing\n"), Err(FeedError::Empty)));
+    }
+}

--- a/threat-intel/src/sources/phishing_database.rs
+++ b/threat-intel/src/sources/phishing_database.rs
@@ -1,0 +1,79 @@
+//! Phishing.Database domain list: one hostname per line.
+
+use crate::indicator::{looks_like_domain, IndicatorKind, RawIndicator};
+use crate::source::{FeedError, FeedSource};
+
+const DEFAULT_URL: &str = concat!(
+    "https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/",
+    "phishing-domains-ACTIVE.txt"
+);
+
+pub struct PhishingDatabase {
+    url: String,
+}
+
+impl PhishingDatabase {
+    pub fn new(url: Option<String>) -> Self {
+        Self {
+            url: url.unwrap_or_else(|| DEFAULT_URL.to_string()),
+        }
+    }
+}
+
+impl FeedSource for PhishingDatabase {
+    fn name(&self) -> &'static str {
+        "phishing_database"
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn weight(&self) -> u8 {
+        75
+    }
+
+    fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError> {
+        let mut out = Vec::new();
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            // Some variants of the list ship in hosts-file form
+            // (`0.0.0.0 evil.example`); take the hostname column.
+            let candidate = line.split_whitespace().next_back().unwrap_or(line);
+            let candidate = candidate.trim_end_matches('.').to_ascii_lowercase();
+            if looks_like_domain(&candidate) {
+                out.push(RawIndicator::new(candidate, IndicatorKind::Domain, self));
+            }
+        }
+
+        if out.is_empty() {
+            return Err(FeedError::Empty);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_hosts_style_lines() {
+        let source = PhishingDatabase::new(None);
+        let body = "# list\nEvil.Example.COM\n0.0.0.0 bad.example\nlocalhost\n\n";
+        let out = source.parse(body).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].value, "evil.example.com");
+        assert_eq!(out[0].kind, IndicatorKind::Domain);
+        assert_eq!(out[1].value, "bad.example");
+    }
+
+    #[test]
+    fn empty_feed_is_an_error() {
+        let source = PhishingDatabase::new(None);
+        assert!(matches!(source.parse("\n#\n"), Err(FeedError::Empty)));
+    }
+}

--- a/threat-intel/src/sources/phishstats.rs
+++ b/threat-intel/src/sources/phishstats.rs
@@ -1,0 +1,128 @@
+//! PhishStats scored CSV feed: `Date,Score,URL,IP`.
+
+use crate::indicator::{is_ip_literal, IndicatorKind, RawIndicator};
+use crate::source::{split_csv, unquote, FeedError, FeedSource};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+
+const DEFAULT_URL: &str = "https://phishstats.info/phish_score.csv";
+
+pub struct PhishStats {
+    url: String,
+}
+
+impl PhishStats {
+    pub fn new(url: Option<String>) -> Self {
+        Self {
+            url: url.unwrap_or_else(|| DEFAULT_URL.to_string()),
+        }
+    }
+}
+
+impl FeedSource for PhishStats {
+    fn name(&self) -> &'static str {
+        "phishstats"
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn weight(&self) -> u8 {
+        80
+    }
+
+    fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError> {
+        let mut out = Vec::new();
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let fields = split_csv(line);
+            if fields.len() < 3 {
+                continue;
+            }
+            let reported_at = parse_timestamp(unquote(&fields[0]));
+            let score = unquote(&fields[1]).to_string();
+            let url = unquote(&fields[2]);
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                continue;
+            }
+            let tags = if score.is_empty() {
+                Vec::new()
+            } else {
+                vec![format!("phishstats_score:{score}")]
+            };
+            out.push(
+                RawIndicator::new(url, IndicatorKind::Url, self)
+                    .with_reported_at(reported_at)
+                    .with_tags(tags),
+            );
+
+            // The fourth column carries the resolved address at report time.
+            if let Some(ip) = fields.get(3).map(|f| unquote(f)) {
+                if is_ip_literal(ip) {
+                    out.push(
+                        RawIndicator::new(ip, IndicatorKind::Ip, self)
+                            .with_reported_at(reported_at)
+                            .with_reference(url),
+                    );
+                }
+            }
+        }
+
+        if out.is_empty() {
+            return Err(FeedError::Empty);
+        }
+        Ok(out)
+    }
+}
+
+fn parse_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .and_then(|naive| Utc.from_local_datetime(&naive).single())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = concat!(
+        "#Date,Score,URL,IP\n",
+        "\"2026-08-19 10:11:12\",\"7.20\",\"https://a.example/login?a=1,2\",\"203.0.113.7\"\n",
+        "\"2026-08-19 10:12:00\",\"5.00\",\"http://b.example/\",\"unknown\"\n",
+        "garbage line\n",
+    );
+
+    #[test]
+    fn parses_urls_and_resolved_ips() {
+        let source = PhishStats::new(None);
+        let out = source.parse(SAMPLE).unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].value, "https://a.example/login?a=1,2");
+        assert_eq!(out[0].kind, IndicatorKind::Url);
+        assert_eq!(out[0].tags, vec!["phishstats_score:7.20"]);
+        assert!(out[0].reported_at.is_some());
+        assert_eq!(out[1].value, "203.0.113.7");
+        assert_eq!(out[1].kind, IndicatorKind::Ip);
+        assert_eq!(
+            out[1].reference.as_deref(),
+            Some("https://a.example/login?a=1,2")
+        );
+        assert_eq!(out[2].value, "http://b.example/");
+    }
+
+    #[test]
+    fn parses_rfc3339_timestamps() {
+        assert!(parse_timestamp("2026-08-19T10:11:12Z").is_some());
+        assert!(parse_timestamp("nonsense").is_none());
+        assert!(parse_timestamp("").is_none());
+    }
+}

--- a/threat-intel/src/sources/urlhaus.rs
+++ b/threat-intel/src/sources/urlhaus.rs
@@ -1,0 +1,140 @@
+//! URLhaus recent-URLs CSV feed (abuse.ch).
+//!
+//! Columns: `id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter`.
+
+use crate::indicator::{IndicatorKind, RawIndicator};
+use crate::source::{split_csv, unquote, FeedError, FeedSource};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+
+const DEFAULT_URL: &str = "https://urlhaus.abuse.ch/downloads/csv_recent/";
+
+pub struct UrlHaus {
+    url: String,
+}
+
+impl UrlHaus {
+    pub fn new(url: Option<String>) -> Self {
+        Self {
+            url: url.unwrap_or_else(|| DEFAULT_URL.to_string()),
+        }
+    }
+}
+
+impl FeedSource for UrlHaus {
+    fn name(&self) -> &'static str {
+        "urlhaus"
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+
+    fn weight(&self) -> u8 {
+        70
+    }
+
+    fn parse(&self, body: &str) -> Result<Vec<RawIndicator>, FeedError> {
+        let mut out = Vec::new();
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let fields = split_csv(line);
+            if fields.len() < 4 {
+                continue;
+            }
+            let url = unquote(&fields[2]);
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                continue;
+            }
+            // Offline entries stay out of the collector; enforcement should not
+            // grow on URLs the feed already retired.
+            let status = unquote(&fields[3]).to_ascii_lowercase();
+            if status == "offline" {
+                continue;
+            }
+
+            let mut tags: Vec<String> = Vec::new();
+            if let Some(threat) = fields.get(5).map(|f| unquote(f)) {
+                if !threat.is_empty() {
+                    tags.push(format!("threat:{threat}"));
+                }
+            }
+            if let Some(raw_tags) = fields.get(6).map(|f| unquote(f)) {
+                tags.extend(
+                    raw_tags
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|t| !t.is_empty())
+                        .map(str::to_string),
+                );
+            }
+
+            let reference = fields.get(7).map(|f| unquote(f)).unwrap_or_default();
+            out.push(
+                RawIndicator::new(url, IndicatorKind::Url, self)
+                    .with_reported_at(parse_timestamp(unquote(&fields[1])))
+                    .with_reference(reference)
+                    .with_tags(tags),
+            );
+        }
+
+        if out.is_empty() {
+            return Err(FeedError::Empty);
+        }
+        Ok(out)
+    }
+}
+
+fn parse_timestamp(raw: &str) -> Option<DateTime<Utc>> {
+    if raw.is_empty() {
+        return None;
+    }
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S")
+        .ok()
+        .and_then(|naive| Utc.from_local_datetime(&naive).single())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = concat!(
+        "# Dump generated\n",
+        "# id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter\n",
+        "\"1\",\"2026-08-19 10:00:00\",\"http://a.example/x.bin\",\"online\",\"\",",
+        "\"malware_download\",\"elf,mirai\",\"https://urlhaus.abuse.ch/url/1/\",\"reporter\"\n",
+        "\"2\",\"2026-08-18 09:00:00\",\"http://b.example/y.bin\",\"offline\",\"\",",
+        "\"malware_download\",\"\",\"https://urlhaus.abuse.ch/url/2/\",\"reporter\"\n",
+    );
+
+    #[test]
+    fn keeps_online_urls_with_threat_tags() {
+        let source = UrlHaus::new(None);
+        let out = source.parse(SAMPLE).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].value, "http://a.example/x.bin");
+        assert_eq!(out[0].kind, IndicatorKind::Url);
+        assert_eq!(out[0].tags, vec!["threat:malware_download", "elf", "mirai"]);
+        assert_eq!(
+            out[0].reference.as_deref(),
+            Some("https://urlhaus.abuse.ch/url/1/")
+        );
+        assert!(out[0].reported_at.is_some());
+    }
+
+    #[test]
+    fn all_offline_entries_yield_empty_error() {
+        let source = UrlHaus::new(None);
+        let body = concat!(
+            "# id,dateadded,url,url_status,last_online,threat,tags,urlhaus_link,reporter\n",
+            "\"2\",\"2026-08-18 09:00:00\",\"http://b.example/y.bin\",\"offline\",\"\",",
+            "\"malware_download\",\"\",\"https://urlhaus.abuse.ch/url/2/\",\"reporter\"\n",
+        );
+        assert!(matches!(source.parse(body), Err(FeedError::Empty)));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **TASK-TI-001 Feed Collector Framework** from `docs/threat-intelligence/AI_Agent_Backlog.md` as a new optional workspace crate `threat-intel`.

The framework owns fetching, scheduling, retries, deduplication, safety caps and metrics, so a feed source is just an endpoint plus a parser (`FeedSource` in `threat-intel/src/source.rs`). Four sources ship with it — OpenPhish, PhishStats, Phishing.Database, URLhaus — each carrying the source reputation weight from the collector spec so the scoring engine (TASK-TI-010) can consume it later.

What the collector does:

- one scheduled task per source, so a slow or broken feed cannot delay the others;
- exponential backoff for transport errors, `429` and `5xx`; `4xx`, parse errors, oversized bodies and empty feeds fail the cycle immediately instead of burning retries;
- response-size cap (`TI_MAX_BODY_MB`), per-fetch indicator cap and intra-batch dedupe;
- Prometheus metrics plus `/health` on `:8093`, including `threat_intel_last_success_timestamp_seconds` for staleness alerting;
- atomic JSONL snapshot per source plus `report.json` with the last result of every feed;
- `TI_RUN_ONCE=true` for cron-style runs and CI smoke checks (non-zero exit if any source failed).

Collection is metadata-only by construction: only configured feed endpoints are requested, never a collected indicator, so the collector does not visit phishing pages or download payloads.

**Out of scope / not implemented:** IOC storage (TASK-TI-002), full normalization (TASK-TI-003), confidence scoring (TASK-TI-010) and ACL/RPZ enforcement (TASK-TI-020/021). The collector output does not influence proxying decisions; the feature is documented as Experimental.

Also wired in per repository conventions: Dockerfile stage, Compose profile `threat-intel`, Helm `threatIntel.enabled`, systemd unit, `packaging/config/threat-intel.env.example`, docs page + wiki catalog entry, maturity matrix row and CHANGELOG.

**Second commit — `fix(deps): bump h2 to 0.4.16`.** Unrelated to the collector, but it is what the RustSec gate needed: RUSTSEC-2026-0258 landed on 2026-08-17 and turned `Security Audit` red on every branch, including `main`. Lockfile-only, and only the `h2` entry — a plain `cargo update -p h2` also re-resolved `socket2` and `windows-sys` downwards, so the version and checksum were bumped in place and `cargo metadata --locked` confirms the graph stays consistent.

## Related Issues

<!-- No tracking issue; the work item is TASK-TI-001 in docs/threat-intelligence/AI_Agent_Backlog.md -->

- Closes #

## Testing

Ran the same entrypoint the Jenkins pipeline stages call:

```bash
./scripts/ci/run.sh rust-all        # ca, fmt, clippy, build, lite, test — clean
./scripts/ci/run.sh rust-grpc       # clean
./scripts/ci/run.sh rust-wasm       # clean
./scripts/ci/run.sh security-audit  # no vulnerabilities after the h2 bump
./scripts/ci/run.sh docs            # links OK, wiki catalog OK
```

Also smoke-tested the binary end to end against a local fixture feed
(`TI_RUN_ONCE=true TI_OPENPHISH_URL=http://127.0.0.1:.../feed.txt`): snapshot and
`report.json` written, exit code 0.

New tests cover each feed parser, the source registry, config parsing and backoff,
snapshot/report writing, and the collector path against a local HTTP fixture
(success, `5xx` failure, dedupe/cap enforcement).

## Checklist

- [x] CI is green — every repository check passes. The one red mark, `github-advanced-security`, fails inside GitHub's own service (`CAPIError: 400 The requested model is not supported`) before it reads the diff, on both pushed commits.
- [x] Documentation updated (if behavior or env vars changed)
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable)