### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   installer:
     name: Validate installer scripts


### PR DESCRIPTION
Potential fix for [https://github.com/onixus/bsdm-proxy/security/code-scanning/28](https://github.com/onixus/bsdm-proxy/security/code-scanning/28)

Add an explicit `permissions` block to `.github/workflows/installer.yml` to enforce least privilege for `GITHUB_TOKEN`.

Best fix (without changing functionality): define permissions at the workflow root so all jobs in this workflow inherit it (currently there is only one job). Since the workflow only needs to read repository contents for checkout and local script validation, set:

- `contents: read`

Change location:
- In `.github/workflows/installer.yml`, insert the `permissions` block after the `on:` triggers section and before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
