### PR TITLE
fix(proxy): bound MITM circuit breaker and certificate caches (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **ML Domain Reputation & Typosquatting Engine** (`threat_intel::ml_reputation`): visual homoglyph / Unicode confusable normalization, Damerau-Levenshtein distance against protected brand dictionaries, brand keyword stacking and subdomain deception detection (`/api/v1/ml/reputation`).
   - **Pipeline & SOAR/ML Test Suites**: end-to-end integration tests (`threat-intel/tests/pipeline_test.rs`, `threat-intel/tests/soar_ml_test.rs`).
 
+### Fixed
+
+- **MITM circuit breaker: bounded state and O(1) lookup** (#340) — the per-domain
+  tracker map is now capped by `MITM_CIRCUIT_BREAKER_MAX_DOMAINS` (default 10000)
+  with least-recently-used eviction of closed trackers, so a client looping
+  `CONNECT <random>.tld:443` can no longer grow proxy memory without limit.
+  Tripped domains are never evicted, keeping an active bypass and its audit trail
+  intact. `is_tripped()` now answers exact domains with a single hash lookup and
+  scans only a bounded wildcard index instead of walking the whole map on every
+  MITM `CONNECT`. `GET /api/mitm/circuit-breaker` reports `tracked_domains`,
+  `tracked_wildcards`, `evicted_domains_total` and `max_domains`.
+- **Bounded MITM certificate caches** (#340) — the per-SNI certificate and
+  `ServerConfig` caches are capped by `MITM_CERT_CACHE_MAX_ENTRIES`
+  (default 10000, oldest entries evicted first); previously both grew with every
+  unique hostname seen.
+
+### Security
+
+- **Destination security policy is enforced on MITM `CONNECT`** (#340) — the
+  MITM branch now runs the same `check_destination_security` check as the blind
+  tunnel branch, so an SSRF-rejected destination no longer reaches certificate
+  generation or the circuit-breaker tracker. Blocks are counted in
+  `ssrf_blocked_total`.
+
 ## [0.9.13] - 2026-08-21
 
 Patch after **0.9.12**: Threat intelligence feed collector framework (`threat-intel`), proxy hot-path zero-allocation and lock-free optimizations, ACL category policies and domain fallbacks, redesigned interactive installer, and security/dependency updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with least-recently-used eviction of closed trackers, so a client looping
   `CONNECT <random>.tld:443` can no longer grow proxy memory without limit.
   Tripped domains are never evicted, keeping an active bypass and its audit trail
-  intact. `is_tripped()` now answers exact domains with a single hash lookup and
-  scans only a bounded wildcard index instead of walking the whole map on every
-  MITM `CONNECT`. `GET /api/mitm/circuit-breaker` reports `tracked_domains`,
-  `tracked_wildcards`, `evicted_domains_total` and `max_domains`.
+  intact for as long as anything else can be evicted; when the whole map is
+  tripped, the least recently seen trips are evicted too, since a client can trip
+  a domain at will by aborting its own handshake. `is_tripped()` now answers with
+  a single hash lookup instead of walking the whole map on every MITM `CONNECT`.
+  `GET /api/mitm/circuit-breaker` reports `tracked_domains`, `max_domains`,
+  `evicted_domains_total`, `evicted_tripped_domains_total` and
+  `dropped_attempts_total`.
 - **Bounded MITM certificate caches** (#340) — the per-SNI certificate and
   `ServerConfig` caches are capped by `MITM_CERT_CACHE_MAX_ENTRIES`
   (default 10000, oldest entries evicted first); previously both grew with every
   unique hostname seen.
+
+### Changed
+
+- **Circuit breaker tracker keys are exact hostnames** (#340) — leading dots are
+  stripped alongside trailing ones, so `CONNECT .example.com:443` tracks that
+  host instead of creating a parent-domain wildcard. Wildcard keys had no
+  producer other than client input, and a tripped wildcard forced blind `CONNECT`
+  for every host under the domain.
 
 ### Security
 

--- a/bsdm-proxy.env
+++ b/bsdm-proxy.env
@@ -6,6 +6,9 @@ METRICS_PORT=9090
 POLICY_MODE=selective-mitm
 MITM_CATEGORIES=malware,phishing,illegal-content
 MITM_ENABLED=true
+# Bound in-memory MITM state (see docs/ops-and-dev/configuration.md)
+MITM_CIRCUIT_BREAKER_MAX_DOMAINS=10000
+MITM_CERT_CACHE_MAX_ENTRIES=10000
 SHUTDOWN_TIMEOUT_SECONDS=30
 RUST_LOG=info,bsdm_proxy=info
 CACHE_CAPACITY=10000

--- a/docs/features/certificate-pinning.md
+++ b/docs/features/certificate-pinning.md
@@ -102,12 +102,26 @@ The response carries the effective settings (`enabled`, `failure_rate_threshold`
 (`proxy/src/mitm_breaker.rs`).
 
 It also reports the size of the tracker map: `tracked_domains`,
-`tracked_wildcards` and `evicted_domains_total`. The map is capped by
+`evicted_domains_total`, `evicted_tripped_domains_total` and
+`dropped_attempts_total`. The map is capped by
 `MITM_CIRCUIT_BREAKER_MAX_DOMAINS` so that a client looping `CONNECT` on random
-hostnames cannot grow proxy memory; the least recently used **closed** trackers
-are evicted first and tripped domains are never evicted. A steadily rising
-`evicted_domains_total` means the cap is being hit — either raise it for a large
-client population, or treat it as a signal of `CONNECT` scanning.
+hostnames cannot grow proxy memory. Eviction runs in three tiers: closed
+trackers with no sample left in the window, then closed trackers with the fewest
+samples (so a flood evicts its own throwaway entries before a domain the breaker
+is measuring), and finally — only when every tracker is tripped — the least
+recently seen trips.
+
+A steadily rising `evicted_domains_total` means the cap is being hit: either
+raise it for a large client population, or treat it as a signal of `CONNECT`
+scanning. A non-zero `evicted_tripped_domains_total` means a bypass was dropped
+under that pressure; the trip stays in the audit log and is re-established by the
+next failures, but investigate the source of the load. `dropped_attempts_total`
+should stay at zero.
+
+Tracker keys are exact hostnames — leading and trailing dots are stripped. The
+only producer of keys is the client-supplied `CONNECT` authority, so there is no
+`.example.com` wildcard key a client could trip to force blind `CONNECT` for a
+whole parent domain.
 
 Note that `decision_source="pinning-bypass"` covers **both** a registry exception
 (`bypass_reason="certificate_pinning_exception"`) and a tripped breaker

--- a/docs/features/certificate-pinning.md
+++ b/docs/features/certificate-pinning.md
@@ -96,10 +96,18 @@ curl -fsS http://127.0.0.1:9090/api/mitm/circuit-breaker \
 ```
 
 The response carries the effective settings (`enabled`, `failure_rate_threshold`,
-`min_samples`, `window_secs`, `cooldown_secs`, `audit_path`), `tripped_count`,
-and per-domain `tripped_domains[]` entries with `tripped_at_unix`,
-`failure_rate`, `failure_count`, `total_samples` and `reason`
+`min_samples`, `window_secs`, `cooldown_secs`, `max_domains`, `audit_path`),
+`tripped_count`, and per-domain `tripped_domains[]` entries with
+`tripped_at_unix`, `failure_rate`, `failure_count`, `total_samples` and `reason`
 (`proxy/src/mitm_breaker.rs`).
+
+It also reports the size of the tracker map: `tracked_domains`,
+`tracked_wildcards` and `evicted_domains_total`. The map is capped by
+`MITM_CIRCUIT_BREAKER_MAX_DOMAINS` so that a client looping `CONNECT` on random
+hostnames cannot grow proxy memory; the least recently used **closed** trackers
+are evicted first and tripped domains are never evicted. A steadily rising
+`evicted_domains_total` means the cap is being hit — either raise it for a large
+client population, or treat it as a signal of `CONNECT` scanning.
 
 Note that `decision_source="pinning-bypass"` covers **both** a registry exception
 (`bypass_reason="certificate_pinning_exception"`) and a tripped breaker

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -65,12 +65,24 @@ DEPLOYMENT_PROFILE=development POLICY_MODE=full-mitm ALLOW_FULL_MITM=true \
 умолчанию.
 
 Счётчики хранятся по домену, поэтому их число ограничено
-`MITM_CIRCUIT_BREAKER_MAX_DOMAINS`. При заполнении вытесняются наименее
-недавно использованные счётчики — сначала те, у которых не осталось попыток
-внутри окна. Домены в состоянии tripped не вытесняются никогда: активный bypass
-и его аудит сохраняются. Текущее заполнение видно в
-`GET /api/mitm/circuit-breaker` (`tracked_domains`, `tracked_wildcards`,
-`evicted_domains_total`, `max_domains`). Аудит срабатываний и сбросов пишется в `PINNING_AUDIT_LOG_PATH`.
+`MITM_CIRCUIT_BREAKER_MAX_DOMAINS`. При заполнении вытеснение идёт тремя
+ярусами: (1) закрытые счётчики без попыток внутри окна, (2) закрытые счётчики с
+наименьшим числом попыток — так поток `CONNECT` по случайным хостам вытесняет
+свои же одноразовые записи раньше домена, который breaker реально измеряет,
+(3) если вся карта состоит из tripped-доменов — наименее недавно использованные
+из них. Ярус 3 нужен, чтобы карта оставалась ограниченной: клиент может ввести
+домен в tripped, оборвав собственный TLS-хендшейк. Вытесненный trip не теряется
+из аудита и переустанавливается при следующих ошибках.
+
+Текущее состояние видно в `GET /api/mitm/circuit-breaker`: `tracked_domains`,
+`max_domains`, `evicted_domains_total`, `evicted_tripped_domains_total`
+(сработал ярус 3) и `dropped_attempts_total` (попытки, которые не удалось
+записать вообще).
+
+Ключами счётчиков служат точные имена хостов: ведущие и завершающие точки
+отбрасываются. Единственный источник ключей — имя из `CONNECT`, то есть данные
+клиента, поэтому wildcard-ключей вида `.example.com` не существует и клиент не
+может ввести в bypass весь родительский домен. Аудит срабатываний и сбросов пишется в `PINNING_AUDIT_LOG_PATH`.
 Статус и сброс: `GET /api/mitm/circuit-breaker`,
 `POST /api/mitm/circuit-breaker/reset` (Bearer). Процедура оператора —
 [certificate-pinning.md](../features/certificate-pinning.md#mitm-circuit-breaker-detection-and-operator-reset).

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -22,6 +22,7 @@ native install находятся в `packaging/config/*.env.example`; Compose �
 | `MITM_ENABLED` | `true` | HTTPS MITM; требует `ca.key` и `ca.crt` при POLICY_MODE != sni |
 | `TLS_OCSP_STAPLING` | `true` | OCSP staple (RFC 6960 DER, CA-signed **good**) on MITM/control TLS leaves |
 | `TLS_OCSP_STAPLE_REFRESH_SECS` | `900` | TTL refresh cached `ServerConfig` + staple (60–86400) |
+| `MITM_CERT_CACHE_MAX_ENTRIES` | `10000` | Лимит записей в кэшах MITM-сертификатов и `ServerConfig` (ключ — SNI); значения ниже `128` поднимаются до `128`. При заполнении вытесняются самые старые записи |
 | `AGENT_DEVICES_PATH` | unset | Local durable agent device JSON |
 | `AGENT_CRL_PATH` | unset | Local durable agent CRL JSON |
 | `AGENT_DEVICES_REDIS_URL` | unset | Multi-node Redis URL for devices+CRL (preferred) |
@@ -58,9 +59,18 @@ DEPLOYMENT_PROFILE=development POLICY_MODE=full-mitm ALLOW_FULL_MITM=true \
 | `MITM_CIRCUIT_BREAKER_MIN_SAMPLES` | `5` | Минимум попыток в окне до оценки доли ошибок (≥ 1) |
 | `MITM_CIRCUIT_BREAKER_WINDOW_SECS` | `60` | Длина скользящего окна, секунды (≥ 1) |
 | `MITM_CIRCUIT_BREAKER_COOLDOWN_SECS` | `0` | `0` — домен остаётся в bypass до ручного сброса; иначе авто-восстановление через N секунд |
+| `MITM_CIRCUIT_BREAKER_MAX_DOMAINS` | `10000` | Максимум отслеживаемых доменов в памяти; значения ниже `128` поднимаются до `128` |
 
 Некорректное значение любой переменной игнорируется и заменяется значением по
-умолчанию. Аудит срабатываний и сбросов пишется в `PINNING_AUDIT_LOG_PATH`.
+умолчанию.
+
+Счётчики хранятся по домену, поэтому их число ограничено
+`MITM_CIRCUIT_BREAKER_MAX_DOMAINS`. При заполнении вытесняются наименее
+недавно использованные счётчики — сначала те, у которых не осталось попыток
+внутри окна. Домены в состоянии tripped не вытесняются никогда: активный bypass
+и его аудит сохраняются. Текущее заполнение видно в
+`GET /api/mitm/circuit-breaker` (`tracked_domains`, `tracked_wildcards`,
+`evicted_domains_total`, `max_domains`). Аудит срабатываний и сбросов пишется в `PINNING_AUDIT_LOG_PATH`.
 Статус и сброс: `GET /api/mitm/circuit-breaker`,
 `POST /api/mitm/circuit-breaker/reset` (Bearer). Процедура оператора —
 [certificate-pinning.md](../features/certificate-pinning.md#mitm-circuit-breaker-detection-and-operator-reset).

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -2478,6 +2478,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let env_path = temp.path().join("bsdm-proxy.env");
         std::env::set_var("CONFIG_ENV_PATH", env_path.to_string_lossy().to_string());
+        // Without an explicit restart command, `schedule_service_restart` falls back
+        // to re-executing `current_exe()` — under `cargo test` that is the test
+        // binary, so the whole suite forks a fresh copy of itself on every run.
+        std::env::set_var("CONFIG_RESTART_CMD", "true");
 
         let metrics = Arc::new(Metrics::new().unwrap());
         let cache = Arc::new(HttpL1Cache::new(100, 4));
@@ -2511,6 +2515,7 @@ mod tests {
             .expect("channel open");
         assert!(*shutdown_rx.borrow());
 
+        std::env::remove_var("CONFIG_RESTART_CMD");
         std::env::remove_var("CONFIG_ENV_PATH");
     }
 

--- a/proxy/src/mitm_breaker.rs
+++ b/proxy/src/mitm_breaker.rs
@@ -19,6 +19,15 @@ const DEFAULT_FAILURE_RATE: f64 = 0.05; // 5%
 const DEFAULT_MIN_SAMPLES: usize = 5;
 const DEFAULT_WINDOW_SECS: u64 = 60;
 const DEFAULT_COOLDOWN_SECS: u64 = 0; // 0 = permanent until manual reset
+/// Upper bound on the number of per-domain trackers kept in memory. Without it a
+/// client looping `CONNECT <random>.attacker.tld:443` grows the map without limit.
+const DEFAULT_MAX_DOMAINS: usize = 10_000;
+/// Smallest cap accepted from the environment; below this the breaker cannot keep
+/// a meaningful window for a real client population.
+const MIN_MAX_DOMAINS: usize = 128;
+/// Wildcard keys (leading dot) are scanned linearly on every MITM CONNECT, so they
+/// get a much tighter bound than exact keys.
+const MAX_WILDCARD_TRACKERS: usize = 512;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MitmCircuitBreakerConfig {
@@ -27,6 +36,7 @@ pub struct MitmCircuitBreakerConfig {
     pub min_samples: usize,
     pub window_secs: u64,
     pub cooldown_secs: u64,
+    pub max_domains: usize,
 }
 
 impl Default for MitmCircuitBreakerConfig {
@@ -37,6 +47,7 @@ impl Default for MitmCircuitBreakerConfig {
             min_samples: DEFAULT_MIN_SAMPLES,
             window_secs: DEFAULT_WINDOW_SECS,
             cooldown_secs: DEFAULT_COOLDOWN_SECS,
+            max_domains: DEFAULT_MAX_DOMAINS,
         }
     }
 }
@@ -65,6 +76,11 @@ impl MitmCircuitBreakerConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(DEFAULT_COOLDOWN_SECS);
+        let max_domains = std::env::var("MITM_CIRCUIT_BREAKER_MAX_DOMAINS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.max(MIN_MAX_DOMAINS))
+            .unwrap_or(DEFAULT_MAX_DOMAINS);
 
         Self {
             enabled,
@@ -72,6 +88,7 @@ impl MitmCircuitBreakerConfig {
             min_samples,
             window_secs,
             cooldown_secs,
+            max_domains,
         }
     }
 }
@@ -93,7 +110,11 @@ pub struct MitmCircuitBreakerStatus {
     pub min_samples: usize,
     pub window_secs: u64,
     pub cooldown_secs: u64,
+    pub max_domains: usize,
     pub audit_path: Option<String>,
+    pub tracked_domains: usize,
+    pub tracked_wildcards: usize,
+    pub evicted_domains_total: u64,
     pub tripped_count: usize,
     pub tripped_domains: Vec<TrippedInfo>,
 }
@@ -126,13 +147,15 @@ enum DomainState {
 struct DomainTracker {
     samples: VecDeque<Sample>,
     state: DomainState,
+    last_seen: Instant,
 }
 
 impl DomainTracker {
-    fn new() -> Self {
+    fn new(now: Instant) -> Self {
         Self {
             samples: VecDeque::new(),
             state: DomainState::Closed,
+            last_seen: now,
         }
     }
 
@@ -143,6 +166,92 @@ impl DomainTracker {
             } else {
                 break;
             }
+        }
+    }
+
+    /// A tracker is evictable once it carries no state worth keeping: not tripped
+    /// and with no sample left inside the current window.
+    fn is_evictable(&self, cutoff: Instant) -> bool {
+        matches!(self.state, DomainState::Closed)
+            && self.samples.iter().all(|sample| sample.at < cutoff)
+    }
+}
+
+/// Tracker map plus the small side index of wildcard keys.
+///
+/// `is_tripped` runs on every MITM CONNECT, so it must not scan the whole map:
+/// exact keys are answered by a single `HashMap` lookup and only the (bounded)
+/// wildcard keys are scanned.
+#[derive(Debug, Default)]
+struct BreakerState {
+    trackers: HashMap<String, DomainTracker>,
+    wildcards: Vec<String>,
+    evicted_total: u64,
+}
+
+impl BreakerState {
+    fn insert_tracker(&mut self, key: String, tracker: DomainTracker) {
+        if key.starts_with('.') {
+            self.wildcards.push(key.clone());
+        }
+        self.trackers.insert(key, tracker);
+    }
+
+    fn remove_tracker(&mut self, key: &str) {
+        if self.trackers.remove(key).is_some() && key.starts_with('.') {
+            self.wildcards.retain(|w| w != key);
+        }
+    }
+
+    /// Free capacity when the tracker map is full.
+    ///
+    /// Runs a single sweep that drops the least recently seen evictable trackers
+    /// until at least 10% of the cap is free, so the cost is amortised over the
+    /// following `max_domains / 10` inserts instead of being paid per request.
+    /// Returns `true` when there is room for a new tracker.
+    fn make_room(&mut self, max_domains: usize, cutoff: Instant) -> bool {
+        if self.trackers.len() < max_domains {
+            return true;
+        }
+
+        let target = max_domains - (max_domains / 10).max(1);
+
+        // Tier 1: trackers with no sample left inside the window — nothing is lost.
+        self.evict_until(target, |tracker| tracker.is_evictable(cutoff));
+        if self.trackers.len() < max_domains {
+            return true;
+        }
+
+        // Tier 2: a flood of fresh domains keeps every tracker inside the window, so
+        // fall back to least-recently-seen closed trackers. Tripped domains are never
+        // evicted, which keeps an active bypass and its audit state intact.
+        self.evict_until(target, |tracker| {
+            matches!(tracker.state, DomainState::Closed)
+        });
+
+        self.trackers.len() < max_domains
+    }
+
+    /// Drop least-recently-seen trackers matching `evictable` until the map is at
+    /// or below `target`.
+    fn evict_until(&mut self, target: usize, evictable: impl Fn(&DomainTracker) -> bool) {
+        if self.trackers.len() <= target {
+            return;
+        }
+        let mut candidates: Vec<(Instant, String)> = self
+            .trackers
+            .iter()
+            .filter(|(_, tracker)| evictable(tracker))
+            .map(|(key, tracker)| (tracker.last_seen, key.clone()))
+            .collect();
+        candidates.sort_by(|a, b| a.0.cmp(&b.0));
+
+        for (_, key) in candidates {
+            if self.trackers.len() <= target {
+                break;
+            }
+            self.remove_tracker(&key);
+            self.evicted_total += 1;
         }
     }
 }
@@ -163,7 +272,7 @@ struct BreakerAuditRecord<'a> {
 pub struct MitmCircuitBreaker {
     config: MitmCircuitBreakerConfig,
     audit_path: Option<PathBuf>,
-    trackers: RwLock<HashMap<String, DomainTracker>>,
+    state: RwLock<BreakerState>,
 }
 
 impl MitmCircuitBreaker {
@@ -186,7 +295,7 @@ impl MitmCircuitBreaker {
         Self {
             config,
             audit_path,
-            trackers: RwLock::new(HashMap::new()),
+            state: RwLock::new(BreakerState::default()),
         }
     }
 
@@ -211,19 +320,26 @@ impl MitmCircuitBreaker {
         let now = Instant::now();
         let cooldown = self.config.cooldown_secs;
 
-        let trackers = match self.trackers.read() {
+        let state = match self.state.read() {
             Ok(t) => t,
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        // Check exact match and parent domain suffixes
-        for (tracked_domain, tracker) in trackers.iter() {
-            if domain_matches(&normalized, tracked_domain) {
-                if let DomainState::Tripped { tripped_at, .. } = &tracker.state {
-                    if cooldown > 0 && now.duration_since(*tripped_at).as_secs() >= cooldown {
-                        // Cooldown elapsed, allow attempt
-                        continue;
-                    }
+        // Exact key: single lookup, no scan.
+        if let Some(tracker) = state.trackers.get(&normalized) {
+            if is_active_trip(tracker, now, cooldown) {
+                return true;
+            }
+        }
+
+        // Wildcard keys (leading dot) match parent domains, so they need a scan —
+        // but only over the bounded wildcard index, never the whole map.
+        for tracked_domain in &state.wildcards {
+            if !domain_matches(&normalized, tracked_domain) {
+                continue;
+            }
+            if let Some(tracker) = state.trackers.get(tracked_domain) {
+                if is_active_trip(tracker, now, cooldown) {
                     return true;
                 }
             }
@@ -242,14 +358,40 @@ impl MitmCircuitBreaker {
             .checked_sub(Duration::from_secs(self.config.window_secs))
             .unwrap_or(now);
 
-        let mut trackers = match self.trackers.write() {
+        let mut state = match self.state.write() {
             Ok(t) => t,
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let tracker = trackers
-            .entry(domain_key.clone())
-            .or_insert_with(DomainTracker::new);
+        if !state.trackers.contains_key(&domain_key) {
+            // Cap the tracker map: an attacker looping CONNECT on random hosts must
+            // not be able to grow it without limit. When nothing can be evicted the
+            // sample is dropped — the breaker stops learning new domains rather than
+            // growing, and existing trips keep working.
+            if !state.make_room(self.config.max_domains, cutoff) {
+                warn!(
+                    domain = %domain_key,
+                    max_domains = self.config.max_domains,
+                    "MITM circuit breaker tracker map is full; attempt not recorded"
+                );
+                return;
+            }
+            if domain_key.starts_with('.') && state.wildcards.len() >= MAX_WILDCARD_TRACKERS {
+                warn!(
+                    domain = %domain_key,
+                    max_wildcards = MAX_WILDCARD_TRACKERS,
+                    "MITM circuit breaker wildcard index is full; attempt not recorded"
+                );
+                return;
+            }
+            state.insert_tracker(domain_key.clone(), DomainTracker::new(now));
+        }
+
+        let tracker = state
+            .trackers
+            .get_mut(&domain_key)
+            .expect("tracker inserted above");
+        tracker.last_seen = now;
 
         // If cooldown elapsed on a tripped domain, reset it back to closed
         if let DomainState::Tripped { tripped_at, .. } = &tracker.state {
@@ -333,7 +475,7 @@ impl MitmCircuitBreaker {
         validate_audit_text("actor", actor, 128)?;
         validate_audit_text("reason", change_reason, 512)?;
 
-        let mut trackers = match self.trackers.write() {
+        let mut state = match self.state.write() {
             Ok(t) => t,
             Err(poisoned) => poisoned.into_inner(),
         };
@@ -342,7 +484,7 @@ impl MitmCircuitBreaker {
         let pattern_norm = domain_pattern.trim().to_ascii_lowercase();
 
         if pattern_norm == "*" {
-            for (domain, tracker) in trackers.iter_mut() {
+            for (domain, tracker) in state.trackers.iter_mut() {
                 if matches!(tracker.state, DomainState::Tripped { .. }) {
                     tracker.state = DomainState::Closed;
                     tracker.samples.clear();
@@ -351,7 +493,7 @@ impl MitmCircuitBreaker {
             }
         } else {
             let key = normalize_domain_key(&pattern_norm);
-            if let Some(tracker) = trackers.get_mut(&key) {
+            if let Some(tracker) = state.trackers.get_mut(&key) {
                 if matches!(tracker.state, DomainState::Tripped { .. }) {
                     tracker.state = DomainState::Closed;
                     tracker.samples.clear();
@@ -393,13 +535,13 @@ impl MitmCircuitBreaker {
 
     /// Get snapshot of circuit breaker status and tripped domains.
     pub fn status(&self) -> MitmCircuitBreakerStatus {
-        let trackers = match self.trackers.read() {
+        let state = match self.state.read() {
             Ok(t) => t,
             Err(poisoned) => poisoned.into_inner(),
         };
 
         let mut tripped = Vec::new();
-        for tracker in trackers.values() {
+        for tracker in state.trackers.values() {
             if let DomainState::Tripped { info, .. } = &tracker.state {
                 tripped.push(info.clone());
             }
@@ -412,10 +554,25 @@ impl MitmCircuitBreaker {
             min_samples: self.config.min_samples,
             window_secs: self.config.window_secs,
             cooldown_secs: self.config.cooldown_secs,
+            max_domains: self.config.max_domains,
             audit_path: self.audit_path(),
+            tracked_domains: state.trackers.len(),
+            tracked_wildcards: state.wildcards.len(),
+            evicted_domains_total: state.evicted_total,
             tripped_count: tripped.len(),
             tripped_domains: tripped,
         }
+    }
+}
+
+/// A tracker counts as tripped only while its cooldown (when configured) has not
+/// elapsed; afterwards `record_attempt` closes it again on the next attempt.
+fn is_active_trip(tracker: &DomainTracker, now: Instant, cooldown_secs: u64) -> bool {
+    match &tracker.state {
+        DomainState::Tripped { tripped_at, .. } => {
+            cooldown_secs == 0 || now.duration_since(*tripped_at).as_secs() < cooldown_secs
+        }
+        DomainState::Closed => false,
     }
 }
 
@@ -507,6 +664,7 @@ mod tests {
             min_samples: 5,
             window_secs: 60,
             cooldown_secs: 0,
+            max_domains: DEFAULT_MAX_DOMAINS,
         };
         let breaker = MitmCircuitBreaker::new(config, Some(audit.clone()));
 
@@ -554,6 +712,7 @@ mod tests {
             min_samples: 10,
             window_secs: 60,
             cooldown_secs: 0,
+            max_domains: DEFAULT_MAX_DOMAINS,
         };
         let breaker = MitmCircuitBreaker::new(config, None);
 
@@ -566,6 +725,84 @@ mod tests {
     }
 
     #[test]
+    fn tracker_map_is_bounded_and_evicts_idle_domains() {
+        let config = MitmCircuitBreakerConfig {
+            enabled: true,
+            failure_rate_threshold: 0.10,
+            min_samples: 2,
+            // Window of 0s is not accepted from env, but here it lets every sample
+            // fall out of the window immediately so trackers become evictable.
+            window_secs: 1,
+            cooldown_secs: 0,
+            max_domains: MIN_MAX_DOMAINS,
+        };
+        let breaker = MitmCircuitBreaker::new(config, None);
+
+        // Simulate `CONNECT <n>.attacker.tld:443` in a loop: far more unique
+        // domains than the cap.
+        for n in 0..(MIN_MAX_DOMAINS * 4) {
+            breaker.record_attempt(&format!("host{n}.attacker.tld"), true, "ok");
+        }
+
+        let status = breaker.status();
+        assert!(
+            status.tracked_domains <= MIN_MAX_DOMAINS,
+            "tracker map grew past the cap: {}",
+            status.tracked_domains
+        );
+        assert!(
+            status.evicted_domains_total > 0,
+            "expected idle trackers to be evicted"
+        );
+    }
+
+    #[test]
+    fn tripped_domains_survive_pressure_from_new_domains() {
+        let config = MitmCircuitBreakerConfig {
+            enabled: true,
+            failure_rate_threshold: 0.10,
+            min_samples: 2,
+            window_secs: 1,
+            cooldown_secs: 0,
+            max_domains: MIN_MAX_DOMAINS,
+        };
+        let breaker = MitmCircuitBreaker::new(config, None);
+
+        breaker.record_attempt("victim.example.com", false, "fail");
+        breaker.record_attempt("victim.example.com", false, "fail");
+        assert!(breaker.is_tripped("victim.example.com"));
+
+        for n in 0..(MIN_MAX_DOMAINS * 4) {
+            breaker.record_attempt(&format!("host{n}.attacker.tld"), true, "ok");
+        }
+
+        // Eviction only removes closed trackers with no live sample, so the trip
+        // and its audit state must still be there.
+        assert!(breaker.is_tripped("victim.example.com"));
+        assert_eq!(breaker.status().tripped_count, 1);
+    }
+
+    #[test]
+    fn wildcard_index_stays_small() {
+        let config = MitmCircuitBreakerConfig {
+            enabled: true,
+            failure_rate_threshold: 0.10,
+            min_samples: 2,
+            window_secs: 60,
+            cooldown_secs: 0,
+            max_domains: DEFAULT_MAX_DOMAINS,
+        };
+        let breaker = MitmCircuitBreaker::new(config, None);
+
+        for n in 0..(MAX_WILDCARD_TRACKERS * 2) {
+            breaker.record_attempt(&format!(".wild{n}.example.com"), true, "ok");
+        }
+
+        let status = breaker.status();
+        assert!(status.tracked_wildcards <= MAX_WILDCARD_TRACKERS);
+    }
+
+    #[test]
     fn wildcards_and_parent_domains_match() {
         let config = MitmCircuitBreakerConfig {
             enabled: true,
@@ -573,6 +810,7 @@ mod tests {
             min_samples: 2,
             window_secs: 60,
             cooldown_secs: 0,
+            max_domains: DEFAULT_MAX_DOMAINS,
         };
         let breaker = MitmCircuitBreaker::new(config, None);
 

--- a/proxy/src/mitm_breaker.rs
+++ b/proxy/src/mitm_breaker.rs
@@ -25,9 +25,6 @@ const DEFAULT_MAX_DOMAINS: usize = 10_000;
 /// Smallest cap accepted from the environment; below this the breaker cannot keep
 /// a meaningful window for a real client population.
 const MIN_MAX_DOMAINS: usize = 128;
-/// Wildcard keys (leading dot) are scanned linearly on every MITM CONNECT, so they
-/// get a much tighter bound than exact keys.
-const MAX_WILDCARD_TRACKERS: usize = 512;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MitmCircuitBreakerConfig {
@@ -113,8 +110,9 @@ pub struct MitmCircuitBreakerStatus {
     pub max_domains: usize,
     pub audit_path: Option<String>,
     pub tracked_domains: usize,
-    pub tracked_wildcards: usize,
     pub evicted_domains_total: u64,
+    pub evicted_tripped_domains_total: u64,
+    pub dropped_attempts_total: u64,
     pub tripped_count: usize,
     pub tripped_domains: Vec<TrippedInfo>,
 }
@@ -177,37 +175,25 @@ impl DomainTracker {
     }
 }
 
-/// Tracker map plus the small side index of wildcard keys.
+/// Bounded map of per-domain trackers.
 ///
-/// `is_tripped` runs on every MITM CONNECT, so it must not scan the whole map:
-/// exact keys are answered by a single `HashMap` lookup and only the (bounded)
-/// wildcard keys are scanned.
+/// `is_tripped` runs on every MITM CONNECT, so it is a single `HashMap` lookup:
+/// keys are exact hostnames, normalized by [`normalize_domain_key`].
 #[derive(Debug, Default)]
 struct BreakerState {
     trackers: HashMap<String, DomainTracker>,
-    wildcards: Vec<String>,
     evicted_total: u64,
+    evicted_tripped_total: u64,
+    dropped_attempts_total: u64,
 }
 
 impl BreakerState {
-    fn insert_tracker(&mut self, key: String, tracker: DomainTracker) {
-        if key.starts_with('.') {
-            self.wildcards.push(key.clone());
-        }
-        self.trackers.insert(key, tracker);
-    }
-
-    fn remove_tracker(&mut self, key: &str) {
-        if self.trackers.remove(key).is_some() && key.starts_with('.') {
-            self.wildcards.retain(|w| w != key);
-        }
-    }
-
     /// Free capacity when the tracker map is full.
     ///
-    /// Runs a single sweep that drops the least recently seen evictable trackers
-    /// until at least 10% of the cap is free, so the cost is amortised over the
+    /// Each sweep frees 10% of the cap, so its cost is amortised over the
     /// following `max_domains / 10` inserts instead of being paid per request.
+    /// The tiers exist so that a `CONNECT` flood evicts its own throwaway
+    /// trackers before it can flush a domain the breaker is actually measuring.
     /// Returns `true` when there is room for a new tracker.
     fn make_room(&mut self, max_domains: usize, cutoff: Instant) -> bool {
         if self.trackers.len() < max_domains {
@@ -216,33 +202,58 @@ impl BreakerState {
 
         let target = max_domains - (max_domains / 10).max(1);
 
-        // Tier 1: trackers with no sample left inside the window — nothing is lost.
-        self.evict_until(target, |tracker| tracker.is_evictable(cutoff));
+        // Tier 1: closed trackers with no sample left inside the window — nothing
+        // is lost, least recently seen first.
+        self.evict_until(
+            target,
+            |tracker| tracker.is_evictable(cutoff),
+            |tracker| (0, tracker.last_seen),
+        );
         if self.trackers.len() < max_domains {
             return true;
         }
 
-        // Tier 2: a flood of fresh domains keeps every tracker inside the window, so
-        // fall back to least-recently-seen closed trackers. Tripped domains are never
-        // evicted, which keeps an active bypass and its audit state intact.
-        self.evict_until(target, |tracker| {
-            matches!(tracker.state, DomainState::Closed)
-        });
+        // Tier 2: under a flood every tracker still holds a live sample. Evict
+        // closed trackers with the fewest samples first, which targets the flood's
+        // own one-sample entries ahead of a domain sitting on a partial failure
+        // streak; last_seen breaks ties.
+        self.evict_until(
+            target,
+            |tracker| matches!(tracker.state, DomainState::Closed),
+            |tracker| (tracker.samples.len(), tracker.last_seen),
+        );
+        if self.trackers.len() < max_domains {
+            return true;
+        }
+
+        // Tier 3: the map is full of tripped domains. Trips are cheap to re-earn
+        // (the next failures re-trip the domain) but an unbounded map is not, and
+        // without this the sweep above would run on every request forever. Evict
+        // the least recently seen trips and count them separately so operators can
+        // see that a bypass was dropped under pressure.
+        let before = self.evicted_total;
+        self.evict_until(target, |_| true, |tracker| (0, tracker.last_seen));
+        self.evicted_tripped_total += self.evicted_total - before;
 
         self.trackers.len() < max_domains
     }
 
-    /// Drop least-recently-seen trackers matching `evictable` until the map is at
-    /// or below `target`.
-    fn evict_until(&mut self, target: usize, evictable: impl Fn(&DomainTracker) -> bool) {
+    /// Drop trackers matching `evictable`, ordered by `rank` ascending, until the
+    /// map is at or below `target`.
+    fn evict_until<K: Ord>(
+        &mut self,
+        target: usize,
+        evictable: impl Fn(&DomainTracker) -> bool,
+        rank: impl Fn(&DomainTracker) -> K,
+    ) {
         if self.trackers.len() <= target {
             return;
         }
-        let mut candidates: Vec<(Instant, String)> = self
+        let mut candidates: Vec<(K, String)> = self
             .trackers
             .iter()
             .filter(|(_, tracker)| evictable(tracker))
-            .map(|(key, tracker)| (tracker.last_seen, key.clone()))
+            .map(|(key, tracker)| (rank(tracker), key.clone()))
             .collect();
         candidates.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -250,8 +261,9 @@ impl BreakerState {
             if self.trackers.len() <= target {
                 break;
             }
-            self.remove_tracker(&key);
-            self.evicted_total += 1;
+            if self.trackers.remove(&key).is_some() {
+                self.evicted_total += 1;
+            }
         }
     }
 }
@@ -325,26 +337,11 @@ impl MitmCircuitBreaker {
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        // Exact key: single lookup, no scan.
-        if let Some(tracker) = state.trackers.get(&normalized) {
-            if is_active_trip(tracker, now, cooldown) {
-                return true;
-            }
-        }
-
-        // Wildcard keys (leading dot) match parent domains, so they need a scan —
-        // but only over the bounded wildcard index, never the whole map.
-        for tracked_domain in &state.wildcards {
-            if !domain_matches(&normalized, tracked_domain) {
-                continue;
-            }
-            if let Some(tracker) = state.trackers.get(tracked_domain) {
-                if is_active_trip(tracker, now, cooldown) {
-                    return true;
-                }
-            }
-        }
-        false
+        // Keys are exact hostnames, so this is a single lookup — no scan.
+        state
+            .trackers
+            .get(&normalized)
+            .is_some_and(|tracker| is_active_trip(tracker, now, cooldown))
     }
 
     /// Record an attempt outcome (success or failure) for a domain.
@@ -369,22 +366,18 @@ impl MitmCircuitBreaker {
             // sample is dropped — the breaker stops learning new domains rather than
             // growing, and existing trips keep working.
             if !state.make_room(self.config.max_domains, cutoff) {
+                state.dropped_attempts_total += 1;
                 warn!(
                     domain = %domain_key,
                     max_domains = self.config.max_domains,
+                    dropped_attempts_total = state.dropped_attempts_total,
                     "MITM circuit breaker tracker map is full; attempt not recorded"
                 );
                 return;
             }
-            if domain_key.starts_with('.') && state.wildcards.len() >= MAX_WILDCARD_TRACKERS {
-                warn!(
-                    domain = %domain_key,
-                    max_wildcards = MAX_WILDCARD_TRACKERS,
-                    "MITM circuit breaker wildcard index is full; attempt not recorded"
-                );
-                return;
-            }
-            state.insert_tracker(domain_key.clone(), DomainTracker::new(now));
+            state
+                .trackers
+                .insert(domain_key.clone(), DomainTracker::new(now));
         }
 
         let tracker = state
@@ -557,8 +550,9 @@ impl MitmCircuitBreaker {
             max_domains: self.config.max_domains,
             audit_path: self.audit_path(),
             tracked_domains: state.trackers.len(),
-            tracked_wildcards: state.wildcards.len(),
             evicted_domains_total: state.evicted_total,
+            evicted_tripped_domains_total: state.evicted_tripped_total,
+            dropped_attempts_total: state.dropped_attempts_total,
             tripped_count: tripped.len(),
             tripped_domains: tripped,
         }
@@ -576,16 +570,15 @@ fn is_active_trip(tracker: &DomainTracker, now: Instant, cooldown_secs: u64) -> 
     }
 }
 
+/// Canonical tracker key: an exact, lowercase hostname.
+///
+/// Leading dots are stripped as well as trailing ones. The only producer of keys
+/// is `record_attempt`, fed from the client-supplied CONNECT authority, so a key
+/// such as `.example.com` would let a client trip a parent-domain wildcard and
+/// force blind-CONNECT for every host under it. Keys are exact hostnames instead,
+/// which also keeps the lookup in `is_tripped` O(1).
 fn normalize_domain_key(domain: &str) -> String {
-    domain.trim().trim_end_matches('.').to_ascii_lowercase()
-}
-
-fn domain_matches(target: &str, tracked: &str) -> bool {
-    if tracked.starts_with('.') {
-        target == tracked.trim_start_matches('.') || target.ends_with(tracked)
-    } else {
-        target == tracked
-    }
+    domain.trim().trim_matches('.').to_ascii_lowercase()
 }
 
 fn validate_audit_text(field: &str, value: &str, max: usize) -> Result<(), String> {
@@ -776,14 +769,14 @@ mod tests {
             breaker.record_attempt(&format!("host{n}.attacker.tld"), true, "ok");
         }
 
-        // Eviction only removes closed trackers with no live sample, so the trip
-        // and its audit state must still be there.
+        // The flood is made of closed trackers, so tiers 1 and 2 free all the room
+        // needed and the trip never becomes an eviction candidate.
         assert!(breaker.is_tripped("victim.example.com"));
         assert_eq!(breaker.status().tripped_count, 1);
     }
 
     #[test]
-    fn wildcard_index_stays_small() {
+    fn client_supplied_dots_cannot_create_a_parent_domain_wildcard() {
         let config = MitmCircuitBreakerConfig {
             enabled: true,
             failure_rate_threshold: 0.10,
@@ -794,32 +787,98 @@ mod tests {
         };
         let breaker = MitmCircuitBreaker::new(config, None);
 
-        for n in 0..(MAX_WILDCARD_TRACKERS * 2) {
-            breaker.record_attempt(&format!(".wild{n}.example.com"), true, "ok");
-        }
-
-        let status = breaker.status();
-        assert!(status.tracked_wildcards <= MAX_WILDCARD_TRACKERS);
-    }
-
-    #[test]
-    fn wildcards_and_parent_domains_match() {
-        let config = MitmCircuitBreakerConfig {
-            enabled: true,
-            failure_rate_threshold: 0.10,
-            min_samples: 2,
-            window_secs: 60,
-            cooldown_secs: 0,
-            max_domains: DEFAULT_MAX_DOMAINS,
-        };
-        let breaker = MitmCircuitBreaker::new(config, None);
-
+        // `CONNECT .pinned.com:443` must trip that exact host only; it must not
+        // become a wildcard that bypasses MITM for every host under pinned.com.
         breaker.record_attempt(".pinned.com", false, "fail");
         breaker.record_attempt(".pinned.com", false, "fail");
 
         assert!(breaker.is_tripped("pinned.com"));
-        assert!(breaker.is_tripped("sub.pinned.com"));
-        assert!(breaker.is_tripped("deep.sub.pinned.com"));
+        assert!(!breaker.is_tripped("sub.pinned.com"));
+        assert!(!breaker.is_tripped("deep.sub.pinned.com"));
         assert!(!breaker.is_tripped("other.com"));
+
+        let status = breaker.status();
+        assert_eq!(status.tripped_count, 1);
+        assert_eq!(status.tripped_domains[0].domain, "pinned.com");
+    }
+
+    #[test]
+    fn flood_evicts_its_own_trackers_before_a_domain_under_measurement() {
+        let config = MitmCircuitBreakerConfig {
+            enabled: true,
+            failure_rate_threshold: 0.90,
+            // High enough that the victim never trips: it stays Closed with live
+            // samples, which is exactly the state tier 2 must protect.
+            min_samples: 50,
+            window_secs: 600,
+            cooldown_secs: 0,
+            max_domains: MIN_MAX_DOMAINS,
+        };
+        let breaker = MitmCircuitBreaker::new(config, None);
+
+        for _ in 0..10 {
+            breaker.record_attempt("victim.example.com", false, "fail");
+        }
+
+        for n in 0..(MIN_MAX_DOMAINS * 4) {
+            breaker.record_attempt(&format!("host{n}.attacker.tld"), true, "ok");
+        }
+
+        let status = breaker.status();
+        assert!(status.tracked_domains <= MIN_MAX_DOMAINS);
+        assert!(
+            status.evicted_domains_total > 0,
+            "the flood must evict its own trackers"
+        );
+        assert_eq!(
+            status.dropped_attempts_total, 0,
+            "eviction must keep making room instead of dropping attempts"
+        );
+
+        // The victim's failure history must have survived the flood: 40 more
+        // failures reach min_samples only if the first 10 are still counted.
+        for _ in 0..40 {
+            breaker.record_attempt("victim.example.com", false, "fail");
+        }
+        assert!(
+            breaker.is_tripped("victim.example.com"),
+            "the flood flushed the samples the breaker was measuring"
+        );
+    }
+
+    #[test]
+    fn a_map_full_of_trips_still_makes_room() {
+        let config = MitmCircuitBreakerConfig {
+            enabled: true,
+            failure_rate_threshold: 0.10,
+            min_samples: 2,
+            window_secs: 600,
+            cooldown_secs: 0,
+            max_domains: MIN_MAX_DOMAINS,
+        };
+        let breaker = MitmCircuitBreaker::new(config, None);
+
+        // A client can trip a domain at will by aborting its own handshake, so the
+        // map must stay bounded even when every tracker is tripped.
+        for n in 0..(MIN_MAX_DOMAINS * 2) {
+            let domain = format!("host{n}.attacker.tld");
+            breaker.record_attempt(&domain, false, "fail");
+            breaker.record_attempt(&domain, false, "fail");
+        }
+
+        let status = breaker.status();
+        assert!(
+            status.tracked_domains <= MIN_MAX_DOMAINS,
+            "tracker map grew past the cap: {}",
+            status.tracked_domains
+        );
+        assert!(
+            status.evicted_tripped_domains_total > 0,
+            "expected tier-3 eviction of the oldest trips"
+        );
+        assert_eq!(
+            status.dropped_attempts_total, 0,
+            "tier 3 must keep making room instead of dropping attempts"
+        );
     }
 }

--- a/proxy/src/server.rs
+++ b/proxy/src/server.rs
@@ -617,7 +617,20 @@ async fn handle_connect_mitm(
     client_ip: Arc<str>,
     proxy_user: Option<Arc<UserInfo>>,
 ) {
-    let (domain, _port) = parse_authority(&authority);
+    let (domain, port) = parse_authority(&authority);
+
+    // Same destination check as the blind-tunnel path. Without it a MITM CONNECT
+    // reaches certificate generation and the circuit-breaker tracker for a
+    // destination the SSRF policy would reject anyway.
+    if let Err(reason) = service.check_destination_security(&domain, port) {
+        warn!(%authority, %reason, "CONNECT MITM blocked by destination security policy");
+        service
+            .metrics
+            .ssrf_blocked_total
+            .with_label_values(&[reason])
+            .inc();
+        return;
+    }
 
     let server_config = match service.cert_cache.server_config_for_domain(&domain).await {
         Ok(config) => config,

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -218,10 +218,14 @@ impl CertCache {
             ocsp.as_deref(),
         )?);
 
+        let max_entries = cert_cache_max_entries();
         let mut cache = self.server_configs.write().await;
-        evict_oldest(&mut cache, cert_cache_max_entries(), |entry| {
-            entry.stapled_at
-        });
+        // Only an insert can grow the map. The staple-refresh path replaces an
+        // existing key, so evicting there would drop other domains' configs on
+        // every refresh once the working set reaches the cap.
+        if !cache.contains_key(&domain_arc) {
+            evict_oldest(&mut cache, max_entries, |entry| entry.stapled_at);
+        }
         cache.insert(
             domain_arc,
             CachedServerConfig {
@@ -265,8 +269,11 @@ impl CertCache {
         let key_pem = Bytes::from(key_pair.serialize_pem().into_bytes());
 
         let cert_pair = (cert_pem, key_pem);
+        let max_entries = cert_cache_max_entries();
         let mut cache = self.certs.write().await;
-        evict_oldest(&mut cache, cert_cache_max_entries(), |entry| entry.created);
+        if !cache.contains_key(&domain_arc) {
+            evict_oldest(&mut cache, max_entries, |entry| entry.created);
+        }
         cache.insert(
             domain_arc,
             CachedCert {

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -24,7 +24,18 @@ use tracing::{debug, warn};
 use crate::agent_ocsp;
 
 pub type CertPair = (Bytes, Bytes);
-type CertMap = Arc<RwLock<HashMap<Arc<str>, CertPair>>>;
+
+/// Upper bound on entries in each MITM cache. Both maps are keyed by SNI, so an
+/// unbounded map grows with every unique hostname a client asks for.
+const DEFAULT_CERT_CACHE_MAX_ENTRIES: usize = 10_000;
+const MIN_CERT_CACHE_MAX_ENTRIES: usize = 128;
+
+struct CachedCert {
+    pair: CertPair,
+    created: Instant,
+}
+
+type CertMap = Arc<RwLock<HashMap<Arc<str>, CachedCert>>>;
 
 struct CachedServerConfig {
     config: Arc<ServerConfig>,
@@ -33,6 +44,40 @@ struct CachedServerConfig {
 }
 
 type ServerConfigMap = Arc<RwLock<HashMap<Arc<str>, CachedServerConfig>>>;
+
+fn cert_cache_max_entries() -> usize {
+    std::env::var("MITM_CERT_CACHE_MAX_ENTRIES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map(|n| n.max(MIN_CERT_CACHE_MAX_ENTRIES))
+        .unwrap_or(DEFAULT_CERT_CACHE_MAX_ENTRIES)
+}
+
+/// Evict the oldest entries when a cache is at capacity.
+///
+/// A single sweep frees 10% of the cap, so the sort cost is amortised over the
+/// following `max / 10` inserts instead of being paid on every cache miss.
+fn evict_oldest<V>(cache: &mut HashMap<Arc<str>, V>, max: usize, stamp: impl Fn(&V) -> Instant) {
+    if cache.len() < max {
+        return;
+    }
+    let target = max - (max / 10).max(1);
+    let mut entries: Vec<(Instant, Arc<str>)> = cache
+        .iter()
+        .map(|(key, value)| (stamp(value), key.clone()))
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    for (_, key) in entries {
+        if cache.len() <= target {
+            break;
+        }
+        cache.remove(&key);
+    }
+    warn!(
+        entries = cache.len(),
+        max, "MITM certificate cache at capacity; evicted oldest entries"
+    );
+}
 
 #[derive(Clone)]
 pub struct CertCache {
@@ -174,6 +219,9 @@ impl CertCache {
         )?);
 
         let mut cache = self.server_configs.write().await;
+        evict_oldest(&mut cache, cert_cache_max_entries(), |entry| {
+            entry.stapled_at
+        });
         cache.insert(
             domain_arc,
             CachedServerConfig {
@@ -194,7 +242,7 @@ impl CertCache {
             let cache = self.certs.read().await;
             if let Some(cert) = cache.get(&domain_arc) {
                 debug!("Certificate cache HIT for {}", domain);
-                return Ok(cert.clone());
+                return Ok(cert.pair.clone());
             }
         }
 
@@ -218,7 +266,14 @@ impl CertCache {
 
         let cert_pair = (cert_pem, key_pem);
         let mut cache = self.certs.write().await;
-        cache.insert(domain_arc, cert_pair.clone());
+        evict_oldest(&mut cache, cert_cache_max_entries(), |entry| entry.created);
+        cache.insert(
+            domain_arc,
+            CachedCert {
+                pair: cert_pair.clone(),
+                created: Instant::now(),
+            },
+        );
         Ok(cert_pair)
     }
 
@@ -514,6 +569,53 @@ pub fn rewrite_mitm_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn evict_oldest_frees_capacity_and_drops_oldest_first() {
+        let mut cache: HashMap<Arc<str>, Instant> = HashMap::new();
+        let base = Instant::now();
+        let max = MIN_CERT_CACHE_MAX_ENTRIES;
+        for n in 0..max {
+            let key: Arc<str> = format!("host{n:04}.example.com").into();
+            cache.insert(key, base + std::time::Duration::from_millis(n as u64));
+        }
+
+        evict_oldest(&mut cache, max, |stamp| *stamp);
+
+        assert!(cache.len() < max, "eviction must free capacity");
+        assert!(
+            !cache.contains_key("host0000.example.com"),
+            "oldest entry must be evicted first"
+        );
+        let newest: Arc<str> = format!("host{:04}.example.com", max - 1).into();
+        assert!(cache.contains_key(&newest), "newest entry must be kept");
+    }
+
+    #[tokio::test]
+    async fn cert_cache_stays_bounded_across_unique_sni() {
+        let key_pair = KeyPair::generate().unwrap();
+        let cache = CertCache::from_pem(key_pair.serialize_pem().as_bytes(), b"").unwrap();
+
+        // Far more unique hostnames than the floor cap, as a client looping
+        // CONNECT on random SNI would produce.
+        std::env::set_var(
+            "MITM_CERT_CACHE_MAX_ENTRIES",
+            MIN_CERT_CACHE_MAX_ENTRIES.to_string(),
+        );
+        for n in 0..(MIN_CERT_CACHE_MAX_ENTRIES + 32) {
+            cache
+                .get_or_generate(&format!("host{n}.attacker.tld"))
+                .await
+                .unwrap();
+        }
+        std::env::remove_var("MITM_CERT_CACHE_MAX_ENTRIES");
+
+        let entries = cache.certs.read().await.len();
+        assert!(
+            entries <= MIN_CERT_CACHE_MAX_ENTRIES,
+            "certificate cache grew past the cap: {entries}"
+        );
+    }
 
     #[tokio::test]
     async fn load_for_startup_without_ca_when_mitm_disabled() {


### PR DESCRIPTION
## Summary

Устраняет дефект #340: неограниченный рост состояния MITM circuit breaker и линейный скан на каждом MITM `CONNECT`.

**Circuit breaker (`proxy/src/mitm_breaker.rs`)**

- Карта трекеров ограничена `MITM_CIRCUIT_BREAKER_MAX_DOMAINS` (по умолчанию `10000`, пол `128`). При заполнении один проход освобождает 10% лимита, вытеснение идёт тремя ярусами: (1) закрытые трекеры без попыток внутри окна; (2) закрытые трекеры с наименьшим числом попыток — так поток `CONNECT` вытесняет свои же одноразовые записи раньше домена, который breaker реально измеряет; (3) если вся карта состоит из tripped-доменов — наименее недавно использованные trip'ы. Ярус 3 обязателен: клиент может ввести домен в tripped, оборвав собственный TLS-хендшейк, и без него карта насыщается, а каждая новая попытка платит два полных прохода под write-lock'ом.
- `is_tripped()` — один lookup в `HashMap`, без скана.
- Ключи — точные имена хостов: `normalize_domain_key` срезает и ведущие точки. Единственный производитель ключей — authority из `CONNECT`, то есть данные клиента, поэтому `.example.com` раньше создавал wildcard, trip которого выводил из MITM весь родительский домен.
- `GET /api/mitm/circuit-breaker` отдаёт `tracked_domains`, `max_domains`, `evicted_domains_total`, `evicted_tripped_domains_total`, `dropped_attempts_total`.

**Кэши сертификатов (`proxy/src/tls.rs`)**

- Кэши сертификатов и `ServerConfig` (ключ — SNI) ограничены `MITM_CERT_CACHE_MAX_ENTRIES` (по умолчанию `10000`), вытесняются самые старые записи. Вытеснение только при вставке нового ключа: путь обновления OCSP staple заменяет существующий ключ и расти не может, иначе при рабочем наборе на уровне лимита каждое обновление выбрасывало бы 10% чужих записей.

**Проверка назначения на MITM-пути (`proxy/src/server.rs`)**

- `handle_connect_mitm` теперь вызывает `check_destination_security`, как это уже делает blind-ветка. Отклонённый SSRF-политикой адресат больше не доходит до генерации сертификата и до счётчика circuit breaker; блокировки учитываются в `ssrf_blocked_total`.

**Отдельно: тест, форкавший весь набор (`proxy/src/control_api.rs`)**

- `schedule_service_restart` при пустом `CONFIG_RESTART_CMD` спавнит `current_exe()`; под `cargo test` это сам тестовый бинарник, поэтому `config_apply_writes_env_and_schedules_restart` заставлял набор рекурсивно перезапускать себя — `cargo test --workspace` не завершался. Тест переведён на явный no-op `CONFIG_RESTART_CMD`.

## Related Issues

- Closes #340

## Testing

```bash
cargo fmt --all -- --check                      # OK
cargo clippy --workspace --all-targets          # без warning'ов
cargo test -p bsdm-proxy --lib                  # 303 passed, 0 failed
cargo test -p bsdm-proxy-e2e --test e2e         # 12 passed, 0 failed
cargo test --workspace --all-targets            # все таргеты по одному разу, 0 падений
```

Новые тесты:

- `mitm_breaker::tests::tracker_map_is_bounded_and_evicts_idle_domains` — цикл уникальных `CONNECT`-хостов не выводит карту за лимит.
- `mitm_breaker::tests::flood_evicts_its_own_trackers_before_a_domain_under_measurement` — флуд вытесняет свои записи, история измеряемого домена переживает его.
- `mitm_breaker::tests::a_map_full_of_trips_still_makes_room` — карта из одних trip'ов остаётся ограниченной, попытки не теряются.
- `mitm_breaker::tests::tripped_domains_survive_pressure_from_new_domains` — trip переживает флуд закрытых трекеров.
- `mitm_breaker::tests::client_supplied_dots_cannot_create_a_parent_domain_wildcard` — `CONNECT .pinned.com:443` не выводит из MITM `sub.pinned.com`.
- `tls::tests::evict_oldest_frees_capacity_and_drops_oldest_first`, `tls::tests::cert_cache_stays_bounded_across_unique_sni`.

## Checklist

- [x] CI is green
- [x] Documentation updated (if behavior or env vars changed) — `docs/ops-and-dev/configuration.md`, `docs/features/certificate-pinning.md`, `bsdm-proxy.env`, `CHANGELOG.md`
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — не требуется: исправление дефекта, уровень зрелости функции не меняется