### PR TITLE
fix(threat-intel,dns-sinkhole,proxy): close the paths around the TI shadow gate

### DIFF
--- a/Jenkinsfile.local
+++ b/Jenkinsfile.local
@@ -66,6 +66,15 @@ pipeline {
   }
 
   stages {
+    // Дешёвый конфиг-гейт до сборки: дефолты поставки не должны уводить
+    // threat-intel из Shadow Mode (issue #330) — pure bash, секунды.
+    stage('Deployment defaults') {
+      agent any
+      steps {
+        sh './scripts/ci/check-shadow-defaults.sh'
+      }
+    }
+
     stage('CA rotation drill') {
       agent { docker { image RUST_IMAGE; args CACHE_ARGS; reuseNode true } }
       steps {

--- a/charts/bsdm/templates/threat-intel-deployment.yaml
+++ b/charts/bsdm/templates/threat-intel-deployment.yaml
@@ -46,10 +46,20 @@ spec:
             # require TI_API_TOKEN (fail-closed without it).
             - name: TI_ADMIN_BIND
               value: {{ .Values.threatIntel.adminBind | default "0.0.0.0" | quote }}
-            {{- if .Values.threatIntel.apiToken }}
+            {{- if .Values.threatIntel.existingSecret }}
+            - name: TI_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.threatIntel.existingSecret }}
+                  key: {{ .Values.threatIntel.existingSecretKey | default "ti-api-token" }}
+            {{- else if .Values.threatIntel.apiToken }}
+            # Plaintext token from values.yaml: visible in `kubectl get deploy -o yaml`
+            # and in any Git-stored values file. Prefer threatIntel.existingSecret.
             - name: TI_API_TOKEN
               value: {{ .Values.threatIntel.apiToken | quote }}
             {{- end }}
+            - name: TI_SOAR_AUDIT_PATH
+              value: {{ printf "%s/soar-audit.jsonl" .Values.threatIntel.outputDir | quote }}
             - name: METRICS_PORT
               value: {{ .Values.threatIntel.service.port | quote }}
             - name: RUST_LOG

--- a/charts/bsdm/templates/threat-intel-networkpolicy.yaml
+++ b/charts/bsdm/templates/threat-intel-networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- if and .Values.threatIntel .Values.threatIntel.enabled .Values.networkPolicy.enabled }}
+# The collector binds its admin/SOAR API on 0.0.0.0 inside the pod so kubelet
+# probes and the Prometheus scraper can reach it. Without this policy every pod
+# in the cluster can reach :8093 — read endpoints always, and mutating
+# /api/v1/soar/* as soon as a token exists and leaks.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "bsdm.fullname" . }}-threat-intel
+  labels:
+    {{- include "bsdm.labels" . | nindent 4 }}
+    app.kubernetes.io/component: threat-intel
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "bsdm.threatIntelSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Scraping only. Probes come from the node and are not subject to policy.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.monitoringNamespace | default "monitoring" }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.threatIntel.service.port }}
+    {{- with .Values.networkPolicy.threatIntelAdminNamespaces }}
+    # Explicit opt-in for operator tooling that calls the SOAR API.
+    - from:
+        {{- range . }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.threatIntel.service.port }}
+    {{- end }}
+  egress:
+    # IOC feeds are public HTTPS endpoints; no reason to reach cluster-internal ranges.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+    - ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+{{- end }}

--- a/charts/bsdm/values.yaml
+++ b/charts/bsdm/values.yaml
@@ -132,6 +132,10 @@ networkPolicy:
   enabled: false
   proxyIngressCidrs:
     - 10.0.0.0/8
+  # Namespace allowed to scrape metrics (proxy + threat-intel).
+  monitoringNamespace: "monitoring"
+  # Namespaces allowed to call the threat-intel admin/SOAR API on :8093.
+  threatIntelAdminNamespaces: []
   allowEgressInternet: true
   redisNamespace: ""
   kafkaNamespace: ""
@@ -247,6 +251,11 @@ threatIntel:
   # Admin/SOAR API bind inside the pod. Mutating /api/v1/soar/* endpoints are
   # fail-closed until apiToken is set (Bearer TI_API_TOKEN).
   adminBind: "0.0.0.0"
+  # SOAR token. Prefer an existing Secret: apiToken lands in the Deployment spec
+  # in plaintext and in Git if values.yaml is committed.
+  #   kubectl create secret generic bsdm-ti --from-literal=ti-api-token=...
+  existingSecret: ""
+  existingSecretKey: "ti-api-token"
   apiToken: ""
   # Snapshots are rebuilt on every cycle, so an emptyDir is enough unless the
   # IOC store (TASK-TI-002) needs them to survive a restart.

--- a/dns-sinkhole/src/main.rs
+++ b/dns-sinkhole/src/main.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tracing::{error, info, warn};
-use zone::Zone;
+use zone::{Zone, ZoneError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -35,6 +35,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let zone_path = Path::new(&cfg.zone_path);
     let zone = match Zone::load_path(zone_path) {
         Ok(z) => z,
+        // A shadow artifact is a misconfiguration, not a missing file: falling
+        // back would hide the fact that someone pointed the sinkhole at
+        // observe-only threat-intel output (ADR 0008).
+        Err(e @ ZoneError::ShadowArtifact(_)) => {
+            error!("{e}");
+            return Err(e.into());
+        }
         Err(e) => {
             // First boot: fall back to image/example blocklist if compiled zone missing.
             let fallback = Path::new("/etc/bsdm-proxy/blocklist.rpz");

--- a/dns-sinkhole/src/zone.rs
+++ b/dns-sinkhole/src/zone.rs
@@ -4,6 +4,25 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::Path;
 
+/// Why a zone could not be loaded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoneError {
+    /// The file is observe-only threat-intel output, not a zone to enforce.
+    ShadowArtifact(String),
+    /// Unreadable file or malformed content.
+    Invalid(String),
+}
+
+impl std::fmt::Display for ZoneError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ShadowArtifact(m) | Self::Invalid(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for ZoneError {}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ZoneAction {
     /// Use global sinkhole / NXDOMAIN policy.
@@ -23,12 +42,28 @@ pub struct Zone {
 }
 
 impl Zone {
-    pub fn load_path(path: &Path) -> Result<Self, String> {
-        let text = std::fs::read_to_string(path).map_err(|e| format!("read zone: {e}"))?;
+    pub fn load_path(path: &Path) -> Result<Self, ZoneError> {
+        // The collector writes observe-only artifacts under a `.shadow` suffix.
+        // Refuse them by name as well as by marker: a copy that kept the suffix
+        // is still an artifact nobody signed off for enforcement (ADR 0008).
+        if path
+            .as_os_str()
+            .to_string_lossy()
+            .ends_with(SHADOW_ARTIFACT_SUFFIX)
+        {
+            return Err(ZoneError::ShadowArtifact(format!(
+                "refusing to load {}: a '{SHADOW_ARTIFACT_SUFFIX}' artifact is observe-only \
+                 threat-intel output, not a zone. Enforcement requires \
+                 TI_ENFORCEMENT_MODE=enforce on the collector",
+                path.display()
+            )));
+        }
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| ZoneError::Invalid(format!("read zone: {e}")))?;
         Self::parse(&text)
     }
 
-    pub fn parse(text: &str) -> Result<Self, String> {
+    pub fn parse(text: &str) -> Result<Self, ZoneError> {
         let mut zone = Self::default();
         for (lineno, raw) in text.lines().enumerate() {
             let cleaned = strip_comment(raw);
@@ -40,7 +75,16 @@ impl Zone {
                 // $TTL etc. — ignore for PoC
                 continue;
             }
-            parse_line(&mut zone, line).map_err(|e| format!("zone line {}: {e}", lineno + 1))?;
+            if is_shadow_marker(line) {
+                return Err(ZoneError::ShadowArtifact(format!(
+                    "zone line {}: this zone is marked '{SHADOW_MARKER_NAME} TXT \"shadow\"' — \
+                     it is an observe-only threat-intel artifact and must not be enforced. \
+                     Set TI_ENFORCEMENT_MODE=enforce on the collector to produce a real zone",
+                    lineno + 1
+                )));
+            }
+            parse_line(&mut zone, line)
+                .map_err(|e| ZoneError::Invalid(format!("zone line {}: {e}", lineno + 1)))?;
         }
         Ok(zone)
     }
@@ -61,6 +105,27 @@ impl Zone {
     pub fn len(&self) -> usize {
         self.exact.len() + self.suffixes.len()
     }
+}
+
+/// Owner name that `threat-intel` writes into an observe-only zone.
+///
+/// Kept in sync with `threat_intel::rpz::SHADOW_MARKER_NAME`; the two crates do
+/// not depend on each other, so the constant is duplicated rather than shared.
+const SHADOW_MARKER_NAME: &str = "_bsdm-enforcement-mode";
+
+/// Filename suffix of the collector's observe-only artifacts.
+const SHADOW_ARTIFACT_SUFFIX: &str = ".shadow";
+
+/// True for the marker record that makes a zone unloadable.
+///
+/// Matched on the owner name alone: whatever the mode says, a zone that carries
+/// the record at all is collector output that no operator promoted.
+fn is_shadow_marker(line: &str) -> bool {
+    line.split_whitespace().next().is_some_and(|owner| {
+        owner
+            .trim_end_matches('.')
+            .eq_ignore_ascii_case(SHADOW_MARKER_NAME)
+    })
 }
 
 fn strip_comment(line: &str) -> String {
@@ -155,6 +220,42 @@ fn parse_line(zone: &mut Zone, line: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn a_shadow_marked_zone_is_refused() {
+        // Exactly what threat-intel writes in shadow mode: the human-readable
+        // banner is a comment, the TXT record is the enforceable half.
+        let err = Zone::parse(
+            r#"
+$TTL 300
+; SHADOW MODE (TI_ENFORCEMENT_MODE=shadow): observe-only artifact.
+_bsdm-enforcement-mode IN TXT "shadow"
+phish.test. CNAME .
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ZoneError::ShadowArtifact(_)),
+            "shadow-marked zone must be refused, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_shadow_suffixed_path_is_refused_before_it_is_read() {
+        // The file does not even exist: the suffix alone must stop the load,
+        // otherwise a copy that kept the name would be enforced.
+        let err = Zone::load_path(Path::new("/nonexistent/threats.rpz.shadow")).unwrap_err();
+        assert!(
+            matches!(err, ZoneError::ShadowArtifact(_)),
+            "a .shadow path must be refused by name, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn an_enforce_zone_without_the_marker_still_loads() {
+        let z = Zone::parse("$TTL 300\nphish.test. CNAME .\n").unwrap();
+        assert!(matches!(z.lookup("phish.test"), Some(ZoneAction::Policy)));
+    }
 
     #[test]
     fn parses_plain_and_rpz() {

--- a/dns-sinkhole/src/zone.rs
+++ b/dns-sinkhole/src/zone.rs
@@ -64,6 +64,23 @@ impl Zone {
     }
 
     pub fn parse(text: &str) -> Result<Self, ZoneError> {
+        // Scan for the marker before parsing anything: a real collector artifact
+        // opens with a multi-line SOA that `parse_line` rejects, so a per-line
+        // check would report a malformed zone and let the caller fall back to a
+        // default blocklist instead of failing on the shadow artifact itself.
+        if let Some((lineno, _)) = text
+            .lines()
+            .enumerate()
+            .find(|(_, raw)| is_shadow_marker(strip_comment(raw).trim()))
+        {
+            return Err(ZoneError::ShadowArtifact(format!(
+                "zone line {}: this zone is marked '{SHADOW_MARKER_NAME} TXT \"shadow\"' — \
+                 it is an observe-only threat-intel artifact and must not be enforced. \
+                 Set TI_ENFORCEMENT_MODE=enforce on the collector to produce a real zone",
+                lineno + 1
+            )));
+        }
+
         let mut zone = Self::default();
         for (lineno, raw) in text.lines().enumerate() {
             let cleaned = strip_comment(raw);
@@ -74,14 +91,6 @@ impl Zone {
             if line.starts_with('$') {
                 // $TTL etc. — ignore for PoC
                 continue;
-            }
-            if is_shadow_marker(line) {
-                return Err(ZoneError::ShadowArtifact(format!(
-                    "zone line {}: this zone is marked '{SHADOW_MARKER_NAME} TXT \"shadow\"' — \
-                     it is an observe-only threat-intel artifact and must not be enforced. \
-                     Set TI_ENFORCEMENT_MODE=enforce on the collector to produce a real zone",
-                    lineno + 1
-                )));
             }
             parse_line(&mut zone, line)
                 .map_err(|e| ZoneError::Invalid(format!("zone line {}: {e}", lineno + 1)))?;
@@ -220,6 +229,33 @@ fn parse_line(zone: &mut Zone, line: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The zone `threat_intel::rpz::generate_rpz_zone` actually writes: SOA and
+    /// NS records the sinkhole parser does not support come *before* the marker.
+    #[test]
+    fn a_real_shadow_artifact_is_refused_despite_the_unsupported_soa_header() {
+        let err = Zone::parse(
+            r#"$TTL 300
+@ IN SOA ns1.bsdm-proxy.internal. hostmaster.bsdm-proxy.internal. (
+  2026082612 ; serial
+  3600 ; refresh
+)
+@ IN NS ns1.bsdm-proxy.internal.
+
+; SHADOW MODE (TI_ENFORCEMENT_MODE=shadow): observe-only artifact.
+; Do NOT load this zone into dns-sinkhole; it blocks nothing by design.
+_bsdm-enforcement-mode IN TXT "shadow"
+; Active Threat Intelligence RPZ Rules
+phish.test CNAME .
+"#,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, ZoneError::ShadowArtifact(_)),
+            "the marker must win over the SOA parse error, else the caller falls \
+             back to a default blocklist and starts normally; got {err:?}"
+        );
+    }
 
     #[test]
     fn a_shadow_marked_zone_is_refused() {

--- a/docs/adr/0008-threat-intel-shadow-mode.md
+++ b/docs/adr/0008-threat-intel-shadow-mode.md
@@ -32,6 +32,7 @@ Public phishing feeds carry URL-level indicators, shared hosters, URL shorteners
 
 3. **Per-feed observability.**
    - Prometheus counter `bsdm_proxy_ti_shadow_matches_total{feed}` counts shadow matches per feed, so feed quality can be compared feed by feed rather than in aggregate.
+   - Gauge `threat_intel_enforcement_mode{mode}` publishes the posture itself, so a monitor can tell an observing installation from an enforcing one without waiting for a SOAR call that may never come.
    - The SOC reviews candidates through the Search API over events carrying `threat_shadow_match`; no separate review UI is required for the pilot.
 
 4. **SOAR containment is mode-aware.**

--- a/docs/adr/0008-threat-intel-shadow-mode.md
+++ b/docs/adr/0008-threat-intel-shadow-mode.md
@@ -35,7 +35,7 @@ Public phishing feeds carry URL-level indicators, shared hosters, URL shorteners
    - The SOC reviews candidates through the Search API over events carrying `threat_shadow_match`; no separate review UI is required for the pilot.
 
 4. **SOAR containment is mode-aware.**
-   - In shadow mode `POST /api/v1/soar/block` returns `202 Accepted` with a `shadow` marker instead of `200`, and records the indicator only in the shadow export. The response must make it unambiguous to the calling playbook that nothing is being blocked.
+   - In shadow mode `POST /api/v1/soar/block` returns `202 Accepted` with a `shadow` marker instead of `200`, and the indicator is tagged `shadow` in the store so that it reaches the shadow export only. Flipping `TI_ENFORCEMENT_MODE` to `enforce` does **not** promote indicators accepted while shadow was in force — the enforcement export skips them, and promoting one takes a deliberate re-submission under `enforce`. The response must make it unambiguous to the calling playbook that nothing is being blocked.
    - `enforce` mode keeps the current `200` semantics.
 
 5. **Documentation states the mode, not an aspiration.** README, `project-status.md` and the TI pages describe the feature as *threat monitoring in Shadow Mode (enforcement in development)*, without present-tense claims of protection or blocking.
@@ -80,8 +80,10 @@ Implemented on this branch; the mode contract above is what the code does:
 
 - `TI_ENFORCEMENT_MODE` parsing, the fail-safe fallback for any unrecognised value and the warning for `TI_RPZ_ENABLED=true` without `enforce`: `threat-intel/src/config.rs`.
 - Artifacts under the enforcement names are written **only** in `enforce`; in shadow the collector writes `threats.rpz.shadow` and `threat_domains.json.shadow`, and the zone body carries a `SHADOW MODE … Do NOT load this zone into dns-sinkhole` banner: `threat-intel/src/collector.rs`, `threat-intel/src/rpz.rs`.
-- SOAR block answers `202` with `"mode":"shadow"`, `"enforced":false` and is counted by `threat_intel_soar_blocks_total{mode}`: `threat-intel/src/soar.rs`, `threat-intel/src/main.rs`, `threat-intel/src/metrics.rs`.
+- SOAR block answers `202` with `"mode":"shadow"`, `"enforced":false` and is counted by `threat_intel_soar_blocks_total{mode}`: `threat-intel/src/soar.rs`, `threat-intel/src/main.rs`, `threat-intel/src/metrics.rs`. Indicators tagged `shadow` are excluded from the enforcement export: `threat-intel/src/storage.rs` (`list_active_domain_sources`), `threat-intel/src/collector.rs`.
 - Mutating SOAR calls additionally require `Authorization: Bearer $TI_API_TOKEN` and are audited accepted-or-denied: `threat-intel/src/api_auth.rs` ([configuration.md](../ops-and-dev/configuration.md#adminsoar-api-коллектора-доступ-и-аудит)).
+- `dns-sinkhole` refuses an observe-only artifact outright — by `.shadow` path suffix and by the `_bsdm-enforcement-mode IN TXT "shadow"` marker the collector writes into the zone; at boot this is a hard error rather than a fallback, so a mistaken `DNS_SINKHOLE_ZONE_PATH` cannot pass unnoticed: `threat-intel/src/rpz.rs`, `dns-sinkhole/src/zone.rs`, `dns-sinkhole/src/main.rs`.
+- The control-plane RPZ API (`/api/dns/*`) is a separate path into the same zone and is **not** governed by `TI_ENFORCEMENT_MODE`; it is bounded instead by a mutation audit trail, `?dryRun=true` previews and a confirmation threshold on list size: `proxy/src/rpz_api.rs` ([control-plane-security.md](../ops-and-dev/control-plane-security.md)).
 - The proxy-side matcher reads only the shadow export (`TI_SHADOW_MATCH_ENABLED`, `TI_SHADOW_FEED_PATH`, `TI_SHADOW_RELOAD_SECS`), annotates `threat_shadow_match` and counts `bsdm_proxy_ti_shadow_matches_total{feed}` without touching the allow/deny path: `proxy/src/ti_shadow.rs`, `proxy/src/metrics.rs`.
 - The event field and its ClickHouse column: `bsdm-events/src/lib.rs`, `bsdm-events/src/clickhouse.rs`, `cache-indexer/src/clickhouse.rs`.
 

--- a/docs/features/threat-intel-collector.md
+++ b/docs/features/threat-intel-collector.md
@@ -8,9 +8,11 @@
 
 The `threat-intel` worker ingests phishing/malware IOC feeds on a schedule,
 normalizes and scores indicators, persists them into SQLite with TTL management (`TI_SQLITE_PATH`),
-and exports live DNS RPZ zones (`threats.rpz`) and Proxy ACL feeds (`threat_domains.json`).
-It also exposes enterprise SIEM formatting (CEF/ECS/Syslog), SOAR automated containment
-APIs (`/api/v1/soar/*`), and ML domain reputation/homoglyph evaluation (`/api/v1/ml/*`).
+and compiles DNS RPZ zones (`threats.rpz`) and Proxy ACL feeds (`threat_domains.json`) to disk.
+In the default shadow mode those artifacts are written with a `.shadow` suffix that no
+data-plane component loads. It also exposes enterprise SIEM formatting (CEF/ECS/Syslog),
+a SOAR API (`/api/v1/soar/*`) which in shadow mode records indicators for observation only
+(`202`, `enforced:false`), and ML domain reputation/homoglyph evaluation (`/api/v1/ml/*`).
 
 It also **compiles enforcement artifacts** when `TI_RPZ_ENABLED` is on (default
 `true`, `threat-intel/src/config.rs`): an RPZ zone `threats.rpz` and a Proxy ACL
@@ -103,9 +105,11 @@ indicator count, attempts, duration and the last error, if any.
 | `TI_OUTPUT_DIR` | `./data/threat-intel` | Snapshot and artifact output directory |
 | `TI_USER_AGENT` | `bsdm-threat-intel/<version>` | Feed request User-Agent |
 | `TI_RUN_ONCE` | `false` | Collect every source once and exit |
-| `TI_ENFORCEMENT_MODE` | `shadow` | `shadow` writes `.shadow` files; `enforce` compiles live targets |
+| `TI_ENFORCEMENT_MODE` | `shadow` | `shadow` writes `.shadow` files; `enforce` compiles live targets. Any unrecognised value falls back to `shadow`. The suffix is a convention on the producer side: `dns-sinkhole` loads whatever `DNS_SINKHOLE_ZONE_PATH` points at, including a `.shadow` file |
 | `TI_RPZ_ENABLED` | `true` | Compile `threats.rpz` and `threat_domains.json` |
-| `TI_API_KEY` | empty | Bearer / header token for SOAR endpoints (`X-API-Key`) |
+| `TI_API_TOKEN` | unset | `Authorization: Bearer` token for mutating `POST /api/v1/soar/*`; unset means those endpoints are disabled in the production profile (fail-closed) |
+| `TI_API_ALLOW_INSECURE` | `false` | Lab-only override that leaves mutating endpoints open without a token; never set it on a pilot network |
+| `TI_SOAR_AUDIT_PATH` | `<TI_OUTPUT_DIR>/soar-audit.jsonl` | Audit trail of SOAR mutations |
 | `TI_ADMIN_BIND` | `127.0.0.1` | Bind host for the HTTP admin/metrics listener |
 | `METRICS_PORT` | `8093` | `/metrics`, `/health`, SOAR and ML endpoints |
 

--- a/docs/features/threat-intel-collector.md
+++ b/docs/features/threat-intel-collector.md
@@ -1,15 +1,12 @@
-# Threat intelligence collector (TASK-TI-001)
+# Threat intelligence collector & pipeline (TASK-TI-001..040)
 
-Optional `threat-intel` worker that pulls phishing/malware IOC feeds on a
-schedule, parses them through per-source plugins, and writes a snapshot per feed
-plus a run report. This is the collector framework from the
-[TI backlog](../threat-intelligence/AI_Agent_Backlog.md): the IOC database
-(TASK-TI-002), full normalization (TASK-TI-003) and confidence scoring
-(TASK-TI-010) are **not** part of it, and nothing here is wired into ACL or RPZ
-enforcement yet.
+The `threat-intel` worker ingests phishing/malware IOC feeds on a schedule,
+normalizes and scores indicators, persists them into SQLite with TTL management,
+and exports live DNS RPZ zones (`threats.rpz`) and Proxy ACL feeds (`threat_domains.json`).
+It also exposes enterprise SIEM formatting (CEF/ECS/Syslog), SOAR automated containment
+APIs (`/api/v1/soar/*`), and ML domain reputation/homoglyph evaluation (`/api/v1/ml/*`).
 
-Status: **Experimental**. Treat the output as an input to a review pipeline, not
-as a block list.
+Status: **Beta**. Full pipeline integration with automated DNS RPZ / Proxy ACL and SIEM/SOAR.
 
 ## Quick start
 

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -332,6 +332,18 @@ ML worker:
 | `DNS_SINKHOLE_DOT_ENABLED` | `true` |
 | `DNS_SINKHOLE_DOT_BIND` | `0.0.0.0:853` |
 | `DNS_SINKHOLE_TLS_CERT`, `DNS_SINKHOLE_TLS_KEY` | required for DoH/DoT |
+| `RPZ_CONFIRM_GROWTH_RULES` | `5000` | Порог правил, выше которого `POST /api/dns/rpz/lists` требует `?confirm=true` |
+
+`dns-sinkhole` **отказывается** загружать observe-only артефакт коллектора: и по
+имени (путь оканчивается на `.shadow`), и по машинному маркеру внутри зоны
+(`_bsdm-enforcement-mode IN TXT "shadow"`). На старте это ошибка без отката на
+fallback-зону — иначе неверный `DNS_SINKHOLE_ZONE_PATH` тихо маскировался бы.
+Баннер-комментарий в зоне оставлен для человека: любой парсер его выбрасывает.
+
+Мутации `/api/dns/*` пишут JSONL-аудит в `<DNS_RPZ_STATE_DIR>/rpz-audit.jsonl`
+(`0600`). Добавление списка поддерживает `?dryRun=true` — предпросмотр числа
+правил, размера зоны до/после и первых 20 строк без записи и без компиляции
+зоны.
 
 Подробнее: [DNS sinkhole](../features/dns-sinkhole.md).
 
@@ -382,15 +394,15 @@ ML worker:
 
 | Переменная | Default | Назначение |
 |---|---:|---|
-| `TI_API_TOKEN` | unset | Bearer для `POST /api/v1/soar/*`; сравнение constant-time. Без него мутации закрыты в production-профиле |
+| `TI_API_TOKEN` | unset | Bearer для `POST /api/v1/soar/*`; сравнение constant-time. Без него мутации закрыты |
 | `TI_API_ALLOW_INSECURE` | `false` | Явная лабораторная лазейка: открыть мутации без токена. Не задавать в пилоте |
-| `TI_API_REQUIRE_TOKEN` | `false` | Форсировать fail-closed в non-production профилях |
 | `TI_ADMIN_BIND` | `127.0.0.1` | Хост admin/SOAR/metrics-листенера |
 | `TI_SOAR_AUDIT_PATH` | `<TI_OUTPUT_DIR>/soar-audit.jsonl` | JSONL-аудит SOAR-действий, файл создаётся с правами `0600` |
-| `DEPLOYMENT_PROFILE` | `production`, если не задана | Определяет fail-closed по умолчанию (`production`/`prod`/пустое значение = production) |
 
-Постура выбирается так: `TI_API_ALLOW_INSECURE=true` → открыто; иначе
-production-профиль → fail-closed; иначе — по `TI_API_REQUIRE_TOKEN`.
+Постура выбирается так: fail-closed всегда, кроме единственного случая
+`TI_API_ALLOW_INSECURE=true`. `DEPLOYMENT_PROFILE` на неё **не влияет**: эту
+переменную переключают другие сервисы по своим причинам, и раньше любое
+не-production значение тихо открывало мутации SOAR без токена.
 
 - **Отказ**: мутация без валидного Bearer получает `401 Unauthorized` с
   заголовком `WWW-Authenticate: Bearer`, **до** обращения к хранилищу —

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -332,7 +332,8 @@ ML worker:
 | `DNS_SINKHOLE_DOT_ENABLED` | `true` |
 | `DNS_SINKHOLE_DOT_BIND` | `0.0.0.0:853` |
 | `DNS_SINKHOLE_TLS_CERT`, `DNS_SINKHOLE_TLS_KEY` | required for DoH/DoT |
-| `RPZ_CONFIRM_GROWTH_RULES` | `5000` | Порог правил, выше которого `POST /api/dns/rpz/lists` требует `?confirm=true` |
+| `RPZ_CONFIRM_GROWTH_RULES` | `5000` | Абсолютный порог правил, выше которого `POST /api/dns/rpz/lists` требует `?confirm=true` |
+| `RPZ_CONFIRM_GROWTH_PCT` | `50` | Относительный порог: прирост зоны больше этого процента тоже требует `?confirm=true` |
 
 `dns-sinkhole` **отказывается** загружать observe-only артефакт коллектора: и по
 имени (путь оканчивается на `.shadow`), и по машинному маркеру внутри зоны

--- a/docs/ops-and-dev/control-plane-security.md
+++ b/docs/ops-and-dev/control-plane-security.md
@@ -126,9 +126,12 @@ Every mutation compiles straight into the zone `dns-sinkhole` serves, so:
    action, target, outcome, rule delta.
 2. `POST /api/dns/rpz/lists?dryRun=true` previews a feed (rule count, zone size
    before/after, first 20 entries) without storing or compiling anything.
-3. A list adding more than `RPZ_CONFIRM_GROWTH_RULES` rules (default `5000`) is
-   refused with `409` until the call is repeated with `?confirm=true`. The
-   refusal is audited.
+3. A list is refused with `409` until the call is repeated with `?confirm=true`
+   when it adds more than `RPZ_CONFIRM_GROWTH_RULES` rules (default `5000`) or
+   grows the current zone by more than `RPZ_CONFIRM_GROWTH_PCT` percent
+   (default `50`). The absolute limit stops one unmoderated feed; the relative
+   one stops a series of lists that each stay just under it. Refusals are
+   audited.
 
 A public feed pulled through `source: url_feed` is unmoderated content: preview
 it before applying it, and remember this path is **not** gated by

--- a/docs/ops-and-dev/control-plane-security.md
+++ b/docs/ops-and-dev/control-plane-security.md
@@ -59,7 +59,6 @@ See also: [control-plane.md](../features/control-plane.md) ·
 | `SEARCH_API_TOKEN` | *unset* | Bearer for Search API |
 | `TI_API_TOKEN` | *unset* | Bearer for mutating `POST /api/v1/soar/*` (`threat-intel`) |
 | `TI_API_ALLOW_INSECURE` | `false` | Lab only: open SOAR mutations without a token |
-| `TI_API_REQUIRE_TOKEN` | `false` | Force fail-closed for the collector API in development/test |
 | `TI_ADMIN_BIND` | `127.0.0.1` | Host of the collector admin/SOAR/metrics listener |
 | `TI_SOAR_AUDIT_PATH` | `<TI_OUTPUT_DIR>/soar-audit.jsonl` | Append-only JSONL audit of SOAR actions (`0600`) |
 | `SEARCH_API_ALLOW_INSECURE` | *unset* (inherits CONTROL insecure) | Lab open search |
@@ -118,6 +117,22 @@ Other control APIs remain on plain `METRICS_PORT` with Bearer auth.
 2. With a token configured → all non-public `/api/*` need
    `Authorization: Bearer …` (constant-time compare).
 3. Without a token in open lab mode → mutations are allowed (legacy), with loud warnings.
+
+### RPZ mutations (`/api/dns/*`)
+
+Every mutation compiles straight into the zone `dns-sinkhole` serves, so:
+
+1. All mutations append to `<DNS_RPZ_STATE_DIR>/rpz-audit.jsonl` (`0600`) —
+   action, target, outcome, rule delta.
+2. `POST /api/dns/rpz/lists?dryRun=true` previews a feed (rule count, zone size
+   before/after, first 20 entries) without storing or compiling anything.
+3. A list adding more than `RPZ_CONFIRM_GROWTH_RULES` rules (default `5000`) is
+   refused with `409` until the call is repeated with `?confirm=true`. The
+   refusal is audited.
+
+A public feed pulled through `source: url_feed` is unmoderated content: preview
+it before applying it, and remember this path is **not** gated by
+`TI_ENFORCEMENT_MODE` — it is the control plane's own list, not threat-intel's.
 
 ### Cache-indexer
 

--- a/docs/threat-intelligence/Roadmap.md
+++ b/docs/threat-intelligence/Roadmap.md
@@ -10,14 +10,15 @@
 - [x] Integrate public threat feeds (`threat-intel` collector: OpenPhish, PhishStats, Phishing.Database, URLhaus — TASK-TI-001)
 - [x] Store IOC (structured SQLite persistence with WAL, migrations, indexes, and TTL expiration — TASK-TI-002)
 - [x] Normalize domains, URLs and IP addresses (canonicalization, Punycode, bogon filter — TASK-TI-003)
-- [x] Generate ACL lists (`threat_domains.json` JSON feed for proxy data-plane policies — TASK-TI-021)
+- [x] Generate ACL lists (`threat_domains.json` JSON feed — TASK-TI-021). Consumed only by the proxy shadow matcher for observation; no ACL engine reads it in any mode
 
-## Phase 2 - Scoring & RPZ Enforcement
+## Phase 2 - Scoring & RPZ artifact generation (enforcement gated by ADR 0008)
 
 - [x] Weighted confidence scoring & multi-source correlation bonus with freshness decay (TASK-TI-010)
 - [x] Automated DNS RPZ zone compilation (`threats.rpz`) with atomic rotation for `dns-sinkhole` (TASK-TI-020)
 - [x] RPZ syntax validation and zone serial management (TASK-TI-020)
-- [x] Proxy ACL and DNS blocklist integration (TASK-TI-020 & 021)
+- [x] Compilation of RPZ/ACL artifacts to disk (TASK-TI-020 & 021)
+- [ ] Consumption of `threat_domains.json` by a proxy ACL engine — not implemented
 - [x] Shadow Mode observation & false-positive evaluation (`threat_shadow_match`, `bsdm_proxy_ti_shadow_matches_total{feed}`) (ADR 0008)
 
 ## Phase 3 - Enterprise SIEM & SOAR
@@ -36,7 +37,9 @@
 ## Success Criteria
 
 - [x] Automated IOC collection and deduplication
-- [x] Measured false-positive rate per feed before any blocking (ADR 0008)
-- [x] Reliable DNS RPZ and Proxy ACL blocking
+- [x] Mechanism for measuring the per-feed false-positive rate (`threat_shadow_match`, per-feed metric — ADR 0008)
+- [ ] The measurement itself on real traffic (observation window per ADR 0008); not yet performed on any installation
+- [ ] Reliable DNS RPZ blocking — requires an explicit `TI_ENFORCEMENT_MODE=enforce` under the ADR 0008 transition criteria; not enabled in the pilot
+- [ ] Proxy ACL blocking — not implemented
 - [x] Auditable SIEM decisions and SOAR exceptions
-- [x] Integration with BSDM Proxy security controls
+- [x] Observational integration with BSDM Proxy (shadow matching, event field, per-feed metric)

--- a/docs/threat-intelligence/Roadmap.md
+++ b/docs/threat-intelligence/Roadmap.md
@@ -1,37 +1,34 @@
 # Threat Intelligence Roadmap
 
-## Phase 1 - MVP
+## Phase 1 - MVP & Ingestion
 
-- [x] Integrate public threat feeds (`threat-intel` collector: OpenPhish, PhishStats, Phishing.Database, URLhaus)
-- [ ] Store IOC (structured SQLite/ClickHouse persistence)
-- [ ] Normalize domains and URLs
-- [ ] Generate ACL lists
+- [x] Integrate public threat feeds (`threat-intel` collector: OpenPhish, PhishStats, Phishing.Database, URLhaus — TASK-TI-001)
+- [x] Store IOC (structured SQLite persistence with WAL, migrations, indexes, and TTL expiration — TASK-TI-002)
+- [x] Normalize domains, URLs and IP addresses (canonicalization, Punycode, bogon filter — TASK-TI-003)
+- [x] Generate ACL lists (`threat_domains.json` JSON feed for proxy data-plane policies — TASK-TI-021)
 
-## Phase 2 - RPZ Enforcement
+## Phase 2 - Scoring & RPZ Enforcement
 
-- [ ] RPZ generation
-- [ ] DNS integration
-- [ ] Policy validation
-- [ ] Rollback
+- [x] Weighted confidence scoring & multi-source correlation bonus with freshness decay (TASK-TI-010)
+- [x] Automated DNS RPZ zone compilation (`threats.rpz`) with atomic rotation for `dns-sinkhole` (TASK-TI-020)
+- [x] RPZ syntax validation and zone serial management (TASK-TI-020)
+- [x] Proxy ACL and DNS blocklist integration (TASK-TI-020 & 021)
 
-## Phase 3 - Enterprise
+## Phase 3 - Enterprise SIEM & SOAR
 
-- [ ] SIEM integration
-- [ ] SOAR automation
-- [ ] API service
-- [ ] Multi-tenant support
+- [x] SIEM integration with CEF, ECS JSON, and Syslog RFC 5424 serialization (TASK-TI-030)
+- [x] SOAR automated containment API (`/api/v1/soar/block`, `/api/v1/soar/unblock`, `/api/v1/soar/investigate` — TASK-TI-031)
+- [x] Real-time REST endpoints on port 8093 (`/health`, `/metrics`, `/api/v1/soar/*`, `/api/v1/ml/*`)
 
-## Phase 4 - Advanced Detection
+## Phase 4 - Advanced Detection & ML
 
-- [ ] Reputation enrichment
-- [ ] ML scoring
-- [ ] Automated false positive handling
-- [ ] Threat hunting workflows
+- [x] ML domain reputation & typosquatting / visual homoglyph engine (Damerau-Levenshtein, confusable mapping, keyword stacking — TASK-TI-040)
+- [x] Multi-source feed reputation scoring & tag multipliers (TASK-TI-010)
+- [x] End-to-end integration and lifecycle test suites (`threat-intel/tests/pipeline_test.rs`, `threat-intel/tests/soar_ml_test.rs`)
 
 ## Success Criteria
 
-- Automated IOC collection
-- Reliable blocking
-- Auditable decisions
-- Integration with BSDM Proxy security controls
-
+- [x] Automated IOC collection and deduplication
+- [x] Reliable DNS RPZ and Proxy ACL blocking
+- [x] Auditable SIEM decisions and SOAR exceptions
+- [x] Integration with BSDM Proxy security controls

--- a/packaging/config/bsdm-proxy.env.example
+++ b/packaging/config/bsdm-proxy.env.example
@@ -223,6 +223,17 @@ HIERARCHY_ENABLED=false
 # THREAT_SCORE_WARN_THRESHOLD=0.7
 # THREAT_SCORE_BLOCK_THRESHOLD=0
 
+# Threat-intel Shadow Mode (issue #330): observe-only IOC matching. The proxy
+# reads the collector's `.shadow` export, annotates threat_shadow_match on the
+# cache event and counts bsdm_proxy_ti_shadow_matches_total{feed}. It never
+# blocks — enforcement is a separate opt-in on the collector
+# (TI_ENFORCEMENT_MODE=enforce in /etc/bsdm-proxy/threat-intel.env).
+# Point TI_SHADOW_FEED_PATH at the collector's TI_OUTPUT_DIR; read-only access
+# is enough. Never point it at a non-`.shadow` artifact.
+# TI_SHADOW_MATCH_ENABLED=true
+# TI_SHADOW_FEED_PATH=/var/lib/bsdm-proxy/threat-intel/threat_domains.json.shadow
+# TI_SHADOW_RELOAD_SECS=300
+
 # Rate limiting (disabled by default)
 # RATE_LIMIT_ENABLED=true
 # RATE_LIMIT_IP_RPS=100

--- a/packaging/systemd/bsdm-threat-intel.service
+++ b/packaging/systemd/bsdm-threat-intel.service
@@ -14,7 +14,34 @@ StateDirectory=bsdm-proxy/threat-intel
 Restart=on-failure
 RestartSec=5
 LimitNOFILE=65536
+
+# Hardening. The unit holds TI_API_TOKEN in its environment and writes the SOAR
+# audit trail (0600 JSONL) under StateDirectory, so keep the blast radius small.
+# If TI_OUTPUT_DIR / TI_SOAR_AUDIT_PATH are moved outside /var/lib/bsdm-proxy,
+# add the new location to ReadWritePaths or the collector will fail to write.
 NoNewPrivileges=true
+UMask=0077
+CapabilityBoundingSet=
+AmbientCapabilities=
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectClock=true
+ProtectHostname=true
+ProtectProc=invisible
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+LockPersonality=true
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target

--- a/prometheus/alerts/ti_shadow.yml
+++ b/prometheus/alerts/ti_shadow.yml
@@ -1,0 +1,79 @@
+# Threat-intel Shadow Mode signals (issue #330).
+# Shadow is the fail-safe default: the collector writes only *.shadow artifacts
+# and the proxy observes matches without changing an allow/deny decision.
+# These rules answer two questions during a pilot: "is the observation pipeline
+# alive?" and "did anything switch to enforcement without a decision?".
+groups:
+  - name: bsdm_threat_intel_shadow
+    interval: 30s
+    rules:
+      # Observation signal. Not a block — a shadow match means the request was
+      # served and only annotated, so this is a go/no-go input, not an incident.
+      - alert: BsdmTiShadowMatchSpike
+        expr: sum(rate(bsdm_proxy_ti_shadow_matches_total[5m])) by (feed) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+          team: bsdm-m4
+          mode: shadow
+        annotations:
+          summary: "Threat-intel shadow matches elevated (feed {{ $labels.feed }})"
+          description: "{{ $value | humanize }} shadow match(es)/s over 10m from feed {{ $labels.feed }}. Traffic was NOT blocked (TI_ENFORCEMENT_MODE=shadow). Review before flipping to enforce; see docs ADR-0008."
+
+      # Enforcement must be an explicit, announced decision. A block counted
+      # with mode="enforce" while the pilot is supposed to be observe-only means
+      # someone set TI_ENFORCEMENT_MODE=enforce on the collector.
+      - alert: BsdmTiEnforcementActive
+        expr: increase(threat_intel_soar_blocks_total{mode="enforce"}[15m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: bsdm-m4
+          mode: enforce
+        annotations:
+          summary: "Threat-intel is ENFORCING (SOAR blocks reached enforcement artifacts)"
+          description: "{{ $value }} SOAR block(s) in enforce mode in 15m. If the deployment is supposed to be in Shadow Mode, TI_ENFORCEMENT_MODE was changed — traffic can now be blocked from feed data."
+
+      # SOAR mutations arriving in shadow mode are expected (202, no enforcement),
+      # but a burst is worth seeing: it is the audit-trail counterpart in metrics.
+      - alert: BsdmTiSoarBlockBurst
+        expr: increase(threat_intel_soar_blocks_total{mode="shadow"}[10m]) > 20
+        for: 5m
+        labels:
+          severity: warning
+          team: bsdm-m4
+          mode: shadow
+        annotations:
+          summary: "Burst of SOAR block requests in shadow mode"
+          description: "{{ $value }} SOAR block call(s) in 10m. Cross-check the audit trail (TI_SOAR_AUDIT_PATH) for the actor."
+
+      # A stale feed silently degrades the shadow observation to nothing.
+      - alert: BsdmTiFeedStale
+        expr: time() - max by (source) (threat_intel_last_success_timestamp_seconds) > 5400
+        for: 15m
+        labels:
+          severity: warning
+          team: bsdm-m4
+        annotations:
+          summary: "Threat-intel feed {{ $labels.source }} is stale"
+          description: "No successful collection from {{ $labels.source }} for over 90m (poll interval default 15m). Shadow observation is running on old indicators."
+
+      - alert: BsdmTiFetchErrors
+        expr: sum by (source) (increase(threat_intel_fetches_total{result!="ok"}[15m])) > 3
+        for: 10m
+        labels:
+          severity: warning
+          team: bsdm-m4
+        annotations:
+          summary: "Threat-intel feed {{ $labels.source }} failing"
+          description: "{{ $value }} failed collection cycle(s) in 15m for {{ $labels.source }}."
+
+      - alert: BsdmTiCollectorDown
+        expr: up{job="threat-intel"} == 0
+        for: 10m
+        labels:
+          severity: warning
+          team: bsdm-m4
+        annotations:
+          summary: "Threat-intel collector is not scrapable"
+          description: "Prometheus cannot scrape threat-intel:8093 for 10m. Expected when the compose profile `threat-intel` is off; otherwise the collector is down."

--- a/prometheus/alerts/ti_shadow.yml
+++ b/prometheus/alerts/ti_shadow.yml
@@ -20,19 +20,19 @@ groups:
           summary: "Threat-intel shadow matches elevated (feed {{ $labels.feed }})"
           description: "{{ $value | humanize }} shadow match(es)/s over 10m from feed {{ $labels.feed }}. Traffic was NOT blocked (TI_ENFORCEMENT_MODE=shadow). Review before flipping to enforce; see docs ADR-0008."
 
-      # Enforcement must be an explicit, announced decision. A block counted
-      # with mode="enforce" while the pilot is supposed to be observe-only means
-      # someone set TI_ENFORCEMENT_MODE=enforce on the collector.
+      # Enforcement must be an explicit, announced decision. The gauge carries the
+      # posture the collector booted with, so a silent flip to enforce is visible
+      # even on an installation where SOAR is never called.
       - alert: BsdmTiEnforcementActive
-        expr: increase(threat_intel_soar_blocks_total{mode="enforce"}[15m]) > 0
+        expr: max(threat_intel_enforcement_mode{mode="enforce"}) > 0
         for: 0m
         labels:
           severity: critical
           team: bsdm-m4
           mode: enforce
         annotations:
-          summary: "Threat-intel is ENFORCING (SOAR blocks reached enforcement artifacts)"
-          description: "{{ $value }} SOAR block(s) in enforce mode in 15m. If the deployment is supposed to be in Shadow Mode, TI_ENFORCEMENT_MODE was changed — traffic can now be blocked from feed data."
+          summary: "Threat-intel is ENFORCING (TI_ENFORCEMENT_MODE=enforce)"
+          description: "The collector reports the enforce posture, so feed data compiles into live RPZ/ACL artifacts and can block traffic. The gauge reflects the mode itself — it fires whether or not anyone calls SOAR. If this deployment is supposed to be in Shadow Mode, TI_ENFORCEMENT_MODE was changed; see ADR-0008."
 
       # SOAR mutations arriving in shadow mode are expected (202, no enforcement),
       # but a burst is worth seeing: it is the audit-trail counterpart in metrics.

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -36,6 +36,16 @@ scrape_configs:
           service: 'alert-worker'
           component: 'bsdm-alerts'
 
+  # Present when compose profile `threat-intel` is enabled (scrapes fail quietly
+  # otherwise). Carries the Shadow Mode signals: threat_intel_soar_blocks_total
+  # {mode} and feed freshness.
+  - job_name: 'threat-intel'
+    static_configs:
+      - targets: ['threat-intel:8093']
+        labels:
+          service: 'threat-intel'
+          component: 'bsdm-threat-intel'
+
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']

--- a/proxy/src/rpz_api.rs
+++ b/proxy/src/rpz_api.rs
@@ -31,11 +31,37 @@ const RPZ_AUDIT_FILE: &str = "rpz-audit.jsonl";
 /// `RPZ_CONFIRM_GROWTH_RULES`.
 const DEFAULT_CONFIRM_GROWTH_RULES: u64 = 5_000;
 
+/// Relative growth (percent of the current zone) allowed without `confirm=true`.
+///
+/// The absolute threshold alone is per-list, so a series of sub-threshold lists
+/// grows the zone without limit. Override with `RPZ_CONFIRM_GROWTH_PCT`.
+const DEFAULT_CONFIRM_GROWTH_PCT: u64 = 50;
+
 fn confirm_growth_threshold() -> u64 {
     std::env::var("RPZ_CONFIRM_GROWTH_RULES")
         .ok()
         .and_then(|v| v.trim().parse::<u64>().ok())
         .unwrap_or(DEFAULT_CONFIRM_GROWTH_RULES)
+}
+
+fn confirm_growth_pct() -> u64 {
+    std::env::var("RPZ_CONFIRM_GROWTH_PCT")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONFIRM_GROWTH_PCT)
+}
+
+/// Whether adding `added` rules to a zone of `current` needs a confirmation.
+///
+/// Two limits, because they catch different mistakes: the absolute one stops a
+/// single unmoderated feed, the relative one stops a zone from being doubled by
+/// a series of lists that each stay just under it.
+fn requires_confirmation(current: u64, added: u64, threshold: u64, growth_pct: u64) -> bool {
+    if added > threshold {
+        return true;
+    }
+    // No baseline to compare against on an empty zone; the absolute limit rules.
+    current > 0 && added.saturating_mul(100) / current > growth_pct
 }
 
 /// True when `name` is present in the query string as `name=true|1|yes`.
@@ -496,10 +522,12 @@ impl RpzApiState {
         let dry_run = query_flag(query, "dryRun");
         let confirmed = query_flag(query, "confirm");
         let threshold = confirm_growth_threshold();
+        let growth_pct = confirm_growth_pct();
         let current_rules = {
             let g = self.inner.read().await;
             Self::active_rule_count(&g)
         };
+        let needs_confirm = requires_confirmation(current_rules, rule_count, threshold, growth_pct);
         let source_label = input
             .url
             .clone()
@@ -525,7 +553,7 @@ impl RpzApiState {
                 "ruleCount": rule_count,
                 "zoneRulesBefore": current_rules,
                 "zoneRulesAfter": current_rules + rule_count,
-                "requiresConfirm": rule_count > threshold,
+                "requiresConfirm": needs_confirm,
                 "sample": content.lines().filter(|l| {
                     let l = l.trim();
                     !l.is_empty() && !l.starts_with('#') && !l.starts_with(';')
@@ -533,7 +561,7 @@ impl RpzApiState {
             }));
         }
 
-        if rule_count > threshold && !confirmed {
+        if needs_confirm && !confirmed {
             self.audit(
                 "add_list",
                 &input.name,
@@ -541,14 +569,17 @@ impl RpzApiState {
                 serde_json::json!({
                     "source": source_label,
                     "ruleCount": rule_count,
+                    "zoneRulesBefore": current_rules,
                     "threshold": threshold,
+                    "growthPct": growth_pct,
                 }),
             );
             return json_err(
                 StatusCode::CONFLICT,
                 &format!(
-                    "list adds {rule_count} rules to a zone of {current_rules} (threshold \
-                     {threshold}). Review it with ?dryRun=true, then repeat with ?confirm=true"
+                    "list adds {rule_count} rules to a zone of {current_rules} (limits: \
+                     {threshold} rules, {growth_pct}% growth). Review it with ?dryRun=true, \
+                     then repeat with ?confirm=true"
                 ),
             );
         }
@@ -1024,6 +1055,15 @@ fn percent_decode(s: &str) -> String {
 mod tests {
     use super::*;
     use http_body_util::BodyExt;
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    /// The threshold overrides below are process-global; sibling tests read
+    /// them. Async mutex because the guard spans `.await` points.
+    fn env_lock() -> &'static AsyncMutex<()> {
+        static LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| AsyncMutex::new(()))
+    }
 
     fn state_in(dir: &Path) -> RpzApiState {
         RpzApiState {
@@ -1068,6 +1108,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_dry_run_previews_the_feed_without_touching_the_zone() {
+        let _guard = env_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
         let api = state_in(dir.path());
 
@@ -1090,6 +1131,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_large_feed_needs_an_explicit_confirmation() {
+        let _guard = env_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
         let api = state_in(dir.path());
         std::env::set_var("RPZ_CONFIRM_GROWTH_RULES", "2");
@@ -1112,7 +1154,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_series_of_small_lists_cannot_grow_the_zone_unchecked() {
+        let _guard = env_lock().lock().await;
+        let dir = tempfile::tempdir().unwrap();
+        let api = state_in(dir.path());
+        // Well under the absolute limit, so only the relative one can catch it.
+        std::env::set_var("RPZ_CONFIRM_GROWTH_RULES", "1000");
+        std::env::set_var("RPZ_CONFIRM_GROWTH_PCT", "50");
+
+        // First list: an empty zone has no baseline, the absolute limit applies.
+        assert_eq!(
+            api.add_list(big_list(100), "").await.status(),
+            StatusCode::OK
+        );
+        // Second list of the same size would double the zone.
+        let refused = api.add_list(big_list(100), "").await;
+        assert_eq!(
+            refused.status(),
+            StatusCode::CONFLICT,
+            "doubling the zone must need a confirmation even below the rule limit"
+        );
+        // A small addition on top of the same zone stays unattended.
+        assert_eq!(
+            api.add_list(big_list(10), "").await.status(),
+            StatusCode::OK
+        );
+
+        std::env::remove_var("RPZ_CONFIRM_GROWTH_RULES");
+        std::env::remove_var("RPZ_CONFIRM_GROWTH_PCT");
+    }
+
+    #[tokio::test]
     async fn every_mutation_leaves_an_audit_record() {
+        let _guard = env_lock().lock().await;
         let dir = tempfile::tempdir().unwrap();
         let api = state_in(dir.path());
 

--- a/proxy/src/rpz_api.rs
+++ b/proxy/src/rpz_api.rs
@@ -21,6 +21,31 @@ use tracing::{info, warn};
 
 use crate::http_types::{full, Body};
 
+/// Mutation audit trail, relative to the RPZ state directory.
+const RPZ_AUDIT_FILE: &str = "rpz-audit.jsonl";
+
+/// Zone growth (in rules) that a single list may add without `confirm=true`.
+///
+/// A public feed can carry hundreds of thousands of domains; applying one to a
+/// live zone is not something to do by accident. Override with
+/// `RPZ_CONFIRM_GROWTH_RULES`.
+const DEFAULT_CONFIRM_GROWTH_RULES: u64 = 5_000;
+
+fn confirm_growth_threshold() -> u64 {
+    std::env::var("RPZ_CONFIRM_GROWTH_RULES")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONFIRM_GROWTH_RULES)
+}
+
+/// True when `name` is present in the query string as `name=true|1|yes`.
+fn query_flag(query: &str, name: &str) -> bool {
+    query.split('&').any(|pair| {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        k == name && matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+    })
+}
+
 fn escape_json(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
@@ -244,6 +269,54 @@ impl RpzApiState {
         state
     }
 
+    /// Appends one line to the mutation audit trail.
+    ///
+    /// Every `/api/dns/*` mutation compiles straight into the zone that
+    /// `dns-sinkhole` serves, so the trail is what makes a bad list traceable
+    /// afterwards. Best effort: a broken audit file must not block a rollback.
+    fn audit(&self, action: &str, target: &str, outcome: &str, detail: serde_json::Value) {
+        use std::io::Write as _;
+
+        let record = serde_json::json!({
+            "ts": now_rfc3339(),
+            "action": action,
+            "target": target,
+            "outcome": outcome,
+            "detail": detail,
+        });
+        let path = self.state_dir.join(RPZ_AUDIT_FILE);
+        if let Err(e) = std::fs::create_dir_all(&self.state_dir) {
+            warn!(err = %e, "rpz audit: state dir");
+            return;
+        }
+        let mut opts = std::fs::OpenOptions::new();
+        opts.create(true).append(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            opts.mode(0o600);
+        }
+        match opts.open(&path) {
+            Ok(mut f) => {
+                if let Err(e) = writeln!(f, "{record}") {
+                    warn!(err = %e, "rpz audit: write");
+                }
+            }
+            Err(e) => warn!(err = %e, path = %path.display(), "rpz audit: open"),
+        }
+    }
+
+    /// Rules the compiled zone currently carries.
+    fn active_rule_count(state: &RpzStateFile) -> u64 {
+        state
+            .lists
+            .iter()
+            .filter(|l| l.active)
+            .map(|l| l.rule_count)
+            .sum::<u64>()
+            + state.custom_rules.len() as u64
+    }
+
     async fn persist(&self, state: &RpzStateFile) -> Result<(), String> {
         std::fs::create_dir_all(&self.state_dir).map_err(|e| format!("create state dir: {e}"))?;
         std::fs::create_dir_all(self.state_dir.join("lists"))
@@ -335,7 +408,7 @@ impl RpzApiState {
         if path == "/api/dns/rpz/lists" {
             return match *method {
                 Method::GET => self.list_lists().await,
-                Method::POST => self.add_list(body).await,
+                Method::POST => self.add_list(body, query).await,
                 _ => method_not_allowed(),
             };
         }
@@ -387,7 +460,7 @@ impl RpzApiState {
         json_ok(&g.lists)
     }
 
-    async fn add_list(&self, body: Bytes) -> Response<Body> {
+    async fn add_list(&self, body: Bytes, query: &str) -> Response<Body> {
         #[derive(Deserialize)]
         struct In {
             name: String,
@@ -417,6 +490,69 @@ impl RpzApiState {
             }
         }
         let rule_count = count_rules(&content);
+
+        // A list compiles into the live zone the moment it is stored, so a
+        // large one needs either a preview or a deliberate confirmation first.
+        let dry_run = query_flag(query, "dryRun");
+        let confirmed = query_flag(query, "confirm");
+        let threshold = confirm_growth_threshold();
+        let current_rules = {
+            let g = self.inner.read().await;
+            Self::active_rule_count(&g)
+        };
+        let source_label = input
+            .url
+            .clone()
+            .unwrap_or_else(|| "inline content".to_string());
+
+        if dry_run {
+            self.audit(
+                "add_list",
+                &input.name,
+                "dry_run",
+                serde_json::json!({
+                    "source": source_label,
+                    "ruleCount": rule_count,
+                    "zoneRulesBefore": current_rules,
+                    "zoneRulesAfter": current_rules + rule_count,
+                }),
+            );
+            return json_ok(&serde_json::json!({
+                "dryRun": true,
+                "applied": false,
+                "name": input.name,
+                "source": source_label,
+                "ruleCount": rule_count,
+                "zoneRulesBefore": current_rules,
+                "zoneRulesAfter": current_rules + rule_count,
+                "requiresConfirm": rule_count > threshold,
+                "sample": content.lines().filter(|l| {
+                    let l = l.trim();
+                    !l.is_empty() && !l.starts_with('#') && !l.starts_with(';')
+                }).take(20).collect::<Vec<_>>(),
+            }));
+        }
+
+        if rule_count > threshold && !confirmed {
+            self.audit(
+                "add_list",
+                &input.name,
+                "refused_unconfirmed",
+                serde_json::json!({
+                    "source": source_label,
+                    "ruleCount": rule_count,
+                    "threshold": threshold,
+                }),
+            );
+            return json_err(
+                StatusCode::CONFLICT,
+                &format!(
+                    "list adds {rule_count} rules to a zone of {current_rules} (threshold \
+                     {threshold}). Review it with ?dryRun=true, then repeat with ?confirm=true"
+                ),
+            );
+        }
+
         let list = RpzList {
             id: id.clone(),
             name: input.name,
@@ -444,6 +580,19 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit(
+            "add_list",
+            &list.id,
+            "applied",
+            serde_json::json!({
+                "name": list.name,
+                "source": source_label,
+                "ruleCount": rule_count,
+                "zoneRulesBefore": current_rules,
+                "zoneRulesAfter": current_rules + rule_count,
+                "confirmed": confirmed,
+            }),
+        );
         json_ok(&list)
     }
 
@@ -462,9 +611,16 @@ impl RpzApiState {
         };
         list.active = input.active;
         list.last_updated = now_rfc3339();
+        let rules = list.rule_count;
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit(
+            "toggle_list",
+            id,
+            "applied",
+            serde_json::json!({"active": input.active, "ruleCount": rules}),
+        );
         json_ok(&serde_json::json!({"status":"ok"}))
     }
 
@@ -497,6 +653,20 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit(
+            "sync_list",
+            id,
+            if out.sync_error.is_some() {
+                "failed"
+            } else {
+                "applied"
+            },
+            serde_json::json!({
+                "url": out.url,
+                "ruleCount": out.rule_count,
+                "syncError": out.sync_error,
+            }),
+        );
         json_ok(&out)
     }
 
@@ -511,6 +681,7 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit("delete_list", id, "applied", serde_json::json!({}));
         json_ok(&serde_json::json!({"status":"deleted"}))
     }
 
@@ -529,6 +700,12 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit(
+            "put_config",
+            "sinkhole",
+            "applied",
+            serde_json::to_value(&cfg).unwrap_or_default(),
+        );
         json_ok(&cfg)
     }
 
@@ -645,6 +822,12 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit(
+            "add_rule",
+            &rule.id,
+            "applied",
+            serde_json::json!({"domain": rule.domain, "action": rule.action.as_api()}),
+        );
         json_ok(&rule)
     }
 
@@ -658,6 +841,7 @@ impl RpzApiState {
         if let Err(e) = self.persist(&g).await {
             return json_err(StatusCode::INTERNAL_SERVER_ERROR, &e);
         }
+        self.audit("delete_rule", id, "applied", serde_json::json!({}));
         json_ok(&serde_json::json!({"status":"deleted"}))
     }
 }
@@ -834,4 +1018,130 @@ fn percent_decode(s: &str) -> String {
         i += 1;
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    fn state_in(dir: &Path) -> RpzApiState {
+        RpzApiState {
+            inner: RwLock::new(RpzStateFile {
+                lists: Vec::new(),
+                custom_rules: Vec::new(),
+                config: DnsSinkholeConfig::default(),
+            }),
+            state_dir: dir.to_path_buf(),
+            zone_path: dir.join("compiled.rpz"),
+            reload_url: None,
+        }
+    }
+
+    /// A list body large enough to trip the confirmation threshold.
+    fn big_list(rules: usize) -> Bytes {
+        let content: String = (0..rules)
+            .map(|i| format!("bad{i}.example\n"))
+            .collect::<String>();
+        Bytes::from(
+            serde_json::json!({
+                "name": "public feed",
+                "description": "unmoderated",
+                "source": "url_feed",
+                "format": "domain-list",
+                "url": "https://feed.example/list.txt",
+                "content": content,
+                "defaultAction": "NXDOMAIN",
+            })
+            .to_string(),
+        )
+    }
+
+    fn audit_lines(dir: &Path) -> Vec<serde_json::Value> {
+        std::fs::read_to_string(dir.join(RPZ_AUDIT_FILE))
+            .unwrap_or_default()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("audit line is JSON"))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn a_dry_run_previews_the_feed_without_touching_the_zone() {
+        let dir = tempfile::tempdir().unwrap();
+        let api = state_in(dir.path());
+
+        let resp = api.add_list(big_list(3), "dryRun=true").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["applied"], serde_json::json!(false));
+        assert_eq!(json["ruleCount"], serde_json::json!(3));
+        assert_eq!(json["zoneRulesAfter"], serde_json::json!(3));
+        assert_eq!(json["sample"].as_array().unwrap().len(), 3);
+        assert!(
+            !dir.path().join("compiled.rpz").exists(),
+            "a preview must not compile a zone"
+        );
+        assert!(api.inner.read().await.lists.is_empty());
+        assert_eq!(audit_lines(dir.path())[0]["outcome"], "dry_run");
+    }
+
+    #[tokio::test]
+    async fn a_large_feed_needs_an_explicit_confirmation() {
+        let dir = tempfile::tempdir().unwrap();
+        let api = state_in(dir.path());
+        std::env::set_var("RPZ_CONFIRM_GROWTH_RULES", "2");
+
+        let refused = api.add_list(big_list(5), "").await;
+        assert_eq!(refused.status(), StatusCode::CONFLICT);
+        assert!(api.inner.read().await.lists.is_empty());
+
+        let applied = api.add_list(big_list(5), "confirm=true").await;
+        assert_eq!(applied.status(), StatusCode::OK);
+        assert_eq!(api.inner.read().await.lists.len(), 1);
+
+        std::env::remove_var("RPZ_CONFIRM_GROWTH_RULES");
+
+        let outcomes: Vec<String> = audit_lines(dir.path())
+            .iter()
+            .map(|l| l["outcome"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(outcomes, vec!["refused_unconfirmed", "applied"]);
+    }
+
+    #[tokio::test]
+    async fn every_mutation_leaves_an_audit_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let api = state_in(dir.path());
+
+        let resp = api.add_list(big_list(1), "").await;
+        let body = BodyExt::collect(resp.into_body()).await.unwrap().to_bytes();
+        let list: RpzList = serde_json::from_slice(&body).unwrap();
+
+        api.toggle_list(&list.id, Bytes::from(r#"{"active":false}"#))
+            .await;
+        api.delete_list(&list.id).await;
+
+        let actions: Vec<String> = audit_lines(dir.path())
+            .iter()
+            .map(|l| l["action"].as_str().unwrap_or_default().to_string())
+            .collect();
+        assert_eq!(actions, vec!["add_list", "toggle_list", "delete_list"]);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(dir.path().join(RPZ_AUDIT_FILE))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "audit trail must not be world-readable"
+            );
+        }
+    }
 }

--- a/proxy/src/ti_shadow.rs
+++ b/proxy/src/ti_shadow.rs
@@ -81,6 +81,26 @@ pub struct TiShadowMatcher {
     domains: RwLock<HashMap<String, String>>,
 }
 
+/// Folds a feed name to a bounded set of label values.
+///
+/// SOAR sources embed a caller-supplied operator (`soar:<operator>`), which
+/// would otherwise open one new metric series per block request.
+fn normalize_feed_label(raw: Option<&str>) -> String {
+    match raw {
+        Some(feed) if feed.starts_with("soar:") => "soar".to_string(),
+        Some(feed)
+            if !feed.is_empty()
+                && feed.len() <= 32
+                && feed
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-') =>
+        {
+            feed.to_string()
+        }
+        _ => UNKNOWN_FEED.to_string(),
+    }
+}
+
 impl TiShadowMatcher {
     /// Builds the matcher and performs the initial load. A missing file is not
     /// an error: the collector may not have produced an export yet.
@@ -156,12 +176,10 @@ impl TiShadowMatcher {
             if key.is_empty() {
                 continue;
             }
-            let feed = parsed
-                .feeds
-                .get(&domain)
-                .map(String::as_str)
-                .unwrap_or(UNKNOWN_FEED)
-                .to_string();
+            // `feed` becomes a Prometheus label and a ClickHouse LowCardinality
+            // value. A SOAR block carries an operator-controlled `soar:<operator>`
+            // source, so anything unbounded is folded before it reaches either.
+            let feed = normalize_feed_label(parsed.feeds.get(&domain).map(String::as_str));
             table.insert(key, feed);
         }
 
@@ -364,6 +382,154 @@ mod tests {
         let m = matcher();
         assert!(m.load_from_str("{not json", None).is_err());
         assert_eq!(m.len(), 2);
+    }
+
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    fn clear_shadow_env() {
+        for var in [
+            "TI_SHADOW_MATCH_ENABLED",
+            "TI_SHADOW_FEED_PATH",
+            "TI_SHADOW_RELOAD_SECS",
+        ] {
+            std::env::remove_var(var);
+        }
+    }
+
+    #[test]
+    fn feed_label_is_folded_to_a_bounded_set() {
+        // An operator-controlled SOAR source collapses to a single series.
+        assert_eq!(normalize_feed_label(Some("soar:alice")), "soar");
+        assert_eq!(normalize_feed_label(Some("soar:")), "soar");
+        // Known feed names survive verbatim.
+        assert_eq!(normalize_feed_label(Some("openphish")), "openphish");
+        assert_eq!(
+            normalize_feed_label(Some("phishing-database")),
+            "phishing-database"
+        );
+        // Anything unbounded, empty or non-ASCII falls back to the default label.
+        assert_eq!(normalize_feed_label(Some(&"x".repeat(33))), UNKNOWN_FEED);
+        assert_eq!(normalize_feed_label(Some("feed with spaces")), UNKNOWN_FEED);
+        assert_eq!(normalize_feed_label(Some("")), UNKNOWN_FEED);
+        assert_eq!(normalize_feed_label(None), UNKNOWN_FEED);
+    }
+
+    #[test]
+    fn shadow_config_from_env_parses_toggle_path_and_reload_floor() {
+        let _guard = env_lock().lock().unwrap();
+        clear_shadow_env();
+
+        let default = TiShadowConfig::from_env();
+        assert!(default.enabled, "observation is on by default");
+        assert_eq!(default.feed_path, PathBuf::from(DEFAULT_FEED_PATH));
+        assert_eq!(
+            default.reload_interval,
+            Duration::from_secs(DEFAULT_RELOAD_SECS)
+        );
+
+        // Only explicit off-values disable observation.
+        for raw in ["0", "false", "No", " OFF "] {
+            std::env::set_var("TI_SHADOW_MATCH_ENABLED", raw);
+            assert!(!TiShadowConfig::from_env().enabled, "raw = {raw}");
+        }
+        // Anything unrecognised keeps observing; shadow never blocks, so the
+        // safe fallback here is "keep collecting evidence".
+        for raw in ["maybe", "true", ""] {
+            std::env::set_var("TI_SHADOW_MATCH_ENABLED", raw);
+            assert!(TiShadowConfig::from_env().enabled, "raw = {raw}");
+        }
+
+        // Reload interval: floored at 10s, garbage falls back to the default.
+        std::env::set_var("TI_SHADOW_RELOAD_SECS", "1");
+        assert_eq!(
+            TiShadowConfig::from_env().reload_interval,
+            Duration::from_secs(10)
+        );
+        std::env::set_var("TI_SHADOW_RELOAD_SECS", "not-a-number");
+        assert_eq!(
+            TiShadowConfig::from_env().reload_interval,
+            Duration::from_secs(DEFAULT_RELOAD_SECS)
+        );
+
+        std::env::set_var("TI_SHADOW_FEED_PATH", "/var/tmp/custom.json.shadow");
+        assert_eq!(
+            TiShadowConfig::from_env().feed_path,
+            PathBuf::from("/var/tmp/custom.json.shadow")
+        );
+
+        clear_shadow_env();
+    }
+
+    #[test]
+    fn reload_reads_disk_and_a_non_shadow_export_still_only_annotates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("threat_domains.json.shadow");
+        // Export mislabelled as `enforce`: the proxy must still treat it as
+        // observation only and leave the decision the ACL engine made intact.
+        std::fs::write(
+            &path,
+            r#"{"mode":"enforce","domains":["c2.example.test"],"feeds":{"c2.example.test":"urlhaus"}}"#,
+        )
+        .unwrap();
+
+        let m = TiShadowMatcher {
+            config: TiShadowConfig {
+                enabled: true,
+                feed_path: path,
+                reload_interval: Duration::from_secs(300),
+            },
+            domains: RwLock::new(HashMap::new()),
+        };
+        assert_eq!(m.reload().unwrap(), 1);
+
+        let metrics = Metrics::new().unwrap();
+        let mut event = event("node.c2.example.test");
+        event.acl_action = Some("allow".into());
+        event.acl_rule_id = Some("rule-7".into());
+        annotate_shadow_match(&m, &metrics, &mut event);
+
+        assert_eq!(event.threat_shadow_match.as_deref(), Some("urlhaus"));
+        // Zero change to the allow/deny path.
+        assert_eq!(event.acl_action.as_deref(), Some("allow"));
+        assert_eq!(event.acl_rule_id.as_deref(), Some("rule-7"));
+        assert_eq!(event.status, 200);
+    }
+
+    #[test]
+    fn missing_feed_file_is_not_fatal_and_matcher_stays_inert() {
+        let m = TiShadowMatcher {
+            config: TiShadowConfig {
+                enabled: true,
+                feed_path: PathBuf::from("/nonexistent/threat_domains.json.shadow"),
+                reload_interval: Duration::from_secs(300),
+            },
+            domains: RwLock::new(HashMap::new()),
+        };
+        assert!(m.reload().is_err());
+        assert!(m.is_empty());
+        assert!(m.match_domain("evil-phish.com").is_none());
+    }
+
+    #[test]
+    fn existing_annotation_is_neither_overwritten_nor_double_counted() {
+        let m = matcher();
+        let metrics = Metrics::new().unwrap();
+
+        let mut event = event("evil-phish.com");
+        event.threat_shadow_match = Some("preset-feed".into());
+        annotate_shadow_match(&m, &metrics, &mut event);
+
+        assert_eq!(event.threat_shadow_match.as_deref(), Some("preset-feed"));
+        assert_eq!(
+            metrics
+                .ti_shadow_matches_total
+                .with_label_values(&["urlhaus"])
+                .get(),
+            0.0
+        );
     }
 
     #[test]

--- a/scripts/ci/check-shadow-defaults.sh
+++ b/scripts/ci/check-shadow-defaults.sh
@@ -47,7 +47,7 @@ check "packaging env example ships TI_ENFORCEMENT_MODE=shadow" \
 check "no deployment file hardcodes enforce as a default" \
   not grep -rInE '^[^#]*TI_ENFORCEMENT_MODE[=:][[:space:]]*"?enforce' \
     --exclude="check-shadow-defaults.sh" \
-    Dockerfile docker-compose.yml deploy charts packaging config scripts
+    Dockerfile docker-compose.yml docker-compose.override.yml deploy charts packaging config scripts
 
 check "proxy reads the observe-only .shadow artifact (compose)" \
   grep -qE 'TI_SHADOW_FEED_PATH=.*\.shadow' docker-compose.yml
@@ -64,7 +64,7 @@ check "admin/SOAR port 8093 is not published to the host" \
 check "no deployment file enables TI_API_ALLOW_INSECURE" \
   not grep -rInE '^[^#]*TI_API_ALLOW_INSECURE[=:][[:space:]]*"?(1|true|yes)' \
     --exclude="check-shadow-defaults.sh" \
-    Dockerfile docker-compose.yml deploy charts packaging config scripts
+    Dockerfile docker-compose.yml docker-compose.override.yml deploy charts packaging config scripts
 
 check "threat-intel scrape job exists so shadow metrics are collected" \
   grep -q "job_name: 'threat-intel'" prometheus/prometheus.yml

--- a/scripts/ci/check-shadow-defaults.sh
+++ b/scripts/ci/check-shadow-defaults.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Regression gate for the fail-safe Threat-Intel Shadow Mode (issue #330).
+#
+# The Rust tests pin the *code* default (threat-intel/src/config.rs). Nothing
+# stopped a deployment default from drifting: one `TI_ENFORCEMENT_MODE=enforce`
+# in docker-compose.yml or `enforcementMode: enforce` in values.yaml and a pilot
+# starts blocking traffic from feed data without a decision. This gate fails the
+# build on that drift and on the neighbouring safety properties: the observe-only
+# `.shadow` artifact path, the read-only mount into the proxy, and the admin/SOAR
+# API not being published to the host.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fail=0
+check() {
+  local description="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf '  ok   %s\n' "$description"
+  else
+    printf '  FAIL %s\n' "$description" >&2
+    fail=1
+  fi
+}
+
+not() { ! "$@"; }
+
+printf '\n==> Threat-intel Shadow Mode defaults\n'
+
+check "Dockerfile threat-intel stage defaults to shadow" \
+  grep -qE '^\s*TI_ENFORCEMENT_MODE=shadow' Dockerfile
+
+check "docker-compose.yml defaults TI_ENFORCEMENT_MODE to shadow" \
+  grep -qE 'TI_ENFORCEMENT_MODE=\$\{TI_ENFORCEMENT_MODE:-shadow\}' docker-compose.yml
+
+check "helm values default enforcementMode to shadow" \
+  grep -qE '^\s*enforcementMode:\s*shadow\s*$' charts/bsdm/values.yaml
+
+check "helm template falls back to shadow when the value is empty" \
+  grep -qE 'enforcementMode \| default "shadow"' charts/bsdm/templates/threat-intel-deployment.yaml
+
+check "packaging env example ships TI_ENFORCEMENT_MODE=shadow" \
+  grep -qE '^TI_ENFORCEMENT_MODE=shadow$' packaging/config/threat-intel.env.example
+
+check "no deployment file hardcodes enforce as a default" \
+  not grep -rInE '^[^#]*TI_ENFORCEMENT_MODE[=:][[:space:]]*"?enforce' \
+    --exclude="check-shadow-defaults.sh" \
+    Dockerfile docker-compose.yml deploy charts packaging config scripts
+
+check "proxy reads the observe-only .shadow artifact (compose)" \
+  grep -qE 'TI_SHADOW_FEED_PATH=.*\.shadow' docker-compose.yml
+
+check "proxy reads the observe-only .shadow artifact (env reference)" \
+  grep -qE '^TI_SHADOW_FEED_PATH=.*\.shadow$' bsdm-proxy.env
+
+check "threat-intel snapshots are mounted read-only into the proxy" \
+  grep -qE 'threat-intel-data:/var/lib/bsdm-proxy/threat-intel:ro' docker-compose.yml
+
+check "admin/SOAR port 8093 is not published to the host" \
+  not grep -rInE '^[^#]*"[0-9]+:8093"' docker-compose.yml docker-compose.override.yml deploy 2>/dev/null
+
+check "no deployment file enables TI_API_ALLOW_INSECURE" \
+  not grep -rInE '^[^#]*TI_API_ALLOW_INSECURE[=:][[:space:]]*"?(1|true|yes)' \
+    --exclude="check-shadow-defaults.sh" \
+    Dockerfile docker-compose.yml deploy charts packaging config scripts
+
+check "threat-intel scrape job exists so shadow metrics are collected" \
+  grep -q "job_name: 'threat-intel'" prometheus/prometheus.yml
+
+check "an alert fires when threat-intel starts enforcing" \
+  grep -q 'BsdmTiEnforcementActive' prometheus/alerts/ti_shadow.yml
+
+if (( fail )); then
+  cat >&2 <<'MSG'
+
+Shadow Mode defaults regressed. Enforcement must stay an explicit, per-deployment
+opt-in (TI_ENFORCEMENT_MODE=enforce set by the operator), never a shipped default.
+See docs ADR-0008 and issue #330.
+MSG
+  exit 1
+fi
+
+printf 'Shadow Mode defaults intact.\n'

--- a/scripts/ci/run.sh
+++ b/scripts/ci/run.sh
@@ -207,6 +207,11 @@ package() {
   )
 }
 
+shadow_defaults() {
+  log "Threat-intel Shadow Mode deployment defaults"
+  ./scripts/ci/check-shadow-defaults.sh
+}
+
 preflight() {
   require_commands bash git python3 cargo rustc node npm
   local rust_version rust_major rust_minor node_major
@@ -229,6 +234,7 @@ preflight() {
   node --version
   npm --version
   python3 --version
+  shadow_defaults
 }
 
 usage() {
@@ -236,7 +242,8 @@ usage() {
 Usage: scripts/ci/run.sh <task>
 
 Tasks:
-  preflight          Check the base CI toolchain
+  preflight          Check the base CI toolchain and deployment safety defaults
+  shadow-defaults    Assert threat-intel Shadow Mode stays the shipped default
   rust-all           Run the complete Rust quality gate
   rust-ca            Run the offline CA rotation drill
   rust-fmt           Check rustfmt
@@ -262,6 +269,7 @@ EOF
 task="${1:-}"
 case "$task" in
   preflight) preflight ;;
+  shadow-defaults) shadow_defaults ;;
   rust-all) rust_all ;;
   rust-ca) rust_ca ;;
   rust-fmt) rust_fmt ;;

--- a/threat-intel/src/api_auth.rs
+++ b/threat-intel/src/api_auth.rs
@@ -37,15 +37,6 @@ fn env_flag(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn is_production_profile() -> bool {
-    std::env::var("DEPLOYMENT_PROFILE")
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            v.is_empty() || v == "production" || v == "prod"
-        })
-        .unwrap_or(true)
-}
-
 /// Auth posture of the collector admin API.
 #[derive(Debug, Clone)]
 pub struct AdminApiSecurity {
@@ -61,15 +52,12 @@ impl AdminApiSecurity {
             .ok()
             .map(|t| t.trim().to_string())
             .filter(|t| !t.is_empty());
-        // Explicit lab override; never set it on a pilot network.
+        // Explicit lab override; never set it on a pilot network. It is the only
+        // way to open the mutating endpoints: the posture deliberately ignores
+        // DEPLOYMENT_PROFILE, which other services flip for unrelated reasons and
+        // which would otherwise silently unauthenticate SOAR mutations.
         let allow_insecure = env_flag("TI_API_ALLOW_INSECURE");
-        let fail_closed = if allow_insecure {
-            false
-        } else if is_production_profile() {
-            true
-        } else {
-            env_flag("TI_API_REQUIRE_TOKEN")
-        };
+        let fail_closed = !allow_insecure;
         let bind_host = std::env::var("TI_ADMIN_BIND").unwrap_or_else(|_| DEFAULT_BIND.to_string());
         let audit_path = std::env::var("TI_SOAR_AUDIT_PATH")
             .map(PathBuf::from)

--- a/threat-intel/src/collector.rs
+++ b/threat-intel/src/collector.rs
@@ -249,7 +249,13 @@ impl Collector {
         let rpz_path = self.config.rpz_artifact_path();
         let acl_path = self.config.acl_artifact_path();
 
-        match storage.list_active_domain_sources(self.config.min_confidence_score, 100_000) {
+        // Enforcement artifacts never inherit indicators that SOAR accepted while
+        // shadow mode was in force (ADR 0008 §4).
+        match storage.list_active_domain_sources(
+            self.config.min_confidence_score,
+            100_000,
+            mode.is_enforce(),
+        ) {
             Ok(pairs) => {
                 let domains: Vec<String> = pairs.iter().map(|(d, _)| d.clone()).collect();
                 let feeds: std::collections::BTreeMap<String, String> = pairs.into_iter().collect();

--- a/threat-intel/src/config.rs
+++ b/threat-intel/src/config.rs
@@ -282,6 +282,80 @@ mod tests {
         }
     }
 
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    /// Loads a `Config` from a clean `TI_*` environment with the given raw
+    /// `TI_ENFORCEMENT_MODE` value (`None` = variable unset).
+    fn config_from_env_with_mode(raw: Option<&str>) -> Config {
+        for var in [
+            "TI_SOURCES",
+            "TI_SQLITE_PATH",
+            "TI_RPZ_OUTPUT_PATH",
+            "TI_ACL_EXPORT_PATH",
+        ] {
+            std::env::remove_var(var);
+        }
+        std::env::set_var("TI_OUTPUT_DIR", "/tmp/ti-env-test");
+        match raw {
+            Some(value) => std::env::set_var("TI_ENFORCEMENT_MODE", value),
+            None => std::env::remove_var("TI_ENFORCEMENT_MODE"),
+        }
+        let config = Config::from_env().expect("config must load");
+        std::env::remove_var("TI_ENFORCEMENT_MODE");
+        std::env::remove_var("TI_OUTPUT_DIR");
+        config
+    }
+
+    #[test]
+    fn from_env_gates_enforcement_on_the_exact_value() {
+        let _guard = env_lock().lock().unwrap();
+
+        // Variable unset: fail-safe shadow, both artifacts suffixed.
+        let unset = config_from_env_with_mode(None);
+        assert_eq!(unset.enforcement_mode, EnforcementMode::Shadow);
+        assert_eq!(
+            unset.rpz_artifact_path(),
+            PathBuf::from("/tmp/ti-env-test/threats.rpz.shadow")
+        );
+        assert_eq!(
+            unset.acl_artifact_path(),
+            PathBuf::from("/tmp/ti-env-test/threat_domains.json.shadow")
+        );
+
+        // Garbage and truthy-looking values must never reach enforcement.
+        for raw in ["true", "1", "yes", "block", "enforced", "ENFORCE!", "  "] {
+            let config = config_from_env_with_mode(Some(raw));
+            assert_eq!(
+                config.enforcement_mode,
+                EnforcementMode::Shadow,
+                "raw = {raw}"
+            );
+            assert!(
+                config
+                    .rpz_artifact_path()
+                    .to_string_lossy()
+                    .ends_with(SHADOW_SUFFIX),
+                "raw = {raw} must keep the RPZ zone unloadable"
+            );
+            assert!(
+                config
+                    .acl_artifact_path()
+                    .to_string_lossy()
+                    .ends_with(SHADOW_SUFFIX),
+                "raw = {raw} must keep the ACL feed unloadable"
+            );
+        }
+
+        // Only the explicit opt-in flips to enforceable artifact paths.
+        let enforced = config_from_env_with_mode(Some(" ENFORCE "));
+        assert!(enforced.enforcement_mode.is_enforce());
+        assert_eq!(enforced.rpz_artifact_path(), enforced.rpz_output_path);
+        assert_eq!(enforced.acl_artifact_path(), enforced.acl_export_path);
+    }
+
     #[test]
     fn shadow_mode_suffixes_enforcement_artifacts() {
         let mut config = config();

--- a/threat-intel/src/main.rs
+++ b/threat-intel/src/main.rs
@@ -53,6 +53,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     let metrics = CollectorMetrics::new()?;
+    // Publish the posture itself, so a monitor can tell "observing" from
+    // "enforcing" without waiting for someone to call SOAR (ADR 0008).
+    for mode in [EnforcementMode::Shadow, EnforcementMode::Enforce] {
+        metrics
+            .enforcement_mode
+            .with_label_values(&[mode.as_str()])
+            .set(i64::from(mode == config.enforcement_mode));
+    }
 
     let storage = if config.storage_enabled {
         let st = SqliteStorage::new(&config.sqlite_path)?;

--- a/threat-intel/src/metrics.rs
+++ b/threat-intel/src/metrics.rs
@@ -27,6 +27,8 @@ pub struct CollectorMetrics {
     pub purged_expired: prometheus::IntCounter,
     /// Number of domains exported to the RPZ zone file.
     pub rpz_records: prometheus::IntGauge,
+    /// `mode` label carries `shadow`/`enforce`; exactly one series is 1.
+    pub enforcement_mode: IntGaugeVec,
     /// SOAR block actions by enforcement mode (`shadow`, `enforce`).
     pub soar_blocks: IntCounterVec,
 }
@@ -103,6 +105,16 @@ impl CollectorMetrics {
             "threat_intel_rpz_records_total",
             "Number of domains compiled into the DNS RPZ zone",
         )?;
+        // A gauge rather than a counter: the question a monitor has to answer is
+        // "is this installation enforcing right now", which no amount of block
+        // counters can express — an enforcing collector nobody calls stays at 0.
+        let enforcement_mode = prometheus::IntGaugeVec::new(
+            Opts::new(
+                "threat_intel_enforcement_mode",
+                "1 for the active enforcement mode, 0 for the others (ADR 0008)",
+            ),
+            &["mode"],
+        )?;
         let soar_blocks = IntCounterVec::new(
             Opts::new(
                 "threat_intel_soar_blocks_total",
@@ -123,6 +135,7 @@ impl CollectorMetrics {
         registry.register(Box::new(purged_expired.clone()))?;
         registry.register(Box::new(rpz_records.clone()))?;
         registry.register(Box::new(soar_blocks.clone()))?;
+        registry.register(Box::new(enforcement_mode.clone()))?;
 
         Ok(Arc::new(Self {
             registry,
@@ -138,6 +151,7 @@ impl CollectorMetrics {
             purged_expired,
             rpz_records,
             soar_blocks,
+            enforcement_mode,
         }))
     }
 

--- a/threat-intel/src/normalizer.rs
+++ b/threat-intel/src/normalizer.rs
@@ -111,11 +111,9 @@ pub fn normalize_url(raw: &str) -> Option<(String, String)> {
         return None;
     }
 
-    let is_prefixed = trimmed.len() >= 7 && {
-        let prefix = &trimmed[..7.min(trimmed.len())].to_ascii_lowercase();
-        prefix.starts_with("http://")
-            || (trimmed.len() >= 8 && trimmed[..8].to_ascii_lowercase().starts_with("https://"))
-    };
+    // Byte-index slicing would panic on a multibyte indicator submitted through SOAR.
+    let lowered = trimmed.to_ascii_lowercase();
+    let is_prefixed = lowered.starts_with("http://") || lowered.starts_with("https://");
 
     let to_parse = if !is_prefixed {
         format!("http://{trimmed}")

--- a/threat-intel/src/rpz.rs
+++ b/threat-intel/src/rpz.rs
@@ -36,6 +36,12 @@ impl Default for RpzConfig {
     }
 }
 
+/// Owner name of the record that marks a zone as an observe-only artifact.
+///
+/// `dns-sinkhole` treats a zone carrying it as unloadable — see
+/// `dns-sinkhole/src/zone.rs`.
+pub const SHADOW_MARKER_NAME: &str = "_bsdm-enforcement-mode";
+
 /// Generates a valid BIND / RPZ zone file content from a list of domain names.
 pub fn generate_rpz_zone(domains: &[String], config: &RpzConfig) -> String {
     let now = Utc::now();
@@ -51,10 +57,15 @@ pub fn generate_rpz_zone(domains: &[String], config: &RpzConfig) -> String {
     ));
     out.push_str(&format!("@ IN NS {}\n\n", config.primary_ns));
     if config.shadow_mode {
+        // The comment is for humans; a zone parser drops it. The TXT record below
+        // is the machine-readable half — `dns-sinkhole` refuses to load a zone
+        // carrying it, so the shadow artifact cannot become enforcement by way of
+        // someone repointing DNS_SINKHOLE_ZONE_PATH (ADR 0008).
         out.push_str(
             "; SHADOW MODE (TI_ENFORCEMENT_MODE=shadow): observe-only artifact.\n\
              ; Do NOT load this zone into dns-sinkhole; it blocks nothing by design.\n",
         );
+        out.push_str(&format!("{SHADOW_MARKER_NAME} IN TXT \"shadow\"\n"));
     }
     out.push_str("; Active Threat Intelligence RPZ Rules\n");
 
@@ -145,6 +156,26 @@ pub fn export_proxy_acl_feed(
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_shadow_zone_carries_the_machine_readable_marker() {
+        let domains = vec!["phish.test".to_string()];
+        let shadow = generate_rpz_zone(&domains, &RpzConfig::default());
+        assert!(
+            shadow.contains(&format!("{SHADOW_MARKER_NAME} IN TXT \"shadow\"")),
+            "dns-sinkhole refuses a zone by this record; without it the banner is \
+             just a comment that any parser drops:\n{shadow}"
+        );
+
+        let enforce = generate_rpz_zone(
+            &domains,
+            &RpzConfig {
+                shadow_mode: false,
+                ..RpzConfig::default()
+            },
+        );
+        assert!(!enforce.contains(SHADOW_MARKER_NAME));
+    }
     use super::*;
 
     #[test]

--- a/threat-intel/src/soar.rs
+++ b/threat-intel/src/soar.rs
@@ -64,7 +64,9 @@ pub fn execute_soar_block(
     req: SoarBlockRequest,
     mode: EnforcementMode,
 ) -> Result<SoarActionResponse, StorageError> {
-    let ttl_secs = req.ttl_secs.unwrap_or(86400 * 30); // Default 30 days
+    // Default 30 days; clamped so a client-supplied TTL cannot overflow the
+    // expiry timestamp or expire the indicator on insert.
+    let ttl_secs = req.ttl_secs.unwrap_or(86400 * 30).clamp(60, 86400 * 365);
     let mut tags = vec!["soar_blocked".to_string(), "manual_containment".to_string()];
     if !mode.is_enforce() {
         tags.push("shadow".to_string());

--- a/threat-intel/src/storage.rs
+++ b/threat-intel/src/storage.rs
@@ -162,7 +162,7 @@ impl SqliteStorage {
 
         let now = Utc::now();
         let now_ts = now.timestamp();
-        let expires_ts = now_ts + ttl_secs;
+        let expires_ts = now_ts.saturating_add(ttl_secs);
 
         for ind in indicators {
             if ind.is_private_or_bogon {
@@ -319,10 +319,17 @@ impl SqliteStorage {
 
     /// Active domains paired with the feed that reported them with the highest
     /// confidence. Used to label shadow matches per feed downstream.
+    ///
+    /// `exclude_shadow` drops indicators tagged `shadow` — those accepted by
+    /// SOAR while `TI_ENFORCEMENT_MODE=shadow` was in force. They are recorded
+    /// for observation only, so they must never turn into blocking rules just
+    /// because the mode was later flipped to `enforce` (ADR 0008 §4): promoting
+    /// them takes a deliberate re-submission under `enforce`.
     pub fn list_active_domain_sources(
         &self,
         min_confidence: u8,
         limit: usize,
+        exclude_shadow: bool,
     ) -> Result<Vec<(String, String)>, StorageError> {
         let conn = self.conn.lock().map_err(|_| StorageError::Poisoned)?;
         let now_ts = Utc::now().timestamp();
@@ -335,6 +342,7 @@ impl SqliteStorage {
               AND domain != ''
               AND expires_at > ?1
               AND confidence_score >= ?2
+              AND (?4 = 0 OR tags NOT LIKE '%"shadow"%')
             GROUP BY domain
             HAVING confidence_score = MAX(confidence_score)
             ORDER BY MAX(confidence_score) DESC, COUNT(*) DESC
@@ -342,9 +350,11 @@ impl SqliteStorage {
             "#,
         )?;
 
-        let rows = stmt.query_map(params![now_ts, min_confidence, limit as i64], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?;
+        let exclude_shadow = i64::from(exclude_shadow);
+        let rows = stmt.query_map(
+            params![now_ts, min_confidence, limit as i64, exclude_shadow],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )?;
 
         let mut pairs = Vec::new();
         for pair in rows {
@@ -544,13 +554,47 @@ mod tests {
         let active = storage.list_active(80, None, 10).unwrap();
         assert_eq!(active.len(), 2);
 
-        let pairs = storage.list_active_domain_sources(80, 10).unwrap();
+        let pairs = storage.list_active_domain_sources(80, 10, false).unwrap();
         assert_eq!(pairs.len(), 2);
         let domains: Vec<&str> = pairs.iter().map(|(d, _)| d.as_str()).collect();
         assert!(domains.contains(&"phish.test.org"));
         assert!(domains.contains(&"sub.victim.net"));
         // Every exported domain carries the feed that reported it.
         assert!(pairs.iter().all(|(_, source)| !source.is_empty()));
+    }
+
+    #[test]
+    fn shadow_tagged_indicators_never_reach_the_enforcement_export() {
+        let storage = SqliteStorage::in_memory().unwrap();
+
+        let feed_raw = RawIndicator::new("feed-threat.test", IndicatorKind::Domain, &TestFeed);
+        let mut soar_raw = RawIndicator::new("soar-shadow.test", IndicatorKind::Domain, &TestFeed);
+        // Exactly what execute_soar_block records while the mode is shadow.
+        soar_raw.source = "soar:operator-1".to_string();
+        soar_raw.tags = vec![
+            "soar_blocked".to_string(),
+            "manual_containment".to_string(),
+            "shadow".to_string(),
+        ];
+
+        let norm_feed = NormalizedIndicator::from_raw(&feed_raw, 90).unwrap();
+        let norm_soar = NormalizedIndicator::from_raw(&soar_raw, 100).unwrap();
+        storage.upsert_batch(&[norm_feed, norm_soar], 3600).unwrap();
+
+        // Shadow artifact: the operator must see what they submitted.
+        let observed = storage.list_active_domain_sources(0, 10, false).unwrap();
+        let observed: Vec<&str> = observed.iter().map(|(d, _)| d.as_str()).collect();
+        assert!(observed.contains(&"soar-shadow.test"));
+        assert!(observed.contains(&"feed-threat.test"));
+
+        // Enforcement artifact: flipping the mode must not promote it silently.
+        let enforced = storage.list_active_domain_sources(0, 10, true).unwrap();
+        let enforced: Vec<&str> = enforced.iter().map(|(d, _)| d.as_str()).collect();
+        assert!(
+            !enforced.contains(&"soar-shadow.test"),
+            "an indicator accepted in shadow mode leaked into the enforcement export: {enforced:?}"
+        );
+        assert!(enforced.contains(&"feed-threat.test"));
     }
 
     #[test]


### PR DESCRIPTION
Верификация влитого fail-safe Shadow Mode (#330, [ADR 0008](docs/adr/0008-threat-intel-shadow-mode.md)) перед пилотом. Сам гейт на стороне producer'а оказался корректным — `TI_ENFORCEMENT_MODE` парсится по allowlist, мусор падает в `shadow`, тест проверяет **отсутствие** артефакта. Обходы нашлись вокруг него.

## Обходы enforcement

1. **SOAR-индикаторы, принятые в shadow, промотировались при первом же переключении режима.** Тег `shadow` вешался, но `list_active_domain_sources` его не читал — накопленный за 30-дневный TTL «наблюдения» объём разом уезжал в `threats.rpz`. Экспорт для enforce теперь их пропускает; промоушен требует повторной подачи под `enforce`. ADR 0008 §4 приведён в соответствие — там утверждалось обратное.
2. **`dns-sinkhole` грузил что угодно из `DNS_SINKHOLE_ZONE_PATH`**, а баннер `; Do NOT load this zone` парсер выбрасывает как комментарий. Коллектор пишет машинный маркер `_bsdm-enforcement-mode IN TXT "shadow"`; sinkhole отвергает такую зону и любой путь с суффиксом `.shadow` — по имени, до чтения файла. На старте это жёсткая ошибка, а не откат на fallback: иначе неверный путь маскировался бы.
3. **Control-plane RPZ API — второй путь в ту же зону, мимо `TI_ENFORCEMENT_MODE`.** Один `POST /api/dns/rpz/lists` с `source=url_feed` затягивал немодерированный публичный фид в hot-reload зону без аудита и предпросмотра. Добавлены: JSONL-аудит мутаций (`0600`), `?dryRun=true`, порог `RPZ_CONFIRM_GROWTH_RULES` (5000) с требованием `?confirm=true`.
4. **Fail-closed для SOAR зависел от общего `DEPLOYMENT_PROFILE`** — любое не-production значение открывало мутации без токена, а эту переменную переключают ещё пять сервисов. Теперь открывает только `TI_API_ALLOW_INSECURE`; `TI_API_REQUIRE_TOKEN` удалена.

## Устойчивость

`soar:<operator>` (контролируется вызывающим) попадал неограниченным в метку Prometheus и `LowCardinality` ClickHouse — свёрнут к фиксированному набору. `normalize_url` паниковал на многобайтном индикаторе (срез по байтовому индексу). `ttl_secs` клампится, expiry — `saturating_add`.

## Поставка

Джобы скрейпа threat-intel не было вообще — добавлена, плюс 6 алертов, включая `BsdmTiEnforcementActive` на несогласованный переход в enforce. Токен в Helm — из Secret вместо plaintext values, NetworkPolicy на 8093, хардненинг systemd-юнита. `scripts/ci/check-shadow-defaults.sh` (13 проверок, подключён в `preflight()` и `Jenkinsfile.local`) не даёт дефолту поставки регрессировать — Rust-тесты пиннят дефолт в коде, но не в compose/values.

## Документация

Roadmap больше не заявляет «Reliable DNS RPZ and Proxy ACL blocking» и измеренный FP rate (механизм есть, измерения не было), страница коллектора — «live» зоны и «containment» в настоящем времени. В таблице переменных значилась несуществующая `TI_API_KEY` вместо `TI_API_TOKEN`.

## Проверки

```
cargo fmt --all -- --check                                        → OK
cargo clippy --workspace --all-targets --all-features -D warnings → 0 warnings
threat-intel + dns-sinkhole                                       → 139 passed, 0 failed
bsdm-proxy --lib                                                  → 304 passed, 0 failed
scripts/ci/check-shadow-defaults.sh                               → 13/13 ok
```

## Требует решения владельца (в этот PR не входит)

- **Helm-чарт пинит `tag: "0.6.1-1"`** при `appVersion: 0.9.13` — это сборка до #330: без `api_auth.rs`, `TI_ENFORCEMENT_MODE` и `TI_ADMIN_BIND` игнорируются. Нужно знать, что реально опубликовано в GHCR; `bsdm-threat-intel` вообще не собирается ни одним пайплайном.
- **Shadow-матчинг в Kubernetes не работает**: коллектор пишет `.shadow` в RWO PVC, proxy его не читает, метрика всегда 0 — go/no-go засчитает этот ноль как «шума нет». Выбор: sidecar с общим emptyDir, RWX-том или HTTP-раздача фида.
- **FP-критерий смещён**: shadow видит только HTTP через прокси, enforcement режет весь DNS; «< 1% от матчей» считает события, а не уникальные домены — один CDN топит три матча по критичному домену.

Отдельно, не из этого дифа: `cargo test -p bsdm-proxy --lib` уходит в респавн через `schedule_service_restart` → `current_exe()` (`proxy/src/runtime_config.rs:217`), поэтому прогон выше сделан с `--skip config_apply_writes_env_and_schedules_restart`.

Closes #330, closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)