### PR TITLE
fix(packaging): generate SEARCH_API_TOKEN for cache-indexer install

### DIFF
--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -106,6 +106,9 @@ if [[ ! -f "${ETC_DIR}/bsdm-proxy.env" ]]; then
 fi
 if [[ ! -f "${ETC_DIR}/cache-indexer.env" ]]; then
   install -m 0640 "${SCRIPT_DIR}/config/cache-indexer.env.example" "${ETC_DIR}/cache-indexer.env"
+  echo "" >> "${ETC_DIR}/cache-indexer.env"
+  echo "# Security and API Control" >> "${ETC_DIR}/cache-indexer.env"
+  echo "SEARCH_API_TOKEN=$(openssl rand -hex 16)" >> "${ETC_DIR}/cache-indexer.env"
   echo "Installed ${ETC_DIR}/cache-indexer.env"
 fi
 if [[ ! -f "${ETC_DIR}/alert-worker.env" ]]; then


### PR DESCRIPTION
## Summary

`packaging/install.sh` generated `CONTROL_API_TOKEN` and `ACL_API_TOKEN` into `bsdm-proxy.env`, but never generated `SEARCH_API_TOKEN`. A tarball install with the Search API enabled therefore left `cache-indexer` unable to start under the production profile — `cache-indexer/src/main.rs:80-99` returns a hard error (`"SEARCH_API_TOKEN is required when SEARCH_API_ENABLED in production"`) unless `SEARCH_API_ALLOW_INSECURE=true`.

This adds the token generation, mirroring the existing `bsdm-proxy.env` block.

The token is written to **`cache-indexer.env`**, not `bsdm-proxy.env`: it is consumed by `cache-indexer/src/search_api.rs:19`. The proxy's same-origin Search reverse proxy (`proxy/src/search_proxy.rs`) forwards the client's `Authorization` header upstream and needs no token of its own, so putting it in the proxy env would not have fixed anything.

`packaging/config/cache-indexer.env.example` already carries a commented `# SEARCH_API_TOKEN=` placeholder; the generated value is appended below it and wins at load time.

## Related Issues

None.

## Testing

The change touches only a shell script, so the Rust suites are unaffected and were not run:

```bash
bash -n packaging/install.sh
```

Not exercised: a full end-to-end tarball install against a running `cache-indexer`.

## Checklist

- [ ] CI is green
- [x] Documentation updated (if behavior or env vars changed) — no doc change needed; `SEARCH_API_TOKEN` is already documented in `docs/ops-and-dev/control-plane-security.md` and `docs/getting-started/pilot-deployment.md`, this only makes the installer match that contract
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — not applicable, no maturity change

🤖 Generated with [Claude Code](https://claude.com/claude-code)