### PR TITLE
chore(proxy,deploy): вычистить остатки порта 1488

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Purged leftover port 1488** — remnants of the old default proxy port: the
+  `OIDC_REDIRECT_URI` fallback (`proxy/src/reverse_proxy.rs`) is now
+  `http://localhost:3128/-/callback`, the cache hierarchy demo
+  (`deploy/compose/docker-compose.hierarchy.yml`) listens on 3128 / 3228 / 3328
+  instead of 1488 / 1489 / 1490, and unit-test fixtures use 3128.
+
 - **MITM circuit breaker: bounded state and O(1) lookup** (#340) — the per-domain
   tracker map is now capped by `MITM_CIRCUIT_BREAKER_MAX_DOMAINS` (default 10000)
   with least-recently-used eviction of closed trackers, so a client looping

--- a/deploy/compose/docker-compose.hierarchy.yml
+++ b/deploy/compose/docker-compose.hierarchy.yml
@@ -6,13 +6,13 @@ name: bsdm-proxy
 #
 # Usage:
 #   docker compose -f deploy/compose/docker-compose.hierarchy.yml up -d --build
-#   curl -x http://127.0.0.1:1488 http://upstream/get
+#   curl -x http://127.0.0.1:3128 http://upstream/get
 #   docker compose -f deploy/compose/docker-compose.hierarchy.yml down
 #
 # Ports:
-#   child proxy   1488 (HTTP), 9090 (metrics), 3130 (ICP UDP)
-#   parent proxy  1489 (HTTP), 9091 (metrics), 3131 (ICP UDP)
-#   sibling proxy 1490 (HTTP), 9092 (metrics), 3132 (ICP UDP)
+#   child proxy   3128 (HTTP), 9090 (metrics), 3130 (ICP UDP)
+#   parent proxy  3228 (HTTP), 9091 (metrics), 3131 (ICP UDP)
+#   sibling proxy 3328 (HTTP), 9092 (metrics), 3132 (ICP UDP)
 
 services:
   upstream:
@@ -26,11 +26,11 @@ services:
       dockerfile: Dockerfile
       target: proxy
     ports:
-      - "1489:1488"
+      - "3228:3128"
       - "9091:9090"
       - "3131:3130/udp"
     environment:
-      - HTTP_PORT=1488
+      - HTTP_PORT=3128
       - METRICS_PORT=9090
       - MITM_ENABLED=false
       - AUTH_ENABLED=false
@@ -57,11 +57,11 @@ services:
       dockerfile: Dockerfile
       target: proxy
     ports:
-      - "1490:1488"
+      - "3328:3128"
       - "9092:9090"
       - "3132:3130/udp"
     environment:
-      - HTTP_PORT=1488
+      - HTTP_PORT=3128
       - METRICS_PORT=9090
       - MITM_ENABLED=false
       - AUTH_ENABLED=false
@@ -88,10 +88,10 @@ services:
       dockerfile: Dockerfile
       target: proxy
     ports:
-      - "1488:1488"
+      - "3128:3128"
       - "9090:9090"
     environment:
-      - HTTP_PORT=1488
+      - HTTP_PORT=3128
       - METRICS_PORT=9090
       - MITM_ENABLED=false
       - AUTH_ENABLED=false
@@ -99,8 +99,8 @@ services:
       - CATEGORIZATION_ENABLED=false
       - HIERARCHY_ENABLED=true
       - ICP_SERVER_ENABLED=false
-      - CACHE_PARENTS=proxy-parent:1488:1.0
-      - CACHE_SIBLINGS=proxy-sibling:1488:1.0:3130
+      - CACHE_PARENTS=proxy-parent:3128:1.0
+      - CACHE_SIBLINGS=proxy-sibling:3128:1.0:3130
       - ICP_CLIENT_BIND=0.0.0.0:0
       - ICP_TIMEOUT_MS=200
       - PARENT_TIMEOUT_SECONDS=5

--- a/docs/ops-and-dev/development.md
+++ b/docs/ops-and-dev/development.md
@@ -257,7 +257,7 @@ curl -x http://127.0.0.1:3128 http://upstream/get
 docker compose -f deploy/compose/docker-compose.hierarchy.yml down
 ```
 
-3-tier stack: **child** (3128) → **sibling** (ICP, 1490) / **parent** (1489) → **upstream**.
+3-tier stack: **child** (3128) → **sibling** (ICP, 3328) / **parent** (3228) → **upstream**.
 
 ### Redis L2 demo (Docker)
 

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -1966,7 +1966,7 @@ mod tests {
         registry
             .add_peer(PeerConfig {
                 host: "10.0.0.1".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Parent,
                 weight: 1.0,
                 icp_port: None,

--- a/proxy/src/hierarchy.rs
+++ b/proxy/src/hierarchy.rs
@@ -473,7 +473,7 @@ mod tests {
         // Add parent
         let parent_config = PeerConfig {
             host: "parent.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight: 1.0,
             icp_port: None,
@@ -494,7 +494,7 @@ mod tests {
 
         let peer_config = PeerConfig {
             host: "test.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight: 1.0,
             icp_port: None,

--- a/proxy/src/hierarchy_config.rs
+++ b/proxy/src/hierarchy_config.rs
@@ -310,10 +310,10 @@ mod tests {
 
     #[test]
     fn parse_parents_list() {
-        let peers = parse_peer_list("127.0.0.1:1488:1.5", PeerType::Parent, None);
+        let peers = parse_peer_list("127.0.0.1:3128:1.5", PeerType::Parent, None);
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0].host, "127.0.0.1");
-        assert_eq!(peers[0].port, 1488);
+        assert_eq!(peers[0].port, 3128);
         assert!((peers[0].weight - 1.5).abs() < f64::EPSILON);
     }
 
@@ -324,7 +324,7 @@ mod tests {
         let path = dir.path().join("peers.json");
         std::fs::write(
             &path,
-            r#"{"parents":["127.0.0.1:1488:1.5"],"siblings":["10.0.0.2:1488"]}"#,
+            r#"{"parents":["127.0.0.1:3128:1.5"],"siblings":["10.0.0.2:3128"]}"#,
         )
         .unwrap();
         std::env::set_var("CACHE_PEERS_PATH", path.to_str().unwrap());
@@ -339,7 +339,7 @@ mod tests {
         registry
             .add_peer(PeerConfig {
                 host: "10.0.0.1".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Parent,
                 weight: 1.0,
                 icp_port: None,
@@ -349,7 +349,7 @@ mod tests {
         registry
             .upsert_sibling(PeerConfig {
                 host: "10.0.0.9".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Sibling,
                 weight: 1.0,
                 icp_port: Some(3130),
@@ -357,7 +357,7 @@ mod tests {
             })
             .await;
 
-        std::fs::write(&path, r#"{"parents":["10.0.0.2:1488:2.0"],"siblings":[]}"#).unwrap();
+        std::fs::write(&path, r#"{"parents":["10.0.0.2:3128:2.0"],"siblings":[]}"#).unwrap();
         let report = reload_static_peers(&registry, false).await.unwrap();
         std::env::remove_var("CACHE_PEERS_PATH");
         assert_eq!(report.source, PeerConfigSource::File);
@@ -371,13 +371,13 @@ mod tests {
 
     #[test]
     fn parse_siblings_get_default_icp_port() {
-        let peers = parse_peer_list("10.0.0.2:1488", PeerType::Sibling, Some(3130));
+        let peers = parse_peer_list("10.0.0.2:3128", PeerType::Sibling, Some(3130));
         assert_eq!(peers[0].icp_port, Some(3130));
     }
 
     #[test]
     fn parse_siblings_with_explicit_icp_port() {
-        let peers = parse_peer_list("10.0.0.2:1488:1.0:3140", PeerType::Sibling, Some(3130));
+        let peers = parse_peer_list("10.0.0.2:3128:1.0:3140", PeerType::Sibling, Some(3130));
         assert_eq!(peers[0].icp_port, Some(3140));
     }
 

--- a/proxy/src/peer_discovery.rs
+++ b/proxy/src/peer_discovery.rs
@@ -199,7 +199,7 @@ mod tests {
         let announcement = PeerAnnouncement {
             node_id: "node-1".to_string(),
             host: "10.0.0.5".to_string(),
-            http_port: 1488,
+            http_port: 3128,
             icp_port: 3130,
             weight: 1.0,
             digest_b64: None,
@@ -207,6 +207,6 @@ mod tests {
         let json = serde_json::to_string(&announcement).unwrap();
         let decoded: PeerAnnouncement = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.node_id, "node-1");
-        assert_eq!(decoded.http_port, 1488);
+        assert_eq!(decoded.http_port, 3128);
     }
 }

--- a/proxy/src/peers.rs
+++ b/proxy/src/peers.rs
@@ -406,7 +406,7 @@ mod tests {
     async fn test_peer_creation() {
         let config = PeerConfig {
             host: "parent.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight: 1.0,
             icp_port: Some(3130),
@@ -415,7 +415,7 @@ mod tests {
 
         let peer = CachePeer::new(config);
         assert_eq!(peer.config.host, "parent.example.com");
-        assert_eq!(peer.config.port, 1488);
+        assert_eq!(peer.config.port, 3128);
         assert!(peer.is_healthy());
     }
 
@@ -423,7 +423,7 @@ mod tests {
     async fn test_peer_stats() {
         let config = PeerConfig {
             host: "test.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight: 1.0,
             icp_port: None,
@@ -449,7 +449,7 @@ mod tests {
 
         let config1 = PeerConfig {
             host: "parent1.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight: 1.0,
             icp_port: None,
@@ -458,7 +458,7 @@ mod tests {
 
         let config2 = PeerConfig {
             host: "sibling1.example.com".to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Sibling,
             weight: 0.5,
             icp_port: Some(3130),
@@ -484,7 +484,7 @@ mod tests {
         registry
             .add_peer(PeerConfig {
                 host: "parent.example.com".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Parent,
                 weight: 1.0,
                 icp_port: None,
@@ -494,7 +494,7 @@ mod tests {
         registry
             .upsert_sibling(PeerConfig {
                 host: "discovered.example.com".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Sibling,
                 weight: 1.0,
                 icp_port: Some(3130),
@@ -506,7 +506,7 @@ mod tests {
         let stats = registry
             .replace_static_peers(vec![PeerConfig {
                 host: "parent2.example.com".into(),
-                port: 1488,
+                port: 3128,
                 peer_type: PeerType::Parent,
                 weight: 1.0,
                 icp_port: None,
@@ -517,22 +517,22 @@ mod tests {
         assert_eq!(stats.added, 1);
         assert_eq!(stats.preserved_discovery, 1);
         assert_eq!(registry.all_peers().await.len(), 2);
-        assert!(registry.is_static("parent:parent2.example.com:1488").await);
+        assert!(registry.is_static("parent:parent2.example.com:3128").await);
         assert!(
             !registry
-                .is_static("sibling:discovered.example.com:1488")
+                .is_static("sibling:discovered.example.com:3128")
                 .await
         );
     }
 
     #[test]
     fn test_peer_config_parse() {
-        let result = PeerConfig::parse_from_string("parent.example.com:1488:1.5", PeerType::Parent);
+        let result = PeerConfig::parse_from_string("parent.example.com:3128:1.5", PeerType::Parent);
         assert!(result.is_ok());
 
         let config = result.unwrap();
         assert_eq!(config.host, "parent.example.com");
-        assert_eq!(config.port, 1488);
+        assert_eq!(config.port, 3128);
         assert_eq!(config.weight, 1.5);
     }
 }

--- a/proxy/src/reverse_proxy.rs
+++ b/proxy/src/reverse_proxy.rs
@@ -24,7 +24,7 @@ impl OidcConfig {
         let client_secret = env::var("OIDC_CLIENT_SECRET").ok()?;
         let issuer_url = env::var("OIDC_ISSUER_URL").ok()?;
         let redirect_uri = env::var("OIDC_REDIRECT_URI")
-            .unwrap_or_else(|_| "http://localhost:1488/-/callback".to_string());
+            .unwrap_or_else(|_| "http://localhost:3128/-/callback".to_string());
 
         Some(Self {
             client_id,
@@ -376,7 +376,7 @@ mod tests {
                 client_id: "test-client".to_string(),
                 client_secret: "secret".to_string(),
                 issuer_url: "http://idp.example.com".to_string(),
-                redirect_uri: "http://localhost:1488/-/callback".to_string(),
+                redirect_uri: "http://localhost:3128/-/callback".to_string(),
             }),
             admin_group: None,
             sessions: RwLock::new(HashMap::new()),

--- a/proxy/src/selection.rs
+++ b/proxy/src/selection.rs
@@ -189,7 +189,7 @@ mod tests {
     fn create_test_peer(host: &str, weight: f64, rtt_ms: u64) -> Arc<CachePeer> {
         let config = PeerConfig {
             host: host.to_string(),
-            port: 1488,
+            port: 3128,
             peer_type: PeerType::Parent,
             weight,
             icp_port: None,

--- a/proxy/src/tls.rs
+++ b/proxy/src/tls.rs
@@ -66,7 +66,7 @@ fn evict_oldest<V>(cache: &mut HashMap<Arc<str>, V>, max: usize, stamp: impl Fn(
         .iter()
         .map(|(key, value)| (stamp(value), key.clone()))
         .collect();
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|(stamp, _)| *stamp);
     for (_, key) in entries {
         if cache.len() <= target {
             break;


### PR DESCRIPTION
## Summary

Порт `1488` был дефолтным портом прокси и давно заменён на `3128`
(`docs/roadmap.md`, CHANGELOG для 0.9.x), но хвосты остались в коде, стенде
и доках. Помимо неудачного выбора самого числа, два из них были фактическими
расхождениями с документацией:

- дефолт `OIDC_REDIRECT_URI` в `proxy/src/reverse_proxy.rs` всё ещё указывал на
  `http://localhost:1488/-/callback`, хотя CHANGELOG утверждал, что редирект
  переведён на 3128;
- `deploy/compose/docker-compose.hierarchy.yml` поднимал child на 1488, а
  `docs/ops-and-dev/development.md` описывал тот же стенд как 3128.

Что изменено:

- **`proxy/src/reverse_proxy.rs`** — дефолт `OIDC_REDIRECT_URI` →
  `http://localhost:3128/-/callback` (плюс соответствующий тест).
- **`deploy/compose/docker-compose.hierarchy.yml`** — `HTTP_PORT=3128` внутри
  всех трёх контейнеров, хостовые порты **3128 / 3228 / 3328**
  (child / parent / sibling) вместо 1488 / 1489 / 1490. Взяты 3228/3328, а не
  3129/3130, чтобы не путались с ICP UDP 3130–3132. Обновлены шапка с usage,
  `CACHE_PARENTS` и `CACHE_SIBLINGS`.
- **`docs/ops-and-dev/development.md`** — порты 3-tier стенда приведены к compose.
- **Фикстуры юнит-тестов** (`peers.rs`, `hierarchy.rs`, `hierarchy_config.rs`,
  `selection.rs`, `peer_discovery.rs`, `control_api.rs`) — 1488 → 3128.
- **`proxy/src/tls.rs`** — попутно `evict_oldest` переведён на `sort_by_key`.
  Это единственный `clippy::unnecessary_sort_by`, из-за которого `make lint`
  (clippy с `-D warnings`) падал на `main` ещё до этой ветки.

Исторические упоминания 1488 в `CHANGELOG.md` и `docs/roadmap.md` оставлены
намеренно: там документируется сам переход на 3128.

## Related Issues

<!-- Link related issues with Closes #NN -->

Нет связанного issue.

## Testing

```bash
cargo test --workspace
cargo clippy --workspace --all-targets -- -D warnings
```

Локальный Jenkins, джоба `bsdm-proxy (branches)`, сборка #1 — **SUCCESS**:
quality gate (semgrep 0 findings, gitleaks — 652 коммита, no leaks,
`cargo audit` без новых advisory), Format & lint, Build, Test, Feature gates
(`grpc`, `wasm`).

## Checklist

- [x] CI is green
- [x] Documentation updated (if behavior or env vars changed)
- [ ] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — не требуется, переход на 3128 там уже отмечен выполненным

🤖 Generated with [Claude Code](https://claude.com/claude-code)
