### PR TITLE
docs(security): CIS Benchmark configuration analysis

### DIFF
--- a/docs/security/cis-benchmark-analysis-2026-08.md
+++ b/docs/security/cis-benchmark-analysis-2026-08.md
@@ -1,0 +1,76 @@
+# Анализ конфигураций по CIS Benchmarks (2026-08-27)
+
+Статический аудит конфигураций репозитория по применимым CIS Benchmarks:
+
+| Бенчмарк | Область | Файлы |
+|---|---|---|
+| CIS Docker Benchmark v1.6/1.7 (разделы 4, 5) | Образы и рантайм контейнеров | `Dockerfile`, `proxy/Dockerfile`, `cache-indexer/Dockerfile`, `docker-compose.yml`, `deploy/compose/*` |
+| CIS Kubernetes Benchmark v1.9 (раздел 5 Policies) + Pod Security Standards | Helm-чарт | `charts/bsdm/**` |
+| CIS NGINX Benchmark | Reverse-proxy для Search API | `config/search-cors.nginx.conf` |
+| CIS Distribution Independent Linux (элементы) | Установка, systemd, CA, секреты | `packaging/**`, `scripts/installer/**`, `scripts/*.sh`, `bsdm-proxy.env` |
+
+Инструменты (`trivy`, `hadolint`, `kube-score`, `checkov`, `helm`, `nginx -t`, `systemd-analyze security`)
+в среде аудита недоступны — анализ выполнен ручным чтением файлов. Изменения в конфигурации
+не вносились; документ фиксирует находки.
+
+## Сводная статистика
+
+| Область | PASS | FAIL | WARN | N/A |
+|---|---|---|---|---|
+| Docker (Dockerfile + compose) | 8 | 10 | 5 | 0 |
+| Kubernetes (Helm-чарт) | 17 | 10 | 14 | 3 |
+| NGINX | 0 | 15 | 8 | 1 |
+| Linux / установка / systemd | 24* | 14 | 12 | 0 |
+
+\* включая 3 PARTIAL PASS.
+
+Соответствие Pod Security Standards: `baseline` — да, `restricted` — **нет** (блокирует отсутствие `seccompProfile`).
+
+---
+
+## Критические и высокоприоритетные находки (сводный топ)
+
+1. **[CRITICAL] `SYS_MODULE` у amneziawg** — `deploy/compose/docker-compose.awg.yml:24-26`. Возможность загрузки модулей ядра = эквивалент root на хосте, у стороннего `:latest`-образа с UDP-портом наружу. Убрать capability, грузить модуль на хосте; оставить только `NET_ADMIN` + `cap_drop: [ALL]`.
+2. **[HIGH] `Authorization` по plaintext HTTP на 0.0.0.0** — `config/search-cors.nginx.conf:3,22`. Токен Search API уходит открытым текстом. TLS либо `listen 127.0.0.1:80`.
+3. **[HIGH] CORS reflect-any-Origin + credentials** — `search-cors.nginx.conf:8,11,25,26`. Любой сайт в браузере оператора читает Search API от его имени. Whitelist через `map`.
+4. **[HIGH] Fail-open дефолты control-plane в compose** — `docker-compose.yml:115-119,133-136,195`, `deploy/compose/docker-compose.lite.yml:31`: `MITM_ENABLED=true` при `AUTH_ENABLED=false`, `ACL_DEFAULT_ACTION=allow`, `*_ALLOW_INSECURE=true`, порт 9090 на всех интерфейсах. Эталонный `bsdm-proxy.env` задаёт безопасные значения — привести compose к нему.
+5. **[HIGH] Секреты в ConfigMap** — `charts/bsdm/templates/indexer-configmap.yaml:24-26` (`SEARCH_API_TOKEN`), `configmap-env.yaml:39-41` (`PHISHTANK_API_KEY`). Перенести в Secret + `secretKeyRef`.
+6. **[HIGH] Plaintext-fallback секретов в PodSpec** — `indexer-deployment.yaml:49-52` (пароль ClickHouse), `threat-intel-deployment.yaml:55-59` (SOAR-токен). Оставить только ветки `existingSecret`, иначе `fail`.
+7. **[HIGH] `automountServiceAccountToken` не отключён** — все 6 podSpec + `serviceaccount.yaml`. RBAC пустой, K8s API компонентам не нужен; токен в поде MITM-прокси — готовая цепочка эскалации. Выставить `false`.
+8. **[HIGH] Нет `seccompProfile: RuntimeDefault`** — `charts/bsdm/values.yaml:28-38`. В restricted-namespace admission отклонит все 6 Deployment'ов.
+9. **[HIGH] `no-new-privileges` и `cap_drop: [ALL]` отсутствуют во всех compose-сервисах** (CIS 5.25/5.3). Для `dns-sinkhole` понадобится `cap_add: [NET_BIND_SERVICE]` (bind :53 под uid 1000).
+10. **[HIGH] Пять systemd-юнитов из шести без hardening** — `packaging/systemd/bsdm-{proxy,cache-indexer,alert-worker,ml-worker}.service`, `packaging/agent/systemd/bsdm-agent.service` содержат только `User=` и `NoNewPrivileges=`. Эталонный блок (13/13 директив) уже есть в `bsdm-threat-intel.service:22-44` — скопировать с поправкой на `ReadWritePaths` и capabilities для eBPF у proxy.
+11. **[HIGH] Инъекция в unit-файл через `--prefix`** — `packaging/install.sh:140-142`: невалидированный `PREFIX` подставляется `sed`-ом в systemd-юнит, исполняемый root. Валидатор `validate_install_path()` уже существует в `scripts/installer/common.sh` — вызвать его.
+12. **[HIGH] `curl | sudo bash` без подписи артефактов** — `scripts/install-binaries.sh:6`; SHA-256 проверяется (:106-114), но с того же хоста, подписи (cosign/GPG) нет.
+13. **[HIGH] Root-контейнеры в legacy Dockerfile** — `proxy/Dockerfile`, `cache-indexer/Dockerfile`: нет `USER`, нет `HEALTHCHECK`; дублируют unified `Dockerfile`. Лучше удалить.
+
+## Средний приоритет
+
+- **Docker**: memory-лимит отсутствует у `alertmanager` и во всех `deploy/compose/*`; CPU-лимиты только в `pilot.yml`, не в базовом compose; `pids_limit` нигде; `read_only: true` нигде (для bsdm-сервисов внедряется дёшево — пишущие пути уже в томах); базовые образы не пиннуты по digest (`rust:alpine` вообще без версии; `:latest` у ICAP/AWG/httpbin/GHCR); чувствительные порты (ClickHouse 8123/9000 без пароля, Kafka 9092 PLAINTEXT, Grafana admin/admin :3000, Prometheus с `--web.enable-lifecycle`, Redis без пароля) опубликованы на 0.0.0.0 — привязать к 127.0.0.1.
+- **Kubernetes**: NetworkPolicy выключена по умолчанию и покрывает только proxy/threat-intel (indexer/alert-worker/ml-worker/dns-sinkhole открыты любому поду кластера); нет default-deny; egress :53 разрешён куда угодно (DNS-эксфильтрация); ingress `ipBlock 10.0.0.0/8` включает pod CIDR; баг: `networkpolicy.yaml:27` игнорирует `networkPolicy.monitoringNamespace` (захардкожен `monitoring`).
+- **NGINX**: нет `server_tokens off`, лимитов и таймаутов (`client_*_timeout`, `proxy_*_timeout`, `limit_req`), security-заголовков (XFO, nosniff, CSP, Referrer-Policy), ограничения методов; `Vary: Origin` отсутствует в preflight-ветке.
+- **Linux/установка**: гонка прав при генерации MITM CA (`installer/common.sh:139-146`, `install-binaries.sh:136-143` — нет `umask 077` до `openssl`, в отличие от эталонного `gen-ca.sh:30`); 10-летний CA без passphrase и без `pathlen:0`/keyUsage-ограничений; CA в `/certs` (вне FHS); несолёный SHA-256 для паролей + пароль в argv (`gen-basic-auth-user.sh`); токены агента в argv установщиков (`packaging/agent/install-linux.sh:43-44`, fleet); `EnvironmentFile=-` (silent-fail → старт на встроенных дефолтах); fail-open дефолты `ACL_DEFAULT_ACTION=allow`, `ICAP_FAIL_OPEN=true` в `bsdm-proxy.env`; `HTCP_BIND`/`DOH_BIND`/`DOT_BIND` на 0.0.0.0.
+
+## Что уже хорошо
+
+- Unified `Dockerfile`: non-root `USER bsdm`, минимальный рантайм, `COPY` вместо `ADD`, `HEALTHCHECK` на всех стадиях, нет секретов, нет docker.sock-маунтов, нет `privileged`/`pid: host`, выделенные bridge-сети, нет привилегированных хост-портов.
+- Helm-чарт проходит PSS `baseline`: `runAsNonRoot`, `drop: [ALL]`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem`, resources у всех, только ClusterIP, probes/PDB/HPA, нет hostPath, mitm-секрет монтируется файлом с `0440`.
+- `scripts/gen-ca.sh` / `rotate-ca.sh` — образцовые: `umask 077`, `chmod 600`, проверка прав ключа перед использованием, атомарная ротация с rollback, валидация CN.
+- `bsdm-threat-intel.service` — полный systemd-hardening (эталон для остальных юнитов).
+- Секреты не закоммичены; установщики используют `set -euo pipefail`, `mktemp`+`trap`, не печатают секреты, не перезатирают существующие.
+
+## Рекомендуемые CI-гейты
+
+Находки выше ловятся автоматически; в пайплайне их сейчас нет:
+
+- `hadolint` для Dockerfile; `trivy config` для compose/Helm (IaC);
+- `trivy image --exit-code 1 --severity HIGH,CRITICAL` + SBOM + подпись образов (cosign) — закрывает CIS 4.11;
+- запрет-паттерны в CI: `privileged`, `docker.sock`, `cap_add: SYS_*` (регресс с `SYS_MODULE` прошёл ревью незамеченным);
+- `helm template | kube-score` / `checkov` для чарта.
+
+---
+
+Подробные потабличные результаты по каждой проверке (ID CIS, статус, файл:строка,
+доказательство, рекомендация) зафиксированы в сессии аудита; данный документ — сводка
+для приоритизации. Исправления предлагается вносить отдельными PR по областям
+(compose-hardening, chart-hardening, systemd-hardening, nginx, installer).


### PR DESCRIPTION
## Summary

Статический аудит конфигураций репозитория по применимым CIS Benchmarks: CIS Docker Benchmark v1.6/1.7 (Dockerfile, docker-compose, `deploy/compose/*`), CIS Kubernetes Benchmark v1.9 + Pod Security Standards (`charts/bsdm`), CIS NGINX Benchmark (`config/search-cors.nginx.conf`), элементы CIS Distribution Independent Linux (packaging, systemd, installer-скрипты, CA-генерация, секреты).

Добавлен сводный отчёт `docs/security/cis-benchmark-analysis-2026-08.md` с приоритизированными находками. Ключевое:

- **[CRITICAL]** `cap_add: SYS_MODULE` у amneziawg-контейнера (`deploy/compose/docker-compose.awg.yml`) — эквивалент root на хосте.
- **[HIGH]** `Authorization` по plaintext HTTP + reflect-any-Origin CORS с credentials в nginx-конфиге Search API.
- **[HIGH]** Секреты в ConfigMap и plaintext-fallback'и в Helm-чарте; нет `seccompProfile` (чарт не проходит PSS restricted); `automountServiceAccountToken` не отключён.
- **[HIGH]** Fail-open дефолты compose (`AUTH_ENABLED=false` при MITM, `*_ALLOW_INSECURE=true`); нет `no-new-privileges`/`cap_drop` ни в одном сервисе.
- **[HIGH]** 5 из 6 systemd-юнитов без hardening (эталон уже есть — `bsdm-threat-intel.service`); инъекция в unit-файл через невалидированный `--prefix`; `curl | sudo bash` без подписи артефактов.

Отчёт только документирует находки — конфигурации не изменялись. Исправления предлагается вносить отдельными PR по областям.

## Related Issues

- Closes #

## Testing

Docs-only change; проверок кода не требуется.

```bash
# n/a — добавлен только markdown-отчёт
```

## Checklist

- [ ] CI is green
- [x] Documentation updated (if behavior or env vars changed)
- [ ] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrMyn2CamQNV1LACw4cSso

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrMyn2CamQNV1LACw4cSso)_