### PR TITLE
ci(security): pin third-party actions and harden SARIF upload

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -23,9 +23,9 @@ runs:
           protobuf-compiler
 
     - name: Set up Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       with:
         components: ${{ inputs.components }}
 
     - name: Cache Cargo dependencies
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run cargo-audit
-        uses: rustsec/audit-check@v2.0.0
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,12 @@
 name: "Security Scanning (Clippy & Trivy)"
 
+# ВАЖНО: CodeQL здесь НЕ запускается.
+# Для репозитория включён CodeQL default setup (Settings -> Code security),
+# а GitHub отклоняет SARIF от advanced-конфигурации, пока default setup активен
+# ("CodeQL analyses from advanced configurations cannot be processed when the
+# default setup is enabled"). Этот workflow добавляет только свои категории:
+# /tool:clippy и /tool:trivy.
+
 on:
   push:
     branches: [ "main" ]
@@ -34,11 +41,15 @@ jobs:
 
       - name: Run Clippy and Generate SARIF
         run: |
-          cargo clippy --all-targets --all-features --message-format=json | clippy-sarif | tee rust-clippy.sarif | sarif-fmt || true
+          set -o pipefail
+          cargo clippy --all-targets --all-features --message-format=json \
+            | clippy-sarif > rust-clippy.sarif
+          sarif-fmt < rust-clippy.sarif
 
+      # Загружаем SARIF только при успешном clippy: если сборка упала, файл будет
+      # пустым/обрезанным, и выгрузка молча закрыла бы все существующие алерты.
       - name: Upload Rust Clippy SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: rust-clippy.sarif
           category: "/tool:clippy"
@@ -52,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (Config / IaC / Secrets)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           scan-type: 'fs'
           scanners: 'config,secret'
@@ -62,8 +73,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
           category: "/tool:trivy"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,13 +48,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -73,7 +73,7 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' && (inputs.tag == '' || inputs.tag == null) }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -34,7 +34,7 @@ jobs:
       # existing SC2034/SC2155 findings fixed first (restore-clickhouse.sh,
       # ci/run-load-tests.sh, ci/run.sh).
       - name: Shellcheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: .
           severity: error

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends wrk curl
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Run lite and hybrid load-test profiles
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           VERSION="${GITHUB_REF_NAME#v}"
           chmod +x scripts/extract-release-notes.sh
           ./scripts/extract-release-notes.sh "$VERSION" > dist/RELEASE_NOTES.md
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: BSDM-Proxy ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Разбор ошибок на странице **Security → Code scanning** и починка причин.

**Причина красноты на странице:** в репозитории включён **CodeQL default setup**
(он же workflow «Push on main», `dynamic/github-code-scanning/codeql`), а
`.github/workflows/codeql.yml` дополнительно поднимал свою advanced-конфигурацию
CodeQL. GitHub такое отклоняет:

```
Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled
```

Джобы `CodeQL (python)` / `CodeQL (javascript-typescript)` падали с
`configuration error` и заливали failed-run SARIF — отсюда ошибки в Tool status.
Сами джобы уже убраны в 4689ca4; в этом PR добавлен комментарий-предохранитель,
чтобы их не вернули, плюс исправлены остальные проблемы того же workflow.

Изменения:

- Шаг clippy маскировал падения (`| tee ... | sarif-fmt || true`): при ошибке
  сборки заливался пустой SARIF, что молча закрывало все алерты категории
  `/tool:clippy`. Теперь `set -o pipefail`, а выгрузка идёт только при успешном
  прогоне (убран `if: always()`).
- `github/codeql-action/upload-sarif` переведён с v3 (deprecated с декабря 2026)
  на v4.
- Все сторонние actions закреплены на коммит-SHA с комментарием версии; версии
  не менялись, кроме `aquasecurity/trivy-action@master` → `v0.36.0` и
  `ludeeus/action-shellcheck@master` → `2.0.0` (плавающий `master` — риск для
  supply chain и типовая находка code scanning).

## Related Issues

Нет связанного issue.

## Testing

```bash
python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')+glob.glob('.github/actions/*/action.yml')]"
```

Все workflow-файлы парсятся. Локальный `cargo clippy` в этой среде не проходит
(нет `protoc`), в CI он зелёный — на последнем прогоне на `main` clippy не выдал
ни одной находки. Код крейтов этот PR не трогает.

## Checklist

- [x] CI is green
- [x] Documentation updated (if behavior or env vars changed) — не требуется, изменения только в CI
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — не требуется

---
_Generated by [Claude Code](https://claude.ai/code/session_0187k4UTioY5yPwyukaCrnMg)_