### PR TITLE
feat(grafana): Threat Intelligence (Shadow) dashboard + ADR 0008 docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Grafana dashboard «BSDM Threat Intelligence (Shadow)»** — `grafana/dashboards/bsdm-threat-intel-shadow.json` (uid `bsdm-threat-intel-shadow`): enforcement posture of collector and proxy, per-feed `bsdm_proxy_ti_shadow_matches_total`, enforce-block guard, SOAR call rate, feed freshness / fetch results / drop reasons, RPZ records and rollbacks, and ClickHouse false-positive review tables over `threat_shadow_match`. Closes the last acceptance criterion of the August 2026 improvement proposal (ADR 0008).
+
 ## [0.9.14] - 2026-08-31
 
 Release following **0.9.13**: Full Threat Intelligence data-plane enforcement with Triple-Gate fail-safe, SIEM/SOAR integration and ML campaign clustering, AmneziaWG and BSDM Connect client, Domain-based split routing & PAC engine, Argon2id auth security, and CIS Benchmark compliance hardening.

--- a/docs/adr/0008-threat-intel-shadow-mode.md
+++ b/docs/adr/0008-threat-intel-shadow-mode.md
@@ -61,6 +61,7 @@ Enforcement is enabled per feed set and per installation. Passing these criteria
 2. The path referenced by `DNS_SINKHOLE_ZONE_PATH` is **not** a collector-generated `threats.rpz`, and no automation copies it there.
 3. The proxy ACL configuration does not reference `TI_ACL_EXPORT_PATH` / `threat_domains.json`.
 4. `bsdm_proxy_ti_shadow_matches_total` is present in `/metrics` on the proxy and grows with traffic; events carrying `threat_shadow_match` are searchable in ClickHouse.
+5. Grafana dashboard **BSDM Threat Intelligence (Shadow)** (`/d/bsdm-threat-intel-shadow`) shows both posture stats as `shadow`, "Enforce blocks" flat at 0, and the per-feed match rate plus the ClickHouse FP-review table used to fill in the transition record.
 
 **Enabling enforcement (only after the transition criteria are met):**
 

--- a/docs/features/threat-intel-collector.md
+++ b/docs/features/threat-intel-collector.md
@@ -49,6 +49,14 @@ curl http://127.0.0.1:8093/metrics | grep threat_intel_
 A plain binary run binds `127.0.0.1` (`TI_ADMIN_BIND`). Under Compose the port
 is published on `127.0.0.1:8093` and in Helm it is an internal service.
 
+Prometheus scrapes both the collector (`threat_intel_*`) and the proxy
+(`bsdm_proxy_ti_*`). The provisioned Grafana dashboard **BSDM Threat
+Intelligence (Shadow)** (`grafana/dashboards/bsdm-threat-intel-shadow.json`,
+uid `bsdm-threat-intel-shadow`) shows the enforcement posture of collector and
+proxy, shadow matches per feed, feed freshness and a ClickHouse table of
+shadow-matched hosts (`threat_shadow_match`) for false-positive review. The
+matching alert rules live in `prometheus/alerts/ti_shadow.yml`.
+
 Compose profile:
 
 ```bash

--- a/docs/getting-started/pilot-alerts.md
+++ b/docs/getting-started/pilot-alerts.md
@@ -16,6 +16,7 @@ Grafana dashboard `bsdm-proxy` panel **Policy Decision Sources**.
 | Admin Console → **Dashboard** | Segment bar **Hybrid decision_source** (dns/sni/mitm/pin) from `/metrics` |
 | Admin Console → **Logs** | Filter `decision_source` (server + client) |
 | Grafana → BSDM Proxy | Time series `sum(rate(bsdm_proxy_policy_decision_source_total[5m])) by (source)` |
+| Grafana → BSDM Threat Intelligence (Shadow) | Posture stats (`shadow`/`ENFORCE`), `sum(rate(bsdm_proxy_ti_shadow_matches_total[5m])) by (feed)`, ClickHouse FP-review table over `threat_shadow_match` |
 | alert-worker | Webhook JSON for deny/domain bursts (pilot rule subset) |
 
 ---
@@ -63,6 +64,7 @@ Optional later: `high_entropy_domain`, `beacon_periodic` (more ML/noise).
 - [ ] Dashboard shows decision_source bar after traffic (or honest empty state)
 - [ ] Logs can filter `decision_source=sni|mitm|…`
 - [ ] Grafana panel «Policy Decision Sources» loads when Prometheus scrapes proxy
+- [ ] Grafana dashboard «BSDM Threat Intelligence (Shadow)» shows both posture stats as `shadow` and «Enforce blocks (24h)» = 0
 - [ ] `alert-worker` healthy with pilot `ALERT_RULES` and webhook receives at least a test fire or stays quiet with empty CH
 
 ```bash

--- a/docs/improvement-proposal-2026-08.md
+++ b/docs/improvement-proposal-2026-08.md
@@ -64,12 +64,16 @@ ADR-0008 (#323) и issue #330 фиксируют решение: **никако�
 
 ### Критерии приёмки
 
-- [ ] Дефолтная конфигурация пилота не может заблокировать трафик по TI-фидам ни
-      одним переключателем — нужно явное `enforce`.
-- [ ] `threat_shadow_match` виден в аналитике; zero change в allow/deny path.
-- [ ] Метрики совпадений по фидам доступны в Prometheus/Grafana.
-- [ ] `docs/`, `project-status.md`, README синхронизированы (правило обновления
-      из `project-status.md`).
+- [x] Дефолтная конфигурация пилота не может заблокировать трафик по TI-фидам ни
+      одним переключателем — нужно явное `enforce` (`TI_ENFORCEMENT_MODE`, `.shadow`-артефакты,
+      Triple-Gate в `proxy/src/ti_enforce.rs`).
+- [x] `threat_shadow_match` виден в аналитике; zero change в allow/deny path
+      (`proxy/src/ti_shadow.rs`, колонка `threat_shadow_match` в ClickHouse).
+- [x] Метрики совпадений по фидам доступны в Prometheus/Grafana
+      (`bsdm_proxy_ti_shadow_matches_total{feed}`, алерты `prometheus/alerts/ti_shadow.yml`,
+      дашборд `grafana/dashboards/bsdm-threat-intel-shadow.json`).
+- [x] `docs/`, `project-status.md`, README синхронизированы (правило обновления
+      из `project-status.md`) — ADR 0008, `project-status.md` «Мониторинг угроз (Shadow)».
 
 ## Предложение №2 (процесс): гигиена трекера
 

--- a/grafana/dashboards/bsdm-threat-intel-shadow.json
+++ b/grafana/dashboards/bsdm-threat-intel-shadow.json
@@ -1,0 +1,1231 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Threat Intelligence in Shadow Mode (ADR 0008): enforcement posture, per-feed shadow matches, collector health and a ClickHouse false-positive review list. Companion of prometheus/alerts/ti_shadow.yml.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "title": "BSDM Proxy Dashboard",
+      "type": "link",
+      "url": "/d/bsdm-proxy"
+    },
+    {
+      "title": "BSDM HTTP Traffic (ClickHouse)",
+      "type": "link",
+      "url": "/d/bsdm-http-traffic-ch"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Posture — enforcement must be an explicit decision (ADR 0008)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "threat_intel_enforcement_mode{mode=\"enforce\"}: 0 = shadow (fail-safe default), 1 = enforce. Alert BsdmTiEnforcementActive fires on 1.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "shadow"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "ENFORCE"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "orange",
+                  "index": 2,
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(threat_intel_enforcement_mode{mode=\"enforce\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Collector mode (threat-intel)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "bsdm_proxy_ti_effective_mode{effective=\"enforce\"}: 0 = proxy data-plane only observes (ti_shadow.rs), 1 = ti_enforce.rs can deny requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "shadow"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "ENFORCE"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "orange",
+                  "index": 2,
+                  "text": "no data"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(bsdm_proxy_ti_effective_mode{effective=\"enforce\"})",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Proxy effective mode",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Requests that matched an IOC and were served anyway (observation only).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(bsdm_proxy_ti_shadow_matches_total[24h]))",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Shadow matches (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Requests denied by threat-intel enforcement. Must stay 0 while TI_ENFORCEMENT_MODE=shadow.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(bsdm_proxy_ti_enforce_blocked_total[24h])) or vector(0)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Enforce blocks (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Live indicators in the collector SQLite store (all kinds).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(threat_intel_stored_indicators)",
+          "legendFormat": "",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Stored indicators",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 7,
+      "panels": [],
+      "title": "Shadow observation — go/no-go input, not incidents",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "bsdm_proxy_ti_shadow_matches_total by feed. Alert BsdmTiShadowMatchSpike threshold: 0.2/s per feed for 10m. Each match = one request annotated with threat_shadow_match and served.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(bsdm_proxy_ti_shadow_matches_total[5m])) by (feed)",
+          "legendFormat": "{{feed}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Shadow matches by feed (rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Ratio gives the upper bound of traffic that enforcement would have touched. Use with the FP review table below when filling in the go/no-go record.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(bsdm_proxy_ti_shadow_matches_total[5m]))",
+          "legendFormat": "shadow matches",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(bsdm_proxy_policy_decision_source_total[5m]))",
+          "legendFormat": "all decisions",
+          "refId": "B"
+        }
+      ],
+      "title": "Shadow matches vs all policy decisions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Non-zero here means ti_enforce.rs is denying traffic based on feeds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(bsdm_proxy_ti_enforce_blocked_total[5m])) by (feed)",
+          "legendFormat": "{{feed}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Enforce blocks by feed (must be flat at 0 in shadow)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "In shadow mode SOAR block returns 202 and only records the indicator. Alert BsdmTiSoarBlockBurst: >20 shadow blocks in 10m. Cross-check TI_SOAR_AUDIT_PATH.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(threat_intel_soar_blocks_total[5m])) by (mode)",
+          "legendFormat": "block ({{mode}})",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(threat_intel_soar_unblocks_total[5m])) by (mode)",
+          "legendFormat": "unblock ({{mode}})",
+          "refId": "B"
+        }
+      ],
+      "title": "SOAR block / unblock calls",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 12,
+      "panels": [],
+      "title": "Collector health — a stale feed silently degrades shadow observation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "threat_intel_fetches_total per source and result over the poll window (default TI_POLL_INTERVAL_SECS=900).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(threat_intel_fetches_total[15m])) by (source, result)",
+          "legendFormat": "{{source}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feed fetch results",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Alert BsdmTiFeedStale fires above 5400s (90m).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "time() - max by (source) (threat_intel_last_success_timestamp_seconds)",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feed age (time since last successful collection)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(threat_intel_indicators_total[15m])) by (source, kind)",
+          "legendFormat": "{{source}} / {{kind}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Indicators ingested by source",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Normalizer rejects: invalid URL/IDN, bogon or private IP, duplicates.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(threat_intel_indicators_dropped_total[15m])) by (source, reason)",
+          "legendFormat": "{{source}} / {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Indicators dropped by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 39
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "threat_intel_stored_indicators",
+          "legendFormat": "{{kind}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Stored indicators by kind",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Records compiled into threats.rpz(.shadow). Rollbacks via POST /api/v1/rpz/rollback.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 39
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "threat_intel_rpz_records_total",
+          "legendFormat": "rpz records",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(threat_intel_rpz_rollbacks_total[1h])",
+          "legendFormat": "rollbacks (1h)",
+          "refId": "B"
+        }
+      ],
+      "title": "RPZ records / rollbacks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 39
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(threat_intel_fetch_duration_seconds_bucket[15m])) by (le, source))",
+          "legendFormat": "{{source}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Fetch duration p95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 20,
+      "panels": [],
+      "title": "False-positive review (ClickHouse) — evidence for the ADR 0008 transition record",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse"
+      },
+      "description": "SOC triage list: every host that hit an IOC while served. Many distinct users on one host usually means a false positive (shared SaaS / CDN) — whitelist via Admin Console before considering enforce.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 14,
+        "x": 0,
+        "y": 48
+      },
+      "id": 21,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "sql",
+          "rawSql": "SELECT\n  threat_shadow_match AS feed,\n  domain(url) AS host,\n  count() AS requests,\n  uniqExact(client_ip) AS clients,\n  uniqExact(coalesce(username, user_id, '')) AS users,\n  max(ts) AS last_seen\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND threat_shadow_match IS NOT NULL\nGROUP BY feed, host\nORDER BY requests DESC\nLIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Shadow-matched hosts by feed",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-clickhouse-datasource",
+        "uid": "clickhouse"
+      },
+      "description": "Per-feed volume for the observation window. Divide reviewed-FP hosts by hosts here to get the per-feed FP rate required by ADR 0008.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 14,
+        "y": 48
+      },
+      "id": 22,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-clickhouse-datasource",
+            "uid": "clickhouse"
+          },
+          "editorType": "sql",
+          "format": 1,
+          "queryType": "sql",
+          "rawSql": "SELECT\n  threat_shadow_match AS feed,\n  count() AS requests,\n  uniqExact(domain(url)) AS hosts,\n  uniqExact(client_ip) AS clients\nFROM bsdm.http_cache\nWHERE $__timeFilter(ts)\n  AND threat_shadow_match IS NOT NULL\nGROUP BY feed\nORDER BY requests DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Shadow matches per feed (window)",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "bsdm",
+    "threat-intel",
+    "shadow",
+    "adr-0008"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "BSDM Threat Intelligence (Shadow)",
+  "uid": "bsdm-threat-intel-shadow",
+  "version": 1,
+  "weekStart": ""
+}

--- a/prometheus/alerts/ti_shadow.yml
+++ b/prometheus/alerts/ti_shadow.yml
@@ -18,6 +18,7 @@ groups:
           mode: shadow
         annotations:
           summary: "Threat-intel shadow matches elevated (feed {{ $labels.feed }})"
+          dashboard: "/d/bsdm-threat-intel-shadow"
           description: "{{ $value | humanize }} shadow match(es)/s over 10m from feed {{ $labels.feed }}. Traffic was NOT blocked (TI_ENFORCEMENT_MODE=shadow). Review before flipping to enforce; see docs ADR-0008."
 
       # Enforcement must be an explicit, announced decision. The gauge carries the
@@ -32,6 +33,7 @@ groups:
           mode: enforce
         annotations:
           summary: "Threat-intel is ENFORCING (TI_ENFORCEMENT_MODE=enforce)"
+          dashboard: "/d/bsdm-threat-intel-shadow"
           description: "The collector reports the enforce posture, so feed data compiles into live RPZ/ACL artifacts and can block traffic. The gauge reflects the mode itself — it fires whether or not anyone calls SOAR. If this deployment is supposed to be in Shadow Mode, TI_ENFORCEMENT_MODE was changed; see ADR-0008."
 
       # SOAR mutations arriving in shadow mode are expected (202, no enforcement),


### PR DESCRIPTION
## Summary

Closes the last open acceptance criterion of `docs/improvement-proposal-2026-08.md` (Proposal #1, TI Shadow Mode): shadow-match metrics existed in Prometheus (`prometheus/alerts/ti_shadow.yml`) but no Grafana dashboard exposed them.

- New provisioned dashboard `grafana/dashboards/bsdm-threat-intel-shadow.json` (uid `bsdm-threat-intel-shadow`, title **BSDM Threat Intelligence (Shadow)**):
  - Posture row: collector `threat_intel_enforcement_mode` and proxy `bsdm_proxy_ti_effective_mode` as `shadow` / `ENFORCE` stats, shadow matches 24h, enforce blocks 24h (red if > 0), stored indicators.
  - Shadow observation row: `bsdm_proxy_ti_shadow_matches_total` by feed, shadow vs all policy decisions, enforce blocks by feed, SOAR block/unblock by mode.
  - Collector health row: fetch results, feed age (stale threshold matches `BsdmTiFeedStale`), ingested / dropped indicators, stored by kind, RPZ records & rollbacks, fetch p95.
  - ClickHouse FP-review row: shadow-matched hosts by feed (requests, clients, users, last seen) and per-feed totals over `threat_shadow_match` — the evidence table for the ADR 0008 transition record.
- `ti_shadow.yml`: `dashboard` annotation on the shadow-spike and enforcement-active alerts.
- Docs: collector feature doc, ADR 0008 operator procedure (step 5), pilot alerts checklist, CHANGELOG `[Unreleased]`, improvement-proposal acceptance criteria ticked with pointers to the implementing code.

All 15 metric names referenced by the dashboard were checked against `proxy/src/metrics.rs` and `threat-intel/src/metrics.rs`.

## Related Issues

- Follow-up to #330 / #323 (ADR 0008 Shadow Mode); no open issue.

## Testing

Dashboard JSON parsed and metric names cross-checked with a script; alert YAML re-parsed. No Rust code changed, so `cargo test` / `clippy` were not run.

```bash
python3 -c "import json;json.load(open('grafana/dashboards/bsdm-threat-intel-shadow.json'))"
python3 -c "import yaml;yaml.safe_load(open('prometheus/alerts/ti_shadow.yml'))"
```

Not verified: rendering in a live Grafana 12 with the ClickHouse plugin (needs the compose stack).

## Checklist

- [ ] CI is green
- [x] Documentation updated (if behavior or env vars changed)
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — not applicable, maturity unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8Qo3ExEhcC1cfU77MXQR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8Qo3ExEhcC1cfU77MXQR2)_