### PR TITLE
feat(ebpf): modernize XDP packet filter, dual-stack IPv4/IPv6, and Control API integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,27 +776,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
+checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
+checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
+checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
+checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
+checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
+checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -859,24 +859,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
+checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
+checksum = "e61dfa0766c0eadf42b3febd145a35f81f31086e207f534e5fb406fc3d08fc47"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
+checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
+checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -899,15 +899,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
+checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
+checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -916,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
+checksum = "4b3f161aa81ee5dd8d7b0eb8828988f57baf2f78d288e62b6b3714b37aa6d6a1"
 
 [[package]]
 name = "crc32fast"
@@ -1268,7 +1268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2925,7 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -2945,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2982,9 +2982,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
+checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2994,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
+checksum = "3e902032e329008b189b67498b1be7784d5849276f32402eca17441df08a6bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3069,7 +3069,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3540,7 +3540,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3608,7 +3608,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4112,10 +4112,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4814,9 +4814,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
+checksum = "d39226663bd765601279a79b88645a7c4a4d3c2fe73040afdc27bead02ee6659"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -4853,9 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
+checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4884,15 +4884,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
+checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
+checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -4901,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
+checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
+checksum = "a000d1124dd40417ce8433d07de1063ecc9be7cac21745c8de7f9cf7684c3ead"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4943,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
+checksum = "a7439956e78ba68e2cd766f34c3f056d625fad9a055eafb0c4569ac91c09e6b4"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -4953,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
+checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4965,9 +4965,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
+checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4978,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
+checksum = "51e06f9fabbe647e5c2ed186e6920ab1fb48174688d7d3fdadbda537b8499b51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5084,7 +5084,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/admin-console/src/api/ebpf.ts
+++ b/admin-console/src/api/ebpf.ts
@@ -21,12 +21,15 @@ export interface EbpfBlockedIp {
 
 export interface EbpfStats {
   enabled: boolean
+  /** Whether the XDP program is actually loaded on the interface right now. */
+  attached: boolean
   interface: string
   mode: XdpMode
   activeBlockedIps: number
   packetsDroppedTotal: number
   bytesDroppedTotal: number
-  kernelLatencyUs: number
+  /** null when the proxy has no latency measurement available. */
+  kernelLatencyUs: number | null
   cpuUsageUserPercent: number
 }
 
@@ -127,12 +130,13 @@ export async function fetchEbpfStats(): Promise<EbpfStats> {
 
     return {
       enabled: memoryConfig?.enabled ?? true,
+      attached: false,
       interface: memoryConfig?.interface ?? 'eth0',
       mode: memoryConfig?.mode ?? 'driver',
       activeBlockedIps: ips.length,
       packetsDroppedTotal: packets || 184250,
       bytesDroppedTotal: bytes || 117920000,
-      kernelLatencyUs: 0.45,
+      kernelLatencyUs: null,
       cpuUsageUserPercent: 0.0,
     }
   }

--- a/admin-console/test/local/fixtures.ts
+++ b/admin-console/test/local/fixtures.ts
@@ -535,6 +535,7 @@ export const ebpfBlockedIps: EbpfBlockedIp[] = [
 
 export const ebpfStats: EbpfStats = {
   enabled: false,
+  attached: false,
   interface: 'eth0',
   mode: 'skb',
   activeBlockedIps: ebpfBlockedIps.length,

--- a/bpf/xdp_drop.c
+++ b/bpf/xdp_drop.c
@@ -1,18 +1,53 @@
 // eBPF XDP Packet Drop Filter for BSDM Proxy
-// Drops IP packets from blacklisted IP addresses at the NIC driver layer (XDP_DROP).
+// Drops IP packets from blacklisted IPv4 and IPv6 addresses at the NIC driver layer (XDP_DROP)
+// and records drop statistics in kernel maps.
 
 #include <linux/bpf.h>
 #include <linux/if_ether.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
 #include <linux/in.h>
 #include <bpf/bpf_helpers.h>
 
+// IPv4 blocked addresses: key is 32-bit IPv4 in network byte order
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 65536);
-    __type(key, __u32);   // IPv4 address in network byte order
+    __type(key, __u32);
     __type(value, __u8);  // 1 = block
 } bsdm_blocked_ips SEC(".maps");
+
+// IPv6 blocked addresses: key is 128-bit IPv6 address
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 65536);
+    __type(key, struct in6_addr);
+    __type(value, __u8);  // 1 = block
+} bsdm_blocked_ips_v6 SEC(".maps");
+
+// Drop statistics array:
+// index 0 = total dropped packets count
+// index 1 = total dropped bytes count
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 2);
+    __type(key, __u32);
+    __type(value, __u64);
+} bsdm_drop_stats SEC(".maps");
+
+static __always_inline void record_drop(__u64 pkt_len) {
+    __u32 key_pkts = 0;
+    __u64 *pkts = bpf_map_lookup_elem(&bsdm_drop_stats, &key_pkts);
+    if (pkts) {
+        __sync_fetch_and_add(pkts, 1);
+    }
+
+    __u32 key_bytes = 1;
+    __u64 *bytes = bpf_map_lookup_elem(&bsdm_drop_stats, &key_bytes);
+    if (bytes) {
+        __sync_fetch_and_add(bytes, pkt_len);
+    }
+}
 
 SEC("xdp")
 int xdp_drop_blocked_ips(struct xdp_md *ctx) {
@@ -23,17 +58,34 @@ int xdp_drop_blocked_ips(struct xdp_md *ctx) {
     if ((void *)(eth + 1) > data_end)
         return XDP_PASS;
 
-    if (eth->h_proto != __builtin_bswap16(ETH_P_IP))
-        return XDP_PASS;
+    __u16 h_proto = __builtin_bswap16(eth->h_proto);
 
-    struct iphdr *iph = (void *)(eth + 1);
-    if ((void *)(iph + 1) > data_end)
-        return XDP_PASS;
+    // IPv4 packet inspection
+    if (h_proto == ETH_P_IP) {
+        struct iphdr *iph = (void *)(eth + 1);
+        if ((void *)(iph + 1) > data_end)
+            return XDP_PASS;
 
-    __u32 src_ip = iph->saddr;
-    __u8 *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips, &src_ip);
-    if (blocked && *blocked == 1) {
-        return XDP_DROP;
+        __u32 src_ip = iph->saddr;
+        __u8 *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips, &src_ip);
+        if (blocked && *blocked == 1) {
+            __u64 pkt_len = (long)data_end - (long)data;
+            record_drop(pkt_len);
+            return XDP_DROP;
+        }
+    }
+    // IPv6 packet inspection
+    else if (h_proto == ETH_P_IPV6) {
+        struct ipv6hdr *ip6h = (void *)(eth + 1);
+        if ((void *)(ip6h + 1) > data_end)
+            return XDP_PASS;
+
+        __u8 *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips_v6, &ip6h->saddr);
+        if (blocked && *blocked == 1) {
+            __u64 pkt_len = (long)data_end - (long)data;
+            record_drop(pkt_len);
+            return XDP_DROP;
+        }
     }
 
     return XDP_PASS;

--- a/bpf/xdp_drop.c
+++ b/bpf/xdp_drop.c
@@ -9,12 +9,21 @@
 #include <linux/in.h>
 #include <bpf/bpf_helpers.h>
 
+// Per-address drop counters. Presence of an entry means "block this source";
+// the value accumulates what was actually dropped for it. Userspace
+// (proxy/src/ebpf.rs) inserts entries with both counters zeroed and reads them
+// back via `bpftool map dump`.
+struct ip_drop_stats {
+    __u64 packets;
+    __u64 bytes;
+};
+
 // IPv4 blocked addresses: key is 32-bit IPv4 in network byte order
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 65536);
     __type(key, __u32);
-    __type(value, __u8);  // 1 = block
+    __type(value, struct ip_drop_stats);
 } bsdm_blocked_ips SEC(".maps");
 
 // IPv6 blocked addresses: key is 128-bit IPv6 address
@@ -22,7 +31,7 @@ struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 65536);
     __type(key, struct in6_addr);
-    __type(value, __u8);  // 1 = block
+    __type(value, struct ip_drop_stats);
 } bsdm_blocked_ips_v6 SEC(".maps");
 
 // Drop statistics array:
@@ -67,9 +76,11 @@ int xdp_drop_blocked_ips(struct xdp_md *ctx) {
             return XDP_PASS;
 
         __u32 src_ip = iph->saddr;
-        __u8 *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips, &src_ip);
-        if (blocked && *blocked == 1) {
+        struct ip_drop_stats *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips, &src_ip);
+        if (blocked) {
             __u64 pkt_len = (long)data_end - (long)data;
+            __sync_fetch_and_add(&blocked->packets, 1);
+            __sync_fetch_and_add(&blocked->bytes, pkt_len);
             record_drop(pkt_len);
             return XDP_DROP;
         }
@@ -80,9 +91,12 @@ int xdp_drop_blocked_ips(struct xdp_md *ctx) {
         if ((void *)(ip6h + 1) > data_end)
             return XDP_PASS;
 
-        __u8 *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips_v6, &ip6h->saddr);
-        if (blocked && *blocked == 1) {
+        struct in6_addr src_ip6 = ip6h->saddr;
+        struct ip_drop_stats *blocked = bpf_map_lookup_elem(&bsdm_blocked_ips_v6, &src_ip6);
+        if (blocked) {
             __u64 pkt_len = (long)data_end - (long)data;
+            __sync_fetch_and_add(&blocked->packets, 1);
+            __sync_fetch_and_add(&blocked->bytes, pkt_len);
             record_drop(pkt_len);
             return XDP_DROP;
         }

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -98,40 +98,42 @@ impl ControlApiState {
     }
 
     fn ebpf_get_config(&self) -> Response<Body> {
-        let cfg = self.ebpf_manager.config();
-        match serde_json::to_string(&cfg) {
+        match serde_json::to_string(&self.ebpf_manager.config()) {
             Ok(json) => json_response(StatusCode::OK, &json),
-            Err(e) => json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!(r#"{{"error":"{}"}}"#, e),
-            ),
+            Err(e) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
         }
     }
 
     async fn ebpf_put_config(&self, body: Bytes) -> Response<Body> {
-        match serde_json::from_slice::<crate::ebpf::EbpfXdpConfig>(&body) {
-            Ok(new_cfg) => match self.ebpf_manager.update_config(new_cfg) {
-                Ok(()) => self.ebpf_get_config(),
-                Err(err) => json_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    &format!(r#"{{"error":"{}"}}"#, err),
-                ),
-            },
-            Err(e) => json_response(
-                StatusCode::BAD_REQUEST,
-                &format!(r#"{{"error":"Invalid eBPF config JSON: {}"}}"#, e),
-            ),
+        let new_cfg = match serde_json::from_slice::<crate::ebpf::EbpfXdpConfig>(&body) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                return ebpf_error(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid eBPF config JSON: {}", e),
+                )
+            }
+        };
+
+        // Unsupported settings are a client error, kernel failures are not.
+        if let Err(e) = new_cfg.validate() {
+            return ebpf_error(StatusCode::BAD_REQUEST, &e);
+        }
+
+        match self.ebpf_manager.update_config(new_cfg) {
+            Ok(()) => self.ebpf_get_config(),
+            Err(err) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &err),
         }
     }
 
     fn ebpf_get_stats(&self) -> Response<Body> {
         let stats = self.ebpf_manager.stats();
+        self.metrics
+            .ebpf_blocked_ips
+            .set(stats.active_blocked_ips as f64);
         match serde_json::to_string(&stats) {
             Ok(json) => json_response(StatusCode::OK, &json),
-            Err(e) => json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!(r#"{{"error":"{}"}}"#, e),
-            ),
+            Err(e) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
         }
     }
 
@@ -139,66 +141,84 @@ impl ControlApiState {
         let ips = self.ebpf_manager.list_blocked_ips();
         match serde_json::to_string(&ips) {
             Ok(json) => json_response(StatusCode::OK, &json),
-            Err(e) => json_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!(r#"{{"error":"{}"}}"#, e),
-            ),
+            Err(e) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
         }
     }
 
+    fn refresh_ebpf_gauge(&self) {
+        self.metrics
+            .ebpf_blocked_ips
+            .set(self.ebpf_manager.blocked_ip_count() as f64);
+    }
+
     async fn ebpf_block_ip(&self, body: Bytes) -> Response<Body> {
-        #[derive(Deserialize)]
-        struct BlockReq {
-            ip: String,
-            reason: Option<String>,
+        let req = match serde_json::from_slice::<crate::ebpf::BlockIpRequest>(&body) {
+            Ok(req) => req,
+            Err(e) => {
+                return ebpf_error(
+                    StatusCode::BAD_REQUEST,
+                    &format!("Invalid block request JSON: {}", e),
+                )
+            }
+        };
+
+        let ip = match req.ip.trim().parse::<std::net::IpAddr>() {
+            Ok(ip) => ip,
+            Err(_) => {
+                return ebpf_error(
+                    StatusCode::BAD_REQUEST,
+                    "Invalid IP address format (must be IPv4 or IPv6)",
+                )
+            }
+        };
+
+        if self.ebpf_manager.is_ip_blocked(&ip) {
+            return ebpf_error(
+                StatusCode::CONFLICT,
+                &format!("IP {} is already blocked", ip),
+            );
         }
 
-        match serde_json::from_slice::<BlockReq>(&body) {
-            Ok(req) => match req.ip.trim().parse::<std::net::IpAddr>() {
-                Ok(ip) => match self.ebpf_manager.block_ip(ip, req.reason) {
-                    Ok(entry) => {
-                        self.metrics
-                            .ebpf_blocked_ips
-                            .set(self.ebpf_manager.stats().active_blocked_ips as f64);
-                        match serde_json::to_string(&entry) {
-                            Ok(json) => json_response(StatusCode::CREATED, &json),
-                            Err(e) => json_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                &format!(r#"{{"error":"{}"}}"#, e),
-                            ),
-                        }
-                    }
-                    Err(e) => json_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        &format!(r#"{{"error":"{}"}}"#, e),
-                    ),
-                },
-                Err(_) => json_response(
-                    StatusCode::BAD_REQUEST,
-                    r#"{"error":"Invalid IP address format (must be IPv4 or IPv6)"}"#,
-                ),
-            },
-            Err(e) => json_response(
-                StatusCode::BAD_REQUEST,
-                &format!(r#"{{"error":"Invalid block request JSON: {}"}}"#, e),
-            ),
+        match self.ebpf_manager.block_ip(ip, req.reason) {
+            Ok(entry) => {
+                self.refresh_ebpf_gauge();
+                match serde_json::to_string(&entry) {
+                    Ok(json) => json_response(StatusCode::CREATED, &json),
+                    Err(e) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+                }
+            }
+            // The manager rolls the entry back when the kernel map cannot be
+            // programmed, so a failure here means the IP is genuinely not blocked.
+            Err(e) => ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e),
         }
     }
 
     fn ebpf_delete_ip(&self, id_or_ip: &str) -> Response<Body> {
-        if self.ebpf_manager.unblock_ip(id_or_ip) {
-            self.metrics
-                .ebpf_blocked_ips
-                .set(self.ebpf_manager.stats().active_blocked_ips as f64);
-            json_response(StatusCode::OK, r#"{"status":"deleted"}"#)
-        } else {
-            json_response(StatusCode::NOT_FOUND, r#"{"error":"Blocked IP not found"}"#)
+        match self.ebpf_manager.unblock_ip(id_or_ip) {
+            Ok(true) => {
+                self.refresh_ebpf_gauge();
+                json_response(StatusCode::OK, r#"{"status":"deleted"}"#)
+            }
+            Ok(false) => ebpf_error(StatusCode::NOT_FOUND, "Blocked IP not found"),
+            Err(e) => {
+                self.refresh_ebpf_gauge();
+                ebpf_error(StatusCode::INTERNAL_SERVER_ERROR, &e)
+            }
         }
     }
 
     fn ebpf_clear_ips(&self) -> Response<Body> {
-        self.ebpf_manager.clear();
-        self.metrics.ebpf_blocked_ips.set(0.0);
+        let failures = self.ebpf_manager.clear();
+        self.refresh_ebpf_gauge();
+        if failures > 0 {
+            return ebpf_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(
+                    "{} address(es) could not be removed from the kernel map",
+                    failures
+                ),
+            );
+        }
         json_response(StatusCode::OK, r#"{"status":"cleared"}"#)
     }
 
@@ -948,8 +968,11 @@ impl ControlApiState {
             shutdown_tx: None,
             acl_api: None,
             rpz_api: Some(crate::rpz_api::RpzApiState::from_env()),
+            // Inert placeholder: a manager built from env here would attach the
+            // XDP program and then detach it again when with_ebpf_manager()
+            // replaces it. main.rs injects the real, env-configured manager.
             ebpf_manager: Arc::new(crate::ebpf::EbpfXdpManager::new(
-                crate::ebpf::EbpfXdpConfig::from_env(),
+                crate::ebpf::EbpfXdpConfig::default(),
             )),
         }
     }
@@ -1853,6 +1876,13 @@ fn collect_purge_tags(req: &PurgeRequest) -> Vec<String> {
         }
     }
     out
+}
+
+/// Builds an error body with the message properly JSON-escaped (error text may
+/// contain quotes, so it must never be interpolated into a raw JSON literal).
+pub(crate) fn ebpf_error(status: StatusCode, message: &str) -> Response<Body> {
+    let body = serde_json::json!({ "error": message }).to_string();
+    json_response(status, &body)
 }
 
 pub(crate) fn json_response(status: StatusCode, body: &str) -> Response<Body> {
@@ -3167,7 +3197,65 @@ mod tests {
         let list_json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(list_json.len(), 0);
 
-        // 11. Security check: unauthenticated call should be 401 Unauthorized
+        // 11. Duplicate block -> 409 Conflict (no silent counter reset)
+        let dup_first = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from_static(br#"{"ip":"203.0.113.7"}"#),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(dup_first.status(), StatusCode::CREATED);
+        let dup_second = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from_static(br#"{"ip":"203.0.113.7"}"#),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(dup_second.status(), StatusCode::CONFLICT);
+
+        // 12. Unsupported config values are rejected as 400, with a valid JSON body
+        let bad_cfg = serde_json::json!({
+            "enabled": false,
+            "interface": "eth1",
+            "mode": "driver",
+            "mapName": "attacker_owned_map",
+            "maxEntries": 32768
+        });
+        let bad_cfg_resp = state
+            .dispatch(
+                &Method::PUT,
+                "/api/ebpf/config",
+                Bytes::from(bad_cfg.to_string()),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(bad_cfg_resp.status(), StatusCode::BAD_REQUEST);
+        let body = BodyExt::collect(bad_cfg_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let err_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(err_json["error"].as_str().unwrap().contains("mapName"));
+        // The rejected update must not have been applied.
+        assert_eq!(state.ebpf_manager.config().map_name, "bsdm_blocked_ips");
+
+        // 13. Stats expose attachment health and no synthetic latency
+        let stats_resp = state
+            .dispatch(&Method::GET, "/api/ebpf/stats", Bytes::new(), &auth_headers)
+            .await;
+        let body = BodyExt::collect(stats_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let stats_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(stats_json["attached"], false);
+        assert!(stats_json["kernelLatencyUs"].is_null());
+
+        // 14. Security check: unauthenticated call should be 401 Unauthorized
         let unauth_resp = state
             .dispatch(
                 &Method::POST,

--- a/proxy/src/control_api.rs
+++ b/proxy/src/control_api.rs
@@ -97,6 +97,111 @@ impl ControlApiState {
         }
     }
 
+    fn ebpf_get_config(&self) -> Response<Body> {
+        let cfg = self.ebpf_manager.config();
+        match serde_json::to_string(&cfg) {
+            Ok(json) => json_response(StatusCode::OK, &json),
+            Err(e) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(r#"{{"error":"{}"}}"#, e),
+            ),
+        }
+    }
+
+    async fn ebpf_put_config(&self, body: Bytes) -> Response<Body> {
+        match serde_json::from_slice::<crate::ebpf::EbpfXdpConfig>(&body) {
+            Ok(new_cfg) => match self.ebpf_manager.update_config(new_cfg) {
+                Ok(()) => self.ebpf_get_config(),
+                Err(err) => json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!(r#"{{"error":"{}"}}"#, err),
+                ),
+            },
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(r#"{{"error":"Invalid eBPF config JSON: {}"}}"#, e),
+            ),
+        }
+    }
+
+    fn ebpf_get_stats(&self) -> Response<Body> {
+        let stats = self.ebpf_manager.stats();
+        match serde_json::to_string(&stats) {
+            Ok(json) => json_response(StatusCode::OK, &json),
+            Err(e) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(r#"{{"error":"{}"}}"#, e),
+            ),
+        }
+    }
+
+    fn ebpf_list_ips(&self) -> Response<Body> {
+        let ips = self.ebpf_manager.list_blocked_ips();
+        match serde_json::to_string(&ips) {
+            Ok(json) => json_response(StatusCode::OK, &json),
+            Err(e) => json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!(r#"{{"error":"{}"}}"#, e),
+            ),
+        }
+    }
+
+    async fn ebpf_block_ip(&self, body: Bytes) -> Response<Body> {
+        #[derive(Deserialize)]
+        struct BlockReq {
+            ip: String,
+            reason: Option<String>,
+        }
+
+        match serde_json::from_slice::<BlockReq>(&body) {
+            Ok(req) => match req.ip.trim().parse::<std::net::IpAddr>() {
+                Ok(ip) => match self.ebpf_manager.block_ip(ip, req.reason) {
+                    Ok(entry) => {
+                        self.metrics
+                            .ebpf_blocked_ips
+                            .set(self.ebpf_manager.stats().active_blocked_ips as f64);
+                        match serde_json::to_string(&entry) {
+                            Ok(json) => json_response(StatusCode::CREATED, &json),
+                            Err(e) => json_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                &format!(r#"{{"error":"{}"}}"#, e),
+                            ),
+                        }
+                    }
+                    Err(e) => json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &format!(r#"{{"error":"{}"}}"#, e),
+                    ),
+                },
+                Err(_) => json_response(
+                    StatusCode::BAD_REQUEST,
+                    r#"{"error":"Invalid IP address format (must be IPv4 or IPv6)"}"#,
+                ),
+            },
+            Err(e) => json_response(
+                StatusCode::BAD_REQUEST,
+                &format!(r#"{{"error":"Invalid block request JSON: {}"}}"#, e),
+            ),
+        }
+    }
+
+    fn ebpf_delete_ip(&self, id_or_ip: &str) -> Response<Body> {
+        if self.ebpf_manager.unblock_ip(id_or_ip) {
+            self.metrics
+                .ebpf_blocked_ips
+                .set(self.ebpf_manager.stats().active_blocked_ips as f64);
+            json_response(StatusCode::OK, r#"{"status":"deleted"}"#)
+        } else {
+            json_response(StatusCode::NOT_FOUND, r#"{"error":"Blocked IP not found"}"#)
+        }
+    }
+
+    fn ebpf_clear_ips(&self) -> Response<Body> {
+        self.ebpf_manager.clear();
+        self.metrics.ebpf_blocked_ips.set(0.0);
+        json_response(StatusCode::OK, r#"{"status":"cleared"}"#)
+    }
+
     async fn amneziawg_status(&self) -> Response<Body> {
         let guard = self.awg_server.read().await;
         match serde_json::to_string(&*guard) {
@@ -776,6 +881,7 @@ pub struct ControlApiState {
     shutdown_tx: Option<watch::Sender<bool>>,
     acl_api: Option<Arc<AclApiState>>,
     rpz_api: Option<Arc<crate::rpz_api::RpzApiState>>,
+    pub(crate) ebpf_manager: Arc<crate::ebpf::EbpfXdpManager>,
 }
 
 impl ControlApiState {
@@ -842,7 +948,16 @@ impl ControlApiState {
             shutdown_tx: None,
             acl_api: None,
             rpz_api: Some(crate::rpz_api::RpzApiState::from_env()),
+            ebpf_manager: Arc::new(crate::ebpf::EbpfXdpManager::new(
+                crate::ebpf::EbpfXdpConfig::from_env(),
+            )),
         }
+    }
+
+    /// Attach eBPF XDP manager to ControlApiState.
+    pub fn with_ebpf_manager(mut self, manager: Arc<crate::ebpf::EbpfXdpManager>) -> Self {
+        self.ebpf_manager = manager;
+        self
     }
 
     /// Attach MitmCircuitBreaker from ProxyService.
@@ -1079,6 +1194,12 @@ impl ControlApiState {
             }
         }
 
+        if method == Method::DELETE {
+            if let Some(id) = path.strip_prefix("/api/ebpf/ips/") {
+                return self.ebpf_delete_ip(id);
+            }
+        }
+
         match (method, path) {
             (&Method::GET, "/api/config") => self.config_get(),
             (&Method::POST, "/api/config/apply") => self.config_apply(body).await,
@@ -1092,6 +1213,12 @@ impl ControlApiState {
             (&Method::POST, "/api/security/casb") => self.casb_update(body).await,
             (&Method::GET, "/api/security/dlp") => self.dlp_patterns(),
             (&Method::POST, "/api/security/dlp") => self.dlp_update(body).await,
+            (&Method::GET, "/api/ebpf/config") => self.ebpf_get_config(),
+            (&Method::PUT, "/api/ebpf/config") => self.ebpf_put_config(body).await,
+            (&Method::GET, "/api/ebpf/stats") => self.ebpf_get_stats(),
+            (&Method::GET, "/api/ebpf/ips") => self.ebpf_list_ips(),
+            (&Method::POST, "/api/ebpf/ips") => self.ebpf_block_ip(body).await,
+            (&Method::DELETE, "/api/ebpf/ips") => self.ebpf_clear_ips(),
             (&Method::GET, "/api/auth/basic/users") => self.basic_users_list().await,
             (&Method::POST, "/api/auth/basic/users") => self.basic_users_put(body).await,
             (&Method::DELETE, "/api/auth/basic/users") => self.basic_users_delete(body).await,
@@ -2864,5 +2991,191 @@ mod tests {
             .await;
         assert_eq!(del_resp.status(), StatusCode::OK);
         assert!(!state.pinning_registry.matches("pinned.example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_ebpf_control_api_lifecycle() {
+        let metrics = Arc::new(Metrics::new().unwrap());
+        let cache = Arc::new(HttpL1Cache::new(100, 4));
+        let mut state = state_plain(metrics, cache);
+        state.api_token = Some("secret-token".to_string());
+        state.fail_closed = true;
+
+        let mut auth_headers = HeaderMap::new();
+        auth_headers.insert(
+            AUTHORIZATION,
+            "Bearer secret-token".parse().expect("valid header"),
+        );
+
+        // 1. GET /api/ebpf/config
+        let get_cfg_resp = state
+            .dispatch(
+                &Method::GET,
+                "/api/ebpf/config",
+                Bytes::new(),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(get_cfg_resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(get_cfg_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let cfg_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(cfg_json["interface"], "eth0");
+        assert_eq!(cfg_json["mode"], "skb");
+
+        // 2. PUT /api/ebpf/config
+        let update_cfg = serde_json::json!({
+            "enabled": false,
+            "interface": "eth1",
+            "mode": "driver",
+            "mapName": "bsdm_blocked_ips",
+            "maxEntries": 32768
+        });
+        let put_cfg_resp = state
+            .dispatch(
+                &Method::PUT,
+                "/api/ebpf/config",
+                Bytes::from(update_cfg.to_string()),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(put_cfg_resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(put_cfg_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let updated_cfg_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(updated_cfg_json["interface"], "eth1");
+        assert_eq!(updated_cfg_json["mode"], "driver");
+
+        // 3. GET /api/ebpf/stats
+        let stats_resp = state
+            .dispatch(&Method::GET, "/api/ebpf/stats", Bytes::new(), &auth_headers)
+            .await;
+        assert_eq!(stats_resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(stats_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let stats_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(stats_json["activeBlockedIps"], 0);
+        assert_eq!(stats_json["packetsDroppedTotal"], 0);
+
+        // 4. POST /api/ebpf/ips with invalid IP -> 400 Bad Request
+        let bad_ip_resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from_static(br#"{"ip":"invalid-ip"}"#),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(bad_ip_resp.status(), StatusCode::BAD_REQUEST);
+
+        // 5. POST /api/ebpf/ips with IPv4 -> 201 Created
+        let block_v4 = serde_json::json!({
+            "ip": "198.51.100.1",
+            "reason": "DDoS flood"
+        });
+        let block_v4_resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from(block_v4.to_string()),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(block_v4_resp.status(), StatusCode::CREATED);
+        let body = BodyExt::collect(block_v4_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let v4_entry: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v4_entry["ip"], "198.51.100.1");
+        assert_eq!(v4_entry["reason"], "DDoS flood");
+        let v4_id = v4_entry["id"].as_str().unwrap().to_string();
+
+        // 6. POST /api/ebpf/ips with IPv6 -> 201 Created
+        let block_v6 = serde_json::json!({
+            "ip": "2001:db8::99",
+            "reason": "Abuse scanning"
+        });
+        let block_v6_resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from(block_v6.to_string()),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(block_v6_resp.status(), StatusCode::CREATED);
+
+        // 7. GET /api/ebpf/ips -> 2 entries
+        let list_resp = state
+            .dispatch(&Method::GET, "/api/ebpf/ips", Bytes::new(), &auth_headers)
+            .await;
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let body = BodyExt::collect(list_resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let list_json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(list_json.len(), 2);
+
+        // 8. DELETE /api/ebpf/ips/:id -> 200 OK
+        let del_v4_resp = state
+            .dispatch(
+                &Method::DELETE,
+                &format!("/api/ebpf/ips/{}", v4_id),
+                Bytes::new(),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(del_v4_resp.status(), StatusCode::OK);
+
+        // 9. DELETE /api/ebpf/ips/:id already deleted -> 404 Not Found
+        let del_404_resp = state
+            .dispatch(
+                &Method::DELETE,
+                &format!("/api/ebpf/ips/{}", v4_id),
+                Bytes::new(),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(del_404_resp.status(), StatusCode::NOT_FOUND);
+
+        // 10. DELETE /api/ebpf/ips -> clear all
+        let clear_resp = state
+            .dispatch(
+                &Method::DELETE,
+                "/api/ebpf/ips",
+                Bytes::new(),
+                &auth_headers,
+            )
+            .await;
+        assert_eq!(clear_resp.status(), StatusCode::OK);
+
+        let list_after_clear = state
+            .dispatch(&Method::GET, "/api/ebpf/ips", Bytes::new(), &auth_headers)
+            .await;
+        let body = BodyExt::collect(list_after_clear.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let list_json: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(list_json.len(), 0);
+
+        // 11. Security check: unauthenticated call should be 401 Unauthorized
+        let unauth_resp = state
+            .dispatch(
+                &Method::POST,
+                "/api/ebpf/ips",
+                Bytes::from_static(br#"{"ip":"198.51.100.2"}"#),
+                &HeaderMap::new(),
+            )
+            .await;
+        assert_eq!(unauth_resp.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/proxy/src/ebpf.rs
+++ b/proxy/src/ebpf.rs
@@ -2,13 +2,36 @@
 //!
 //! Enables zero-CPU overhead packet drops at the NIC driver level (`XDP_DROP`)
 //! for blocked IPv4/IPv6 addresses and malicious traffic.
+//!
+//! Locking discipline: kernel side-effects (`ip`, `bpftool`, clang) are NEVER
+//! performed while a `config` or `blocked_ips` lock is held. Every public method
+//! snapshots what it needs, releases the guard, and only then shells out. This
+//! keeps the two locks independent and avoids both self-deadlocks (the same
+//! thread re-entering `config`) and lock-order inversions between callers.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::process::Command;
-use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
+
+/// Maximum number of entries compiled into the BPF hash maps (`bpf/xdp_drop.c`).
+/// Changing it requires editing and recompiling the BPF object.
+pub const COMPILED_MAX_ENTRIES: u32 = 65536;
+
+/// Name of the IPv4 blocklist map declared by `bpf/xdp_drop.c`.
+pub const MAP_NAME_V4: &str = "bsdm_blocked_ips";
+/// Name of the IPv6 blocklist map declared by `bpf/xdp_drop.c`.
+pub const MAP_NAME_V6: &str = "bsdm_blocked_ips_v6";
+/// Name of the global drop-counter array map declared by `bpf/xdp_drop.c`.
+pub const MAP_NAME_STATS: &str = "bsdm_drop_stats";
+
+/// Minimum interval between two `bpftool map dump` sweeps, so that a burst of
+/// control-plane requests cannot turn into a burst of subprocesses.
+const STATS_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Runtime mode for eBPF XDP program attachment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -42,6 +65,15 @@ impl XdpMode {
             Self::Offload => "offload",
         }
     }
+
+    /// Argument accepted by `ip link set dev <if> <arg> ...`.
+    fn ip_link_arg(&self) -> &'static str {
+        match self {
+            Self::Driver => "xdp",
+            Self::Offload => "xdpoffload",
+            Self::Skb => "xdpgeneric",
+        }
+    }
 }
 
 /// Runtime configuration for eBPF XDP filter.
@@ -63,8 +95,8 @@ impl Default for EbpfXdpConfig {
             enabled: false,
             interface: "eth0".to_string(),
             mode: XdpMode::Skb,
-            map_name: "bsdm_blocked_ips".to_string(),
-            max_entries: 65536,
+            map_name: MAP_NAME_V4.to_string(),
+            max_entries: COMPILED_MAX_ENTRIES,
         }
     }
 }
@@ -79,15 +111,43 @@ impl EbpfXdpConfig {
         let max_entries = std::env::var("EBPF_XDP_MAX_ENTRIES")
             .ok()
             .and_then(|s| s.parse().ok())
-            .unwrap_or(65536);
+            .unwrap_or(COMPILED_MAX_ENTRIES);
 
         Self {
             enabled,
             interface,
             mode: XdpMode::parse(&mode_str),
-            map_name: "bsdm_blocked_ips".to_string(),
+            map_name: MAP_NAME_V4.to_string(),
             max_entries,
         }
+    }
+
+    /// Rejects values the kernel side cannot actually honour, so the API never
+    /// acknowledges a setting that has no effect.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.interface.is_empty() || self.interface.len() > 15 {
+            return Err("interface must be 1..=15 characters".to_string());
+        }
+        if !self
+            .interface
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ':' | '@'))
+        {
+            return Err(format!("invalid interface name: {}", self.interface));
+        }
+        if self.map_name != MAP_NAME_V4 {
+            return Err(format!(
+                "mapName must be \"{}\" (the map declared by bpf/xdp_drop.c)",
+                MAP_NAME_V4
+            ));
+        }
+        if self.max_entries == 0 || self.max_entries > COMPILED_MAX_ENTRIES {
+            return Err(format!(
+                "maxEntries must be 1..={} (compiled into bpf/xdp_drop.c)",
+                COMPILED_MAX_ENTRIES
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -115,31 +175,79 @@ pub struct BlockIpRequest {
 #[serde(rename_all = "camelCase")]
 pub struct EbpfStats {
     pub enabled: bool,
+    /// Whether the XDP program is actually loaded on the interface right now.
+    /// `enabled` only reflects the requested configuration.
+    pub attached: bool,
     pub interface: String,
     pub mode: XdpMode,
     pub active_blocked_ips: u32,
     pub packets_dropped_total: u64,
     pub bytes_dropped_total: u64,
-    pub kernel_latency_us: f64,
+    /// `None` when no measurement is available (never a synthetic value).
+    pub kernel_latency_us: Option<f64>,
     pub cpu_usage_user_percent: f64,
 }
 
+struct ManagerInner {
+    config: RwLock<EbpfXdpConfig>,
+    blocked_ips: RwLock<HashMap<IpAddr, EbpfBlockedIp>>,
+    dropped_packets: AtomicU64,
+    dropped_bytes: AtomicU64,
+    attached: AtomicBool,
+    last_stats_refresh: Mutex<Option<Instant>>,
+}
+
+impl Drop for ManagerInner {
+    fn drop(&mut self) {
+        // Only the last owner of the shared state reaches this point, so a
+        // cloned handle going out of scope can never detach a live program.
+        if !self.attached.load(Ordering::SeqCst) {
+            return;
+        }
+        let cfg = match self.config.read() {
+            Ok(c) => c.clone(),
+            Err(_) => return,
+        };
+        detach_kernel_program(&cfg);
+    }
+}
+
+fn detach_kernel_program(config: &EbpfXdpConfig) {
+    if std::env::consts::OS != "linux" {
+        return;
+    }
+    let _ = Command::new("ip")
+        .args([
+            "link",
+            "set",
+            "dev",
+            &config.interface,
+            config.mode.ip_link_arg(),
+            "off",
+        ])
+        .output();
+}
+
 /// Manager for kernel eBPF map sync, packet drops, and runtime statistics.
+///
+/// Cloning yields another handle to the same shared state; the kernel program is
+/// detached only when the last handle is dropped.
 #[derive(Clone)]
 pub struct EbpfXdpManager {
-    config: Arc<RwLock<EbpfXdpConfig>>,
-    blocked_ips: Arc<RwLock<HashMap<IpAddr, EbpfBlockedIp>>>,
-    global_dropped_packets: Arc<RwLock<u64>>,
-    global_dropped_bytes: Arc<RwLock<u64>>,
+    inner: Arc<ManagerInner>,
 }
 
 impl EbpfXdpManager {
     pub fn new(config: EbpfXdpConfig) -> Self {
         let manager = Self {
-            config: Arc::new(RwLock::new(config.clone())),
-            blocked_ips: Arc::new(RwLock::new(HashMap::new())),
-            global_dropped_packets: Arc::new(RwLock::new(0)),
-            global_dropped_bytes: Arc::new(RwLock::new(0)),
+            inner: Arc::new(ManagerInner {
+                config: RwLock::new(config.clone()),
+                blocked_ips: RwLock::new(HashMap::new()),
+                dropped_packets: AtomicU64::new(0),
+                dropped_bytes: AtomicU64::new(0),
+                attached: AtomicBool::new(false),
+                last_stats_refresh: Mutex::new(None),
+            }),
         };
 
         if config.enabled {
@@ -155,10 +263,13 @@ impl EbpfXdpManager {
         manager
     }
 
-    fn attach_kernel_program(&self, config: &EbpfXdpConfig) {
+    /// Attaches the XDP object and records whether it actually succeeded, so
+    /// `stats()` never claims an active filter that is not loaded.
+    fn attach_kernel_program(&self, config: &EbpfXdpConfig) -> bool {
         if std::env::consts::OS != "linux" {
             warn!("eBPF XDP is only supported on Linux. Operating in simulated mode.");
-            return;
+            self.inner.attached.store(false, Ordering::SeqCst);
+            return false;
         }
 
         if !std::path::Path::new("bpf/xdp_drop.o").exists() {
@@ -178,24 +289,29 @@ impl EbpfXdpManager {
                 Ok(o) if o.status.success() => {
                     info!("Compiled bpf/xdp_drop.o successfully")
                 }
-                Ok(o) => error!(
-                    "Failed to compile XDP program: {}",
-                    String::from_utf8_lossy(&o.stderr)
-                ),
-                Err(e) => error!("Failed to invoke clang: {}", e),
+                Ok(o) => {
+                    error!(
+                        "Failed to compile XDP program: {}",
+                        String::from_utf8_lossy(&o.stderr)
+                    );
+                    self.inner.attached.store(false, Ordering::SeqCst);
+                    return false;
+                }
+                Err(e) => {
+                    error!("Failed to invoke clang: {}", e);
+                    self.inner.attached.store(false, Ordering::SeqCst);
+                    return false;
+                }
             }
         }
 
-        let mode_str = match config.mode {
-            XdpMode::Driver => "xdp",
-            XdpMode::Offload => "xdpoffload",
-            XdpMode::Skb => "xdpgeneric",
-        };
+        let mode_str = config.mode.ip_link_arg();
 
         // Detach previous attachment first (ignore errors if none existed)
         let _ = Command::new("ip")
             .args(["link", "set", "dev", &config.interface, mode_str, "off"])
             .output();
+        self.inner.attached.store(false, Ordering::SeqCst);
 
         info!(
             "Attaching XDP program bpf/xdp_drop.o to netdev {}",
@@ -215,90 +331,109 @@ impl EbpfXdpManager {
             ])
             .output();
         match attach {
-            Ok(o) if !o.status.success() => error!(
-                "Failed to attach XDP to {}: {}",
-                config.interface,
-                String::from_utf8_lossy(&o.stderr)
-            ),
-            Err(e) => error!("Failed to invoke ip command: {}", e),
-            _ => info!("Attached XDP program to {} successfully", config.interface),
+            Ok(o) if o.status.success() => {
+                info!("Attached XDP program to {} successfully", config.interface);
+                self.inner.attached.store(true, Ordering::SeqCst);
+                true
+            }
+            Ok(o) => {
+                error!(
+                    "Failed to attach XDP to {}: {}",
+                    config.interface,
+                    String::from_utf8_lossy(&o.stderr)
+                );
+                false
+            }
+            Err(e) => {
+                error!("Failed to invoke ip command: {}", e);
+                false
+            }
         }
     }
 
-    fn detach_kernel_program(&self, config: &EbpfXdpConfig) {
-        if std::env::consts::OS == "linux" {
-            let mode_str = match config.mode {
-                XdpMode::Driver => "xdp",
-                XdpMode::Offload => "xdpoffload",
-                XdpMode::Skb => "xdpgeneric",
-            };
-            let _ = Command::new("ip")
-                .args(["link", "set", "dev", &config.interface, mode_str, "off"])
-                .output();
-        }
+    fn detach(&self, config: &EbpfXdpConfig) {
+        detach_kernel_program(config);
+        self.inner.attached.store(false, Ordering::SeqCst);
     }
 
     /// Formats an IP address as a hex string suitable for bpftool.
     fn ip_to_hex(ip: &IpAddr) -> String {
-        match ip {
-            IpAddr::V4(v4) => {
-                let octets = v4.octets();
-                format!(
-                    "{:02x} {:02x} {:02x} {:02x}",
-                    octets[0], octets[1], octets[2], octets[3]
-                )
-            }
-            IpAddr::V6(v6) => {
-                let octets = v6.octets();
-                octets
-                    .iter()
-                    .map(|b| format!("{:02x}", b))
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            }
-        }
+        let bytes: Vec<u8> = match ip {
+            IpAddr::V4(v4) => v4.octets().to_vec(),
+            IpAddr::V6(v6) => v6.octets().to_vec(),
+        };
+        bytes
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     pub fn is_enabled(&self) -> bool {
-        self.config.read().map(|c| c.enabled).unwrap_or(false)
+        self.inner.config.read().map(|c| c.enabled).unwrap_or(false)
+    }
+
+    /// Whether the XDP program is currently loaded on the interface.
+    pub fn is_attached(&self) -> bool {
+        self.inner.attached.load(Ordering::SeqCst)
     }
 
     pub fn config(&self) -> EbpfXdpConfig {
-        self.config.read().map(|c| c.clone()).unwrap_or_default()
+        self.inner
+            .config
+            .read()
+            .map(|c| c.clone())
+            .unwrap_or_default()
     }
 
     /// Updates the runtime eBPF configuration.
+    ///
+    /// The kernel program is only re-attached when the attachment actually
+    /// changes (enable transition, interface or mode change) — unrelated field
+    /// edits no longer tear down a working filter.
     pub fn update_config(&self, new_cfg: EbpfXdpConfig) -> Result<(), String> {
-        let mut cfg = self
-            .config
-            .write()
-            .map_err(|_| "Failed to acquire config write lock".to_string())?;
+        new_cfg.validate()?;
 
-        let was_enabled = cfg.enabled;
-        let old_iface = cfg.interface.clone();
-        let old_mode = cfg.mode;
+        // Snapshot the transition under the lock, then release it before any
+        // kernel interaction.
+        let (was_enabled, old_cfg) = {
+            let mut cfg = self
+                .inner
+                .config
+                .write()
+                .map_err(|_| "Failed to acquire config write lock".to_string())?;
+            let previous = cfg.clone();
+            *cfg = new_cfg.clone();
+            (previous.enabled, previous)
+        };
 
-        *cfg = new_cfg.clone();
+        let attachment_changed =
+            old_cfg.interface != new_cfg.interface || old_cfg.mode != new_cfg.mode;
 
-        if was_enabled
-            && (!new_cfg.enabled || old_iface != new_cfg.interface || old_mode != new_cfg.mode)
-        {
-            let old_config = EbpfXdpConfig {
-                enabled: was_enabled,
-                interface: old_iface,
-                mode: old_mode,
-                map_name: cfg.map_name.clone(),
-                max_entries: cfg.max_entries,
-            };
-            self.detach_kernel_program(&old_config);
+        if was_enabled && (!new_cfg.enabled || attachment_changed) {
+            self.detach(&old_cfg);
         }
 
-        if new_cfg.enabled {
-            self.attach_kernel_program(&new_cfg);
-            // Re-sync existing blocked IPs into the kernel map
-            if let Ok(blocked) = self.blocked_ips.read() {
-                for ip in blocked.keys() {
-                    self.sync_ip_to_kernel(ip, true);
+        if new_cfg.enabled && (!was_enabled || attachment_changed || !self.is_attached()) {
+            if !self.attach_kernel_program(&new_cfg) {
+                return Err(format!(
+                    "eBPF XDP program could not be attached to {}",
+                    new_cfg.interface
+                ));
+            }
+            // Re-sync existing blocked IPs into the freshly loaded kernel maps.
+            let ips: Vec<IpAddr> = self
+                .inner
+                .blocked_ips
+                .read()
+                .map(|m| m.keys().copied().collect())
+                .unwrap_or_default();
+            for ip in ips {
+                if let Err(e) = self.sync_ip_to_kernel(&ip, true) {
+                    error!(
+                        "Failed to re-sync blocked IP {} after config change: {}",
+                        ip, e
+                    );
                 }
             }
         }
@@ -306,61 +441,83 @@ impl EbpfXdpManager {
         Ok(())
     }
 
-    fn sync_ip_to_kernel(&self, ip: &IpAddr, block: bool) {
+    fn map_name_for(&self, ip: &IpAddr) -> String {
+        match ip {
+            IpAddr::V4(_) => MAP_NAME_V4.to_string(),
+            IpAddr::V6(_) => MAP_NAME_V6.to_string(),
+        }
+    }
+
+    /// Programs (or removes) a single address in the kernel map.
+    ///
+    /// Returns `Err` on any kernel-side failure so callers never report success
+    /// for an address that is not actually filtered.
+    fn sync_ip_to_kernel(&self, ip: &IpAddr, block: bool) -> Result<(), String> {
         if std::env::consts::OS != "linux" {
-            return;
+            debug!("eBPF XDP simulated mode: skipping kernel sync for {}", ip);
+            return Ok(());
         }
 
-        let map_name = match ip {
-            IpAddr::V4(_) => self
-                .config
-                .read()
-                .map(|c| c.map_name.clone())
-                .unwrap_or_else(|_| "bsdm_blocked_ips".to_string()),
-            IpAddr::V6(_) => "bsdm_blocked_ips_v6".to_string(),
+        let map_name = self.map_name_for(ip);
+        let hex = Self::ip_to_hex(ip);
+        // Value layout must match `struct ip_drop_stats` in bpf/xdp_drop.c
+        // (two u64 counters, zero-initialised on insert).
+        let zero_value = vec!["00"; 16].join(" ");
+
+        let args: Vec<&str> = if block {
+            vec![
+                "map",
+                "update",
+                "name",
+                &map_name,
+                "key",
+                "hex",
+                &hex,
+                "value",
+                "hex",
+                &zero_value,
+            ]
+        } else {
+            vec!["map", "delete", "name", &map_name, "key", "hex", &hex]
         };
 
-        let hex = Self::ip_to_hex(ip);
+        let out = Command::new("bpftool")
+            .args(&args)
+            .output()
+            .map_err(|e| format!("failed to invoke bpftool: {}", e))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let action = if block { "update" } else { "delete" };
+            error!(
+                "Failed to {} BPF map {} for {}: {}",
+                action, map_name, ip, stderr
+            );
+            return Err(format!("bpftool map {} failed: {}", action, stderr));
+        }
+
         if block {
-            let args = vec![
-                "map", "update", "name", &map_name, "key", "hex", &hex, "value", "hex", "01",
-            ];
-            let out = Command::new("bpftool").args(&args).output();
-            if let Ok(o) = out {
-                if !o.status.success() {
-                    error!(
-                        "Failed to update BPF map {} for {}: {}",
-                        map_name,
-                        ip,
-                        String::from_utf8_lossy(&o.stderr)
-                    );
-                } else {
-                    info!(
-                        "eBPF XDP: Blocked IP {} synced to kernel BPF map {}",
-                        ip, map_name
-                    );
-                }
-            }
+            info!(
+                "eBPF XDP: Blocked IP {} synced to kernel BPF map {}",
+                ip, map_name
+            );
         } else {
-            let args = vec!["map", "delete", "name", &map_name, "key", "hex", &hex];
-            let _ = Command::new("bpftool").args(&args).output();
             info!(
                 "eBPF XDP: Removed IP {} from kernel BPF map {}",
                 ip, map_name
             );
         }
+        Ok(())
     }
 
     /// Block an IP address with optional reason. Returns the created entry.
+    ///
+    /// If the kernel map cannot be programmed the entry is rolled back and an
+    /// error is returned — the API must not advertise a block that is not live.
     pub fn block_ip(&self, ip: IpAddr, reason: Option<String>) -> Result<EbpfBlockedIp, String> {
-        let mut map = self
-            .blocked_ips
-            .write()
-            .map_err(|_| "Failed to acquire write lock".to_string())?;
-
         let id = format!("ebpf-{}", ip.to_string().replace(['.', ':'], "-"));
         let entry = EbpfBlockedIp {
-            id: id.clone(),
+            id,
             ip: ip.to_string(),
             added_at: chrono::Utc::now().to_rfc3339(),
             reason: reason.unwrap_or_else(|| "Manual administrative block".to_string()),
@@ -368,83 +525,201 @@ impl EbpfXdpManager {
             bytes_dropped: 0,
         };
 
-        map.insert(ip, entry.clone());
+        {
+            let mut map = self
+                .inner
+                .blocked_ips
+                .write()
+                .map_err(|_| "Failed to acquire write lock".to_string())?;
+            if map.contains_key(&ip) {
+                return Err(format!("IP {} is already blocked", ip));
+            }
+            map.insert(ip, entry.clone());
+        }
 
         if self.is_enabled() {
-            self.sync_ip_to_kernel(&ip, true);
+            if let Err(e) = self.sync_ip_to_kernel(&ip, true) {
+                if let Ok(mut map) = self.inner.blocked_ips.write() {
+                    map.remove(&ip);
+                }
+                return Err(e);
+            }
         }
 
         Ok(entry)
     }
 
     /// Unblock an IP address by its IP string or ID.
-    pub fn unblock_ip(&self, id_or_ip: &str) -> bool {
-        let mut map = match self.blocked_ips.write() {
-            Ok(m) => m,
-            Err(_) => return false,
+    ///
+    /// `Ok(false)` means the entry was unknown; `Err` means the entry was
+    /// removed from the registry but the kernel map still holds it.
+    pub fn unblock_ip(&self, id_or_ip: &str) -> Result<bool, String> {
+        let removed = {
+            let mut map = self
+                .inner
+                .blocked_ips
+                .write()
+                .map_err(|_| "Failed to acquire write lock".to_string())?;
+
+            let target = id_or_ip
+                .parse::<IpAddr>()
+                .ok()
+                .filter(|ip| map.contains_key(ip))
+                .or_else(|| {
+                    map.iter().find_map(|(ip, entry)| {
+                        if entry.id == id_or_ip || entry.ip == id_or_ip {
+                            Some(*ip)
+                        } else {
+                            None
+                        }
+                    })
+                });
+
+            match target {
+                Some(ip) => {
+                    map.remove(&ip);
+                    Some(ip)
+                }
+                None => None,
+            }
         };
 
-        // Check if argument parses directly as an IP address
-        if let Ok(ip) = id_or_ip.parse::<IpAddr>() {
-            if map.remove(&ip).is_some() {
-                if self.is_enabled() {
-                    self.sync_ip_to_kernel(&ip, false);
-                }
-                return true;
-            }
-        }
+        let Some(ip) = removed else {
+            return Ok(false);
+        };
 
-        // Search by ID or IP string representation
-        let found_ip = map.iter().find_map(|(ip, entry)| {
-            if entry.id == id_or_ip || entry.ip == id_or_ip {
-                Some(*ip)
-            } else {
-                None
-            }
-        });
-
-        if let Some(ip) = found_ip {
-            map.remove(&ip);
-            if self.is_enabled() {
-                self.sync_ip_to_kernel(&ip, false);
-            }
-            true
-        } else {
-            false
+        if self.is_enabled() {
+            self.sync_ip_to_kernel(&ip, false)?;
         }
+        Ok(true)
+    }
+
+    /// Number of addresses currently in the blocklist registry.
+    pub fn blocked_ip_count(&self) -> usize {
+        self.inner.blocked_ips.read().map(|m| m.len()).unwrap_or(0)
     }
 
     /// Check if an IP address is blocked.
     pub fn is_ip_blocked(&self, ip: &IpAddr) -> bool {
-        self.blocked_ips
+        self.inner
+            .blocked_ips
             .read()
             .map(|set| set.contains_key(ip))
             .unwrap_or(false)
     }
 
+    /// Pulls the authoritative counters out of the kernel maps into the
+    /// in-memory registry. No-op (returns `false`) outside Linux or when the
+    /// program is not attached.
+    pub fn refresh_kernel_stats(&self) -> bool {
+        if std::env::consts::OS != "linux" || !self.is_attached() {
+            return false;
+        }
+
+        // Rate-limit the dump so control-plane traffic cannot spawn one bpftool
+        // process per request.
+        match self.inner.last_stats_refresh.lock() {
+            Ok(mut last) => {
+                let now = Instant::now();
+                if let Some(prev) = *last {
+                    if now.duration_since(prev) < STATS_REFRESH_INTERVAL {
+                        return false;
+                    }
+                }
+                *last = Some(now);
+            }
+            Err(_) => return false,
+        }
+
+        let mut refreshed = false;
+
+        if let Some(entries) = dump_map(MAP_NAME_STATS) {
+            let mut packets = None;
+            let mut bytes = None;
+            for (key, value) in &entries {
+                let idx = le_u32(key);
+                let counter = le_u64(value);
+                match (idx, counter) {
+                    (Some(0), Some(v)) => packets = Some(v),
+                    (Some(1), Some(v)) => bytes = Some(v),
+                    _ => {}
+                }
+            }
+            if let Some(p) = packets {
+                self.inner.dropped_packets.store(p, Ordering::Relaxed);
+                refreshed = true;
+            }
+            if let Some(b) = bytes {
+                self.inner.dropped_bytes.store(b, Ordering::Relaxed);
+                refreshed = true;
+            }
+        }
+
+        // Per-address counters live in the value of each blocklist entry.
+        let mut per_ip: HashMap<IpAddr, (u64, u64)> = HashMap::new();
+        for (map_name, is_v6) in [(MAP_NAME_V4, false), (MAP_NAME_V6, true)] {
+            let Some(entries) = dump_map(map_name) else {
+                continue;
+            };
+            for (key, value) in entries {
+                let Some(ip) = bytes_to_ip(&key, is_v6) else {
+                    continue;
+                };
+                if value.len() < 16 {
+                    continue;
+                }
+                let packets = le_u64(&value[..8]).unwrap_or(0);
+                let bytes = le_u64(&value[8..16]).unwrap_or(0);
+                per_ip.insert(ip, (packets, bytes));
+            }
+        }
+
+        if !per_ip.is_empty() {
+            if let Ok(mut map) = self.inner.blocked_ips.write() {
+                for (ip, entry) in map.iter_mut() {
+                    if let Some((packets, bytes)) = per_ip.get(ip) {
+                        entry.packets_dropped = *packets;
+                        entry.bytes_dropped = *bytes;
+                    }
+                }
+                refreshed = true;
+            }
+        }
+
+        refreshed
+    }
+
     /// Retrieve kernel packet drop stats.
     pub fn stats(&self) -> EbpfStats {
-        let config = self.config();
-        let active_count = self.blocked_ips.read().map(|m| m.len() as u32).unwrap_or(0);
+        self.refresh_kernel_stats();
 
-        let global_pkts = self.global_dropped_packets.read().map(|g| *g).unwrap_or(0);
-        let global_bytes = self.global_dropped_bytes.read().map(|g| *g).unwrap_or(0);
+        let config = self.config();
+        let active_count = self
+            .inner
+            .blocked_ips
+            .read()
+            .map(|m| m.len() as u32)
+            .unwrap_or(0);
 
         EbpfStats {
             enabled: config.enabled,
+            attached: self.is_attached(),
             interface: config.interface,
             mode: config.mode,
             active_blocked_ips: active_count,
-            packets_dropped_total: global_pkts,
-            bytes_dropped_total: global_bytes,
-            kernel_latency_us: if config.enabled { 0.35 } else { 0.0 },
+            packets_dropped_total: self.inner.dropped_packets.load(Ordering::Relaxed),
+            bytes_dropped_total: self.inner.dropped_bytes.load(Ordering::Relaxed),
+            // No latency probe exists yet; report absence instead of a constant.
+            kernel_latency_us: None,
             cpu_usage_user_percent: 0.0,
         }
     }
 
     /// List all currently blocked IPs with audit metadata.
     pub fn list_blocked_ips(&self) -> Vec<EbpfBlockedIp> {
-        self.blocked_ips
+        self.refresh_kernel_stats();
+        self.inner
+            .blocked_ips
             .read()
             .map(|m| {
                 let mut list: Vec<EbpfBlockedIp> = m.values().cloned().collect();
@@ -454,41 +729,111 @@ impl EbpfXdpManager {
             .unwrap_or_default()
     }
 
-    /// Record a simulated or verified packet drop for metrics/accounting.
+    /// Record a drop observed outside the kernel maps (simulation mode, tests).
     pub fn record_drop(&self, ip: &IpAddr, bytes: u64) {
-        if let Ok(mut m) = self.blocked_ips.write() {
+        if let Ok(mut m) = self.inner.blocked_ips.write() {
             if let Some(entry) = m.get_mut(ip) {
                 entry.packets_dropped = entry.packets_dropped.saturating_add(1);
                 entry.bytes_dropped = entry.bytes_dropped.saturating_add(bytes);
             }
         }
-        if let Ok(mut g_pkts) = self.global_dropped_packets.write() {
-            *g_pkts = g_pkts.saturating_add(1);
-        }
-        if let Ok(mut g_bytes) = self.global_dropped_bytes.write() {
-            *g_bytes = g_bytes.saturating_add(bytes);
-        }
+        self.inner.dropped_packets.fetch_add(1, Ordering::Relaxed);
+        self.inner.dropped_bytes.fetch_add(bytes, Ordering::Relaxed);
     }
 
-    /// Clear all blocked IPs.
-    pub fn clear(&self) {
-        if let Ok(mut m) = self.blocked_ips.write() {
-            if self.is_enabled() {
-                for ip in m.keys() {
-                    self.sync_ip_to_kernel(ip, false);
-                }
+    /// Clear all blocked IPs. Returns the number of entries whose kernel-side
+    /// removal failed (they are logged individually).
+    pub fn clear(&self) -> usize {
+        let ips: Vec<IpAddr> = match self.inner.blocked_ips.write() {
+            Ok(mut m) => {
+                let keys: Vec<IpAddr> = m.keys().copied().collect();
+                m.clear();
+                keys
             }
-            m.clear();
+            Err(_) => return 0,
+        };
+
+        if !self.is_enabled() {
+            return 0;
         }
+
+        let mut failures = 0;
+        for ip in ips {
+            if let Err(e) = self.sync_ip_to_kernel(&ip, false) {
+                error!("Failed to remove {} from kernel map: {}", ip, e);
+                failures += 1;
+            }
+        }
+        failures
     }
 }
 
-impl Drop for EbpfXdpManager {
-    fn drop(&mut self) {
-        let config = self.config();
-        if config.enabled {
-            self.detach_kernel_program(&config);
-        }
+/// Runs `bpftool -j map dump name <map>` and returns raw (key, value) byte pairs.
+fn dump_map(map_name: &str) -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
+    let out = Command::new("bpftool")
+        .args(["-j", "map", "dump", "name", map_name])
+        .output()
+        .map_err(|e| debug!("bpftool unavailable for map {}: {}", map_name, e))
+        .ok()?;
+
+    if !out.status.success() {
+        debug!(
+            "bpftool map dump {} failed: {}",
+            map_name,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+        return None;
+    }
+
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .map_err(|e| warn!("Unparseable bpftool output for {}: {}", map_name, e))
+        .ok()?;
+
+    let entries = parsed.as_array()?;
+    let mut result = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let (Some(key), Some(value)) = (
+            entry.get("key").and_then(hex_array),
+            entry.get("value").and_then(hex_array),
+        ) else {
+            continue;
+        };
+        result.push((key, value));
+    }
+    Some(result)
+}
+
+/// Parses bpftool's `["0x0a","0x00",...]` byte arrays.
+fn hex_array(value: &serde_json::Value) -> Option<Vec<u8>> {
+    let arr = value.as_array()?;
+    let mut bytes = Vec::with_capacity(arr.len());
+    for item in arr {
+        let s = item.as_str()?;
+        let s = s.trim_start_matches("0x");
+        bytes.push(u8::from_str_radix(s, 16).ok()?);
+    }
+    Some(bytes)
+}
+
+fn le_u32(bytes: &[u8]) -> Option<u32> {
+    let raw: [u8; 4] = bytes.get(..4)?.try_into().ok()?;
+    Some(u32::from_le_bytes(raw))
+}
+
+fn le_u64(bytes: &[u8]) -> Option<u64> {
+    let raw: [u8; 8] = bytes.get(..8)?.try_into().ok()?;
+    Some(u64::from_le_bytes(raw))
+}
+
+/// Map keys hold the address in network byte order, exactly as written by
+/// [`EbpfXdpManager::ip_to_hex`].
+fn bytes_to_ip(bytes: &[u8], is_v6: bool) -> Option<IpAddr> {
+    if is_v6 {
+        let raw: [u8; 16] = bytes.get(..16)?.try_into().ok()?;
+        Some(IpAddr::V6(Ipv6Addr::from(raw)))
+    } else {
+        let raw: [u8; 4] = bytes.get(..4)?.try_into().ok()?;
+        Some(IpAddr::V4(Ipv4Addr::from(raw)))
     }
 }
 
@@ -504,6 +849,7 @@ mod tests {
         assert_eq!(cfg.mode, XdpMode::Skb);
         assert_eq!(cfg.map_name, "bsdm_blocked_ips");
         assert_eq!(cfg.max_entries, 65536);
+        cfg.validate().expect("default config is valid");
     }
 
     #[test]
@@ -514,6 +860,33 @@ mod tests {
         assert_eq!(XdpMode::parse("hw"), XdpMode::Offload);
         assert_eq!(XdpMode::parse("skb"), XdpMode::Skb);
         assert_eq!(XdpMode::parse("generic"), XdpMode::Skb);
+    }
+
+    #[test]
+    fn test_config_validation_rejects_unsupported_values() {
+        let too_many = EbpfXdpConfig {
+            max_entries: COMPILED_MAX_ENTRIES + 1,
+            ..Default::default()
+        };
+        assert!(too_many.validate().is_err());
+
+        let foreign_map = EbpfXdpConfig {
+            map_name: "some_other_map".to_string(),
+            ..Default::default()
+        };
+        assert!(foreign_map.validate().is_err());
+
+        let odd_iface = EbpfXdpConfig {
+            interface: "eth0; rm -rf /".to_string(),
+            ..Default::default()
+        };
+        assert!(odd_iface.validate().is_err());
+
+        let empty_iface = EbpfXdpConfig {
+            interface: String::new(),
+            ..Default::default()
+        };
+        assert!(empty_iface.validate().is_err());
     }
 
     #[test]
@@ -532,6 +905,9 @@ mod tests {
         assert_eq!(entry_v4.reason, "Test v4 drop");
         assert!(manager.is_ip_blocked(&ip_v4));
 
+        // Duplicate blocks are rejected instead of silently resetting counters.
+        assert!(manager.block_ip(ip_v4, None).is_err());
+
         let entry_v6 = manager
             .block_ip(ip_v6, Some("Test v6 drop".to_string()))
             .expect("block v6");
@@ -543,6 +919,8 @@ mod tests {
         assert_eq!(stats.active_blocked_ips, 2);
         assert_eq!(stats.packets_dropped_total, 0);
         assert_eq!(stats.bytes_dropped_total, 0);
+        assert!(!stats.attached);
+        assert_eq!(stats.kernel_latency_us, None);
 
         // Record a drop and verify metrics update
         manager.record_drop(&ip_v4, 64);
@@ -551,12 +929,111 @@ mod tests {
         assert_eq!(updated_stats.bytes_dropped_total, 64);
 
         // Unblock by IP string
-        assert!(manager.unblock_ip("192.0.2.42"));
+        assert!(manager.unblock_ip("192.0.2.42").expect("unblock v4"));
         assert!(!manager.is_ip_blocked(&ip_v4));
 
         // Unblock by ID
-        assert!(manager.unblock_ip(&entry_v6.id));
+        assert!(manager.unblock_ip(&entry_v6.id).expect("unblock v6"));
         assert!(!manager.is_ip_blocked(&ip_v6));
         assert_eq!(manager.stats().active_blocked_ips, 0);
+
+        // Unknown identifiers are reported as "not found", not as an error.
+        assert!(!manager.unblock_ip("203.0.113.9").expect("unknown ip"));
+    }
+
+    #[test]
+    fn test_clone_does_not_detach_shared_state() {
+        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
+        let ip: IpAddr = "198.51.100.7".parse().expect("valid ipv4");
+        manager.block_ip(ip, None).expect("block");
+
+        let handle = manager.clone();
+        drop(handle);
+
+        // The surviving handle still sees the shared registry.
+        assert!(manager.is_ip_blocked(&ip));
+        assert_eq!(manager.stats().active_blocked_ips, 1);
+    }
+
+    #[test]
+    fn test_update_config_does_not_deadlock_with_blocked_entries() {
+        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
+        manager
+            .block_ip("198.51.100.10".parse().expect("valid ipv4"), None)
+            .expect("block v4");
+        manager
+            .block_ip("2001:db8::10".parse().expect("valid ipv6"), None)
+            .expect("block v6");
+
+        let mut cfg = manager.config();
+        cfg.interface = "eth1".to_string();
+        cfg.mode = XdpMode::Driver;
+        manager.update_config(cfg).expect("update config");
+
+        assert_eq!(manager.config().interface, "eth1");
+        assert_eq!(manager.config().mode, XdpMode::Driver);
+        assert_eq!(manager.stats().active_blocked_ips, 2);
+    }
+
+    #[test]
+    fn test_update_config_rejects_invalid_settings() {
+        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
+        let mut cfg = manager.config();
+        cfg.max_entries = COMPILED_MAX_ENTRIES * 4;
+        assert!(manager.update_config(cfg).is_err());
+        // Rejected updates must not be applied.
+        assert_eq!(manager.config().max_entries, COMPILED_MAX_ENTRIES);
+    }
+
+    #[test]
+    fn test_concurrent_block_and_config_update_do_not_deadlock() {
+        use std::thread;
+
+        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
+        let writer = manager.clone();
+        let updater = manager.clone();
+
+        let t1 = thread::spawn(move || {
+            for i in 0..200u8 {
+                let ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, i));
+                let _ = writer.block_ip(ip, None);
+                let _ = writer.unblock_ip(&ip.to_string());
+            }
+        });
+        let t2 = thread::spawn(move || {
+            for i in 0..200u32 {
+                let mut cfg = updater.config();
+                cfg.max_entries = 1024 + i;
+                let _ = updater.update_config(cfg);
+            }
+        });
+
+        t1.join().expect("blocker thread");
+        t2.join().expect("updater thread");
+    }
+
+    #[test]
+    fn test_hex_array_and_key_decoding() {
+        let json: serde_json::Value =
+            serde_json::from_str(r#"["0xc0","0x00","0x02","0x2a"]"#).expect("json");
+        let bytes = hex_array(&json).expect("bytes");
+        assert_eq!(bytes, vec![0xc0, 0x00, 0x02, 0x2a]);
+        assert_eq!(
+            bytes_to_ip(&bytes, false),
+            Some("192.0.2.42".parse().expect("ipv4"))
+        );
+        assert_eq!(le_u64(&[1, 0, 0, 0, 0, 0, 0, 0]), Some(1));
+        assert_eq!(le_u32(&[2, 0, 0, 0]), Some(2));
+    }
+
+    #[test]
+    fn test_ip_to_hex_uses_network_byte_order() {
+        let v4: IpAddr = "192.0.2.42".parse().expect("ipv4");
+        assert_eq!(EbpfXdpManager::ip_to_hex(&v4), "c0 00 02 2a");
+        let v6: IpAddr = "2001:db8::1".parse().expect("ipv6");
+        assert_eq!(
+            EbpfXdpManager::ip_to_hex(&v6),
+            "20 01 0d b8 00 00 00 00 00 00 00 00 00 00 00 01"
+        );
     }
 }

--- a/proxy/src/ebpf.rs
+++ b/proxy/src/ebpf.rs
@@ -1,23 +1,28 @@
 //! eBPF / XDP (eXpress Data Path) kernel packet filter & bypass manager.
 //!
 //! Enables zero-CPU overhead packet drops at the NIC driver level (`XDP_DROP`)
-//! for blocked IP addresses and malicious CIDR blocks.
+//! for blocked IPv4/IPv6 addresses and malicious traffic.
 
-use std::collections::HashSet;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::process::Command;
 use std::sync::{Arc, RwLock};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Runtime mode for eBPF XDP program attachment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum XdpMode {
     /// Generic / SKB mode (works on any netdev, driver independent)
     #[default]
+    #[serde(alias = "skb")]
     Skb,
     /// Native driver mode (zero-copy hardware driver level)
+    #[serde(alias = "driver", alias = "native")]
     Driver,
     /// Hardware offload to SmartNIC
+    #[serde(alias = "offload", alias = "hw")]
     Offload,
 }
 
@@ -29,15 +34,26 @@ impl XdpMode {
             _ => Self::Skb,
         }
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Skb => "skb",
+            Self::Driver => "driver",
+            Self::Offload => "offload",
+        }
+    }
 }
 
 /// Runtime configuration for eBPF XDP filter.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EbpfXdpConfig {
     pub enabled: bool,
     pub interface: String,
     pub mode: XdpMode,
+    #[serde(alias = "map_name")]
     pub map_name: String,
+    #[serde(alias = "max_entries")]
     pub max_entries: u32,
 }
 
@@ -75,101 +91,154 @@ impl EbpfXdpConfig {
     }
 }
 
+/// A blocked IP entry with audit metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EbpfBlockedIp {
+    pub id: String,
+    pub ip: String,
+    pub added_at: String,
+    pub reason: String,
+    pub packets_dropped: u64,
+    pub bytes_dropped: u64,
+}
+
+/// Request body for blocking an IP address.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockIpRequest {
+    pub ip: String,
+    pub reason: Option<String>,
+}
+
 /// Kernel XDP statistics.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EbpfStats {
+    pub enabled: bool,
+    pub interface: String,
+    pub mode: XdpMode,
     pub active_blocked_ips: u32,
     pub packets_dropped_total: u64,
     pub bytes_dropped_total: u64,
     pub kernel_latency_us: f64,
+    pub cpu_usage_user_percent: f64,
 }
 
-/// Manager for kernel eBPF map sync and packet drops.
+/// Manager for kernel eBPF map sync, packet drops, and runtime statistics.
 #[derive(Clone)]
 pub struct EbpfXdpManager {
-    config: EbpfXdpConfig,
-    blocked_ips: Arc<RwLock<HashSet<IpAddr>>>,
-    packets_dropped: Arc<RwLock<u64>>,
+    config: Arc<RwLock<EbpfXdpConfig>>,
+    blocked_ips: Arc<RwLock<HashMap<IpAddr, EbpfBlockedIp>>>,
+    global_dropped_packets: Arc<RwLock<u64>>,
+    global_dropped_bytes: Arc<RwLock<u64>>,
 }
 
 impl EbpfXdpManager {
     pub fn new(config: EbpfXdpConfig) -> Self {
+        let manager = Self {
+            config: Arc::new(RwLock::new(config.clone())),
+            blocked_ips: Arc::new(RwLock::new(HashMap::new())),
+            global_dropped_packets: Arc::new(RwLock::new(0)),
+            global_dropped_bytes: Arc::new(RwLock::new(0)),
+        };
+
         if config.enabled {
             info!(
                 "Initializing eBPF XDP manager on interface {} (mode: {:?})",
                 config.interface, config.mode
             );
+            manager.attach_kernel_program(&config);
+        } else {
+            debug!("eBPF XDP manager initialized in disabled state");
+        }
 
-            if std::env::consts::OS == "linux" {
-                if !std::path::Path::new("bpf/xdp_drop.o").exists() {
-                    info!("Compiling bpf/xdp_drop.c ...");
-                    let out = Command::new("clang")
-                        .args([
-                            "-O2",
-                            "-target",
-                            "bpf",
-                            "-c",
-                            "bpf/xdp_drop.c",
-                            "-o",
-                            "bpf/xdp_drop.o",
-                        ])
-                        .output();
-                    match out {
-                        Ok(o) if o.status.success() => {
-                            info!("Compiled bpf/xdp_drop.o successfully")
-                        }
-                        Ok(o) => error!(
-                            "Failed to compile XDP program: {}",
-                            String::from_utf8_lossy(&o.stderr)
-                        ),
-                        Err(e) => error!("Failed to invoke clang: {}", e),
-                    }
+        manager
+    }
+
+    fn attach_kernel_program(&self, config: &EbpfXdpConfig) {
+        if std::env::consts::OS != "linux" {
+            warn!("eBPF XDP is only supported on Linux. Operating in simulated mode.");
+            return;
+        }
+
+        if !std::path::Path::new("bpf/xdp_drop.o").exists() {
+            info!("Compiling bpf/xdp_drop.c to BPF bytecode...");
+            let out = Command::new("clang")
+                .args([
+                    "-O2",
+                    "-target",
+                    "bpf",
+                    "-c",
+                    "bpf/xdp_drop.c",
+                    "-o",
+                    "bpf/xdp_drop.o",
+                ])
+                .output();
+            match out {
+                Ok(o) if o.status.success() => {
+                    info!("Compiled bpf/xdp_drop.o successfully")
                 }
-
-                let mode_str = match config.mode {
-                    XdpMode::Driver => "xdp",
-                    XdpMode::Offload => "xdpoffload",
-                    XdpMode::Skb => "xdpgeneric",
-                };
-
-                // Detach previous first, ignore errors
-                let _ = Command::new("ip")
-                    .args(["link", "set", "dev", &config.interface, mode_str, "off"])
-                    .output();
-
-                info!("Attaching XDP program to {}", config.interface);
-                let attach = Command::new("ip")
-                    .args([
-                        "link",
-                        "set",
-                        "dev",
-                        &config.interface,
-                        mode_str,
-                        "obj",
-                        "bpf/xdp_drop.o",
-                        "sec",
-                        "xdp",
-                    ])
-                    .output();
-                match attach {
-                    Ok(o) if !o.status.success() => error!(
-                        "Failed to attach XDP: {}",
-                        String::from_utf8_lossy(&o.stderr)
-                    ),
-                    Err(e) => error!("Failed to invoke ip command: {}", e),
-                    _ => {}
-                }
-            } else {
-                warn!("eBPF XDP is only supported on Linux. Operating in mocked mode.");
+                Ok(o) => error!(
+                    "Failed to compile XDP program: {}",
+                    String::from_utf8_lossy(&o.stderr)
+                ),
+                Err(e) => error!("Failed to invoke clang: {}", e),
             }
         }
-        Self {
-            config,
-            blocked_ips: Arc::new(RwLock::new(HashSet::new())),
-            packets_dropped: Arc::new(RwLock::new(0)),
+
+        let mode_str = match config.mode {
+            XdpMode::Driver => "xdp",
+            XdpMode::Offload => "xdpoffload",
+            XdpMode::Skb => "xdpgeneric",
+        };
+
+        // Detach previous attachment first (ignore errors if none existed)
+        let _ = Command::new("ip")
+            .args(["link", "set", "dev", &config.interface, mode_str, "off"])
+            .output();
+
+        info!(
+            "Attaching XDP program bpf/xdp_drop.o to netdev {}",
+            config.interface
+        );
+        let attach = Command::new("ip")
+            .args([
+                "link",
+                "set",
+                "dev",
+                &config.interface,
+                mode_str,
+                "obj",
+                "bpf/xdp_drop.o",
+                "sec",
+                "xdp",
+            ])
+            .output();
+        match attach {
+            Ok(o) if !o.status.success() => error!(
+                "Failed to attach XDP to {}: {}",
+                config.interface,
+                String::from_utf8_lossy(&o.stderr)
+            ),
+            Err(e) => error!("Failed to invoke ip command: {}", e),
+            _ => info!("Attached XDP program to {} successfully", config.interface),
         }
     }
 
+    fn detach_kernel_program(&self, config: &EbpfXdpConfig) {
+        if std::env::consts::OS == "linux" {
+            let mode_str = match config.mode {
+                XdpMode::Driver => "xdp",
+                XdpMode::Offload => "xdpoffload",
+                XdpMode::Skb => "xdpgeneric",
+            };
+            let _ = Command::new("ip")
+                .args(["link", "set", "dev", &config.interface, mode_str, "off"])
+                .output();
+        }
+    }
+
+    /// Formats an IP address as a hex string suitable for bpftool.
     fn ip_to_hex(ip: &IpAddr) -> String {
         match ip {
             IpAddr::V4(v4) => {
@@ -191,136 +260,234 @@ impl EbpfXdpManager {
     }
 
     pub fn is_enabled(&self) -> bool {
-        self.config.enabled
+        self.config.read().map(|c| c.enabled).unwrap_or(false)
     }
 
-    pub fn config(&self) -> &EbpfXdpConfig {
-        &self.config
+    pub fn config(&self) -> EbpfXdpConfig {
+        self.config.read().map(|c| c.clone()).unwrap_or_default()
     }
 
-    /// Block an IP address in the kernel eBPF map.
-    pub fn block_ip(&self, ip: IpAddr) -> bool {
-        if let Ok(mut set) = self.blocked_ips.write() {
-            let inserted = set.insert(ip);
-            if inserted && self.config.enabled {
-                if std::env::consts::OS == "linux" {
-                    let hex = Self::ip_to_hex(&ip);
-                    let args = vec![
-                        "map",
-                        "update",
-                        "name",
-                        &self.config.map_name,
-                        "key",
-                        "hex",
-                        &hex,
-                        "value",
-                        "hex",
-                        "01",
-                    ];
-                    let out = Command::new("bpftool").args(&args).output();
-                    if let Ok(o) = out {
-                        if !o.status.success() {
-                            error!(
-                                "Failed to update BPF map for {}: {}",
-                                ip,
-                                String::from_utf8_lossy(&o.stderr)
-                            );
-                        }
-                    }
+    /// Updates the runtime eBPF configuration.
+    pub fn update_config(&self, new_cfg: EbpfXdpConfig) -> Result<(), String> {
+        let mut cfg = self
+            .config
+            .write()
+            .map_err(|_| "Failed to acquire config write lock".to_string())?;
+
+        let was_enabled = cfg.enabled;
+        let old_iface = cfg.interface.clone();
+        let old_mode = cfg.mode;
+
+        *cfg = new_cfg.clone();
+
+        if was_enabled
+            && (!new_cfg.enabled || old_iface != new_cfg.interface || old_mode != new_cfg.mode)
+        {
+            let old_config = EbpfXdpConfig {
+                enabled: was_enabled,
+                interface: old_iface,
+                mode: old_mode,
+                map_name: cfg.map_name.clone(),
+                max_entries: cfg.max_entries,
+            };
+            self.detach_kernel_program(&old_config);
+        }
+
+        if new_cfg.enabled {
+            self.attach_kernel_program(&new_cfg);
+            // Re-sync existing blocked IPs into the kernel map
+            if let Ok(blocked) = self.blocked_ips.read() {
+                for ip in blocked.keys() {
+                    self.sync_ip_to_kernel(ip, true);
                 }
-                info!("eBPF XDP: Synced blocked IP {} to kernel BPF map", ip);
             }
-            inserted
+        }
+
+        Ok(())
+    }
+
+    fn sync_ip_to_kernel(&self, ip: &IpAddr, block: bool) {
+        if std::env::consts::OS != "linux" {
+            return;
+        }
+
+        let map_name = match ip {
+            IpAddr::V4(_) => self
+                .config
+                .read()
+                .map(|c| c.map_name.clone())
+                .unwrap_or_else(|_| "bsdm_blocked_ips".to_string()),
+            IpAddr::V6(_) => "bsdm_blocked_ips_v6".to_string(),
+        };
+
+        let hex = Self::ip_to_hex(ip);
+        if block {
+            let args = vec![
+                "map", "update", "name", &map_name, "key", "hex", &hex, "value", "hex", "01",
+            ];
+            let out = Command::new("bpftool").args(&args).output();
+            if let Ok(o) = out {
+                if !o.status.success() {
+                    error!(
+                        "Failed to update BPF map {} for {}: {}",
+                        map_name,
+                        ip,
+                        String::from_utf8_lossy(&o.stderr)
+                    );
+                } else {
+                    info!(
+                        "eBPF XDP: Blocked IP {} synced to kernel BPF map {}",
+                        ip, map_name
+                    );
+                }
+            }
+        } else {
+            let args = vec!["map", "delete", "name", &map_name, "key", "hex", &hex];
+            let _ = Command::new("bpftool").args(&args).output();
+            info!(
+                "eBPF XDP: Removed IP {} from kernel BPF map {}",
+                ip, map_name
+            );
+        }
+    }
+
+    /// Block an IP address with optional reason. Returns the created entry.
+    pub fn block_ip(&self, ip: IpAddr, reason: Option<String>) -> Result<EbpfBlockedIp, String> {
+        let mut map = self
+            .blocked_ips
+            .write()
+            .map_err(|_| "Failed to acquire write lock".to_string())?;
+
+        let id = format!("ebpf-{}", ip.to_string().replace(['.', ':'], "-"));
+        let entry = EbpfBlockedIp {
+            id: id.clone(),
+            ip: ip.to_string(),
+            added_at: chrono::Utc::now().to_rfc3339(),
+            reason: reason.unwrap_or_else(|| "Manual administrative block".to_string()),
+            packets_dropped: 0,
+            bytes_dropped: 0,
+        };
+
+        map.insert(ip, entry.clone());
+
+        if self.is_enabled() {
+            self.sync_ip_to_kernel(&ip, true);
+        }
+
+        Ok(entry)
+    }
+
+    /// Unblock an IP address by its IP string or ID.
+    pub fn unblock_ip(&self, id_or_ip: &str) -> bool {
+        let mut map = match self.blocked_ips.write() {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+
+        // Check if argument parses directly as an IP address
+        if let Ok(ip) = id_or_ip.parse::<IpAddr>() {
+            if map.remove(&ip).is_some() {
+                if self.is_enabled() {
+                    self.sync_ip_to_kernel(&ip, false);
+                }
+                return true;
+            }
+        }
+
+        // Search by ID or IP string representation
+        let found_ip = map.iter().find_map(|(ip, entry)| {
+            if entry.id == id_or_ip || entry.ip == id_or_ip {
+                Some(*ip)
+            } else {
+                None
+            }
+        });
+
+        if let Some(ip) = found_ip {
+            map.remove(&ip);
+            if self.is_enabled() {
+                self.sync_ip_to_kernel(&ip, false);
+            }
+            true
         } else {
             false
         }
     }
 
-    /// Unblock an IP address from the kernel eBPF map.
-    pub fn unblock_ip(&self, ip: &IpAddr) -> bool {
-        if let Ok(mut set) = self.blocked_ips.write() {
-            let removed = set.remove(ip);
-            if removed && self.config.enabled {
-                if std::env::consts::OS == "linux" {
-                    let hex = Self::ip_to_hex(ip);
-                    let args = vec![
-                        "map",
-                        "delete",
-                        "name",
-                        &self.config.map_name,
-                        "key",
-                        "hex",
-                        &hex,
-                    ];
-                    let _ = Command::new("bpftool").args(&args).output();
-                }
-                info!("eBPF XDP: Removed IP {} from kernel BPF map", ip);
-            }
-            removed
-        } else {
-            false
-        }
-    }
-
-    /// Check if an IP address is blocked in the kernel map.
+    /// Check if an IP address is blocked.
     pub fn is_ip_blocked(&self, ip: &IpAddr) -> bool {
         self.blocked_ips
             .read()
-            .map(|set| set.contains(ip))
+            .map(|set| set.contains_key(ip))
             .unwrap_or(false)
     }
 
     /// Retrieve kernel packet drop stats.
     pub fn stats(&self) -> EbpfStats {
-        let count = self
-            .blocked_ips
-            .read()
-            .map(|set| set.len() as u32)
-            .unwrap_or(0);
-        let dropped = self.packets_dropped.read().map(|v| *v).unwrap_or(0);
+        let config = self.config();
+        let active_count = self.blocked_ips.read().map(|m| m.len() as u32).unwrap_or(0);
+
+        let global_pkts = self.global_dropped_packets.read().map(|g| *g).unwrap_or(0);
+        let global_bytes = self.global_dropped_bytes.read().map(|g| *g).unwrap_or(0);
 
         EbpfStats {
-            active_blocked_ips: count,
-            packets_dropped_total: if dropped == 0 && count > 0 {
-                184250
-            } else {
-                dropped
-            },
-            bytes_dropped_total: if dropped == 0 && count > 0 {
-                117920000
-            } else {
-                dropped * 64
-            },
-            kernel_latency_us: 0.45,
+            enabled: config.enabled,
+            interface: config.interface,
+            mode: config.mode,
+            active_blocked_ips: active_count,
+            packets_dropped_total: global_pkts,
+            bytes_dropped_total: global_bytes,
+            kernel_latency_us: if config.enabled { 0.35 } else { 0.0 },
+            cpu_usage_user_percent: 0.0,
         }
     }
 
-    pub fn list_blocked_ips(&self) -> Vec<IpAddr> {
+    /// List all currently blocked IPs with audit metadata.
+    pub fn list_blocked_ips(&self) -> Vec<EbpfBlockedIp> {
         self.blocked_ips
             .read()
-            .map(|set| set.iter().copied().collect())
+            .map(|m| {
+                let mut list: Vec<EbpfBlockedIp> = m.values().cloned().collect();
+                list.sort_by(|a, b| b.added_at.cmp(&a.added_at));
+                list
+            })
             .unwrap_or_default()
+    }
+
+    /// Record a simulated or verified packet drop for metrics/accounting.
+    pub fn record_drop(&self, ip: &IpAddr, bytes: u64) {
+        if let Ok(mut m) = self.blocked_ips.write() {
+            if let Some(entry) = m.get_mut(ip) {
+                entry.packets_dropped = entry.packets_dropped.saturating_add(1);
+                entry.bytes_dropped = entry.bytes_dropped.saturating_add(bytes);
+            }
+        }
+        if let Ok(mut g_pkts) = self.global_dropped_packets.write() {
+            *g_pkts = g_pkts.saturating_add(1);
+        }
+        if let Ok(mut g_bytes) = self.global_dropped_bytes.write() {
+            *g_bytes = g_bytes.saturating_add(bytes);
+        }
+    }
+
+    /// Clear all blocked IPs.
+    pub fn clear(&self) {
+        if let Ok(mut m) = self.blocked_ips.write() {
+            if self.is_enabled() {
+                for ip in m.keys() {
+                    self.sync_ip_to_kernel(ip, false);
+                }
+            }
+            m.clear();
+        }
     }
 }
 
 impl Drop for EbpfXdpManager {
     fn drop(&mut self) {
-        if self.config.enabled && std::env::consts::OS == "linux" {
-            let mode_str = match self.config.mode {
-                XdpMode::Driver => "xdp",
-                XdpMode::Offload => "xdpoffload",
-                XdpMode::Skb => "xdpgeneric",
-            };
-            let _ = Command::new("ip")
-                .args([
-                    "link",
-                    "set",
-                    "dev",
-                    &self.config.interface,
-                    mode_str,
-                    "off",
-                ])
-                .output();
+        let config = self.config();
+        if config.enabled {
+            self.detach_kernel_program(&config);
         }
     }
 }
@@ -335,17 +502,61 @@ mod tests {
         assert!(!cfg.enabled);
         assert_eq!(cfg.interface, "eth0");
         assert_eq!(cfg.mode, XdpMode::Skb);
+        assert_eq!(cfg.map_name, "bsdm_blocked_ips");
+        assert_eq!(cfg.max_entries, 65536);
     }
 
     #[test]
-    fn test_ebpf_ip_blocking() {
-        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
-        let ip: IpAddr = "192.0.2.42".parse().unwrap();
+    fn test_ebpf_mode_parsing() {
+        assert_eq!(XdpMode::parse("driver"), XdpMode::Driver);
+        assert_eq!(XdpMode::parse("native"), XdpMode::Driver);
+        assert_eq!(XdpMode::parse("offload"), XdpMode::Offload);
+        assert_eq!(XdpMode::parse("hw"), XdpMode::Offload);
+        assert_eq!(XdpMode::parse("skb"), XdpMode::Skb);
+        assert_eq!(XdpMode::parse("generic"), XdpMode::Skb);
+    }
 
-        assert!(!manager.is_ip_blocked(&ip));
-        assert!(manager.block_ip(ip));
-        assert!(manager.is_ip_blocked(&ip));
-        assert!(manager.unblock_ip(&ip));
-        assert!(!manager.is_ip_blocked(&ip));
+    #[test]
+    fn test_ebpf_ipv4_and_ipv6_blocking() {
+        let manager = EbpfXdpManager::new(EbpfXdpConfig::default());
+        let ip_v4: IpAddr = "192.0.2.42".parse().expect("valid ipv4");
+        let ip_v6: IpAddr = "2001:db8::1".parse().expect("valid ipv6");
+
+        assert!(!manager.is_ip_blocked(&ip_v4));
+        assert!(!manager.is_ip_blocked(&ip_v6));
+
+        let entry_v4 = manager
+            .block_ip(ip_v4, Some("Test v4 drop".to_string()))
+            .expect("block v4");
+        assert_eq!(entry_v4.ip, "192.0.2.42");
+        assert_eq!(entry_v4.reason, "Test v4 drop");
+        assert!(manager.is_ip_blocked(&ip_v4));
+
+        let entry_v6 = manager
+            .block_ip(ip_v6, Some("Test v6 drop".to_string()))
+            .expect("block v6");
+        assert_eq!(entry_v6.ip, "2001:db8::1");
+        assert!(manager.is_ip_blocked(&ip_v6));
+
+        // Stats should reflect active blocked count and initially 0 drops (no fake stubs)
+        let stats = manager.stats();
+        assert_eq!(stats.active_blocked_ips, 2);
+        assert_eq!(stats.packets_dropped_total, 0);
+        assert_eq!(stats.bytes_dropped_total, 0);
+
+        // Record a drop and verify metrics update
+        manager.record_drop(&ip_v4, 64);
+        let updated_stats = manager.stats();
+        assert_eq!(updated_stats.packets_dropped_total, 1);
+        assert_eq!(updated_stats.bytes_dropped_total, 64);
+
+        // Unblock by IP string
+        assert!(manager.unblock_ip("192.0.2.42"));
+        assert!(!manager.is_ip_blocked(&ip_v4));
+
+        // Unblock by ID
+        assert!(manager.unblock_ip(&entry_v6.id));
+        assert!(!manager.is_ip_blocked(&ip_v6));
+        assert_eq!(manager.stats().active_blocked_ips, 0);
     }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -91,7 +91,7 @@ pub use cache_digest::DigestRegistry;
 pub use cache_key::http_cache_key;
 pub use categorization::{CategorizationConfig, CategorizationEngine, Category};
 pub use control_api::ControlApiState;
-pub use ebpf::{EbpfStats, EbpfXdpConfig, EbpfXdpManager, XdpMode};
+pub use ebpf::{BlockIpRequest, EbpfBlockedIp, EbpfStats, EbpfXdpConfig, EbpfXdpManager, XdpMode};
 pub use hierarchy::{HierarchyConfig, HierarchyManager, HierarchyResult};
 pub use hierarchy_config::{
     build_hierarchy_manager, htcp_peer_port, htcp_server_bind_addr, icp_server_bind_addr,

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -373,6 +373,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         http_for_control,
     );
     let ebpf_manager = Arc::new(EbpfXdpManager::new(EbpfXdpConfig::from_env()));
+    let ebpf_for_metrics = ebpf_manager.clone();
 
     control_builder = control_builder
         .with_mitm_circuit_breaker(service.mitm_circuit_breaker())
@@ -674,6 +675,62 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     });
+
+    if ebpf_for_metrics.is_enabled() {
+        let metrics_clone = metrics.clone();
+        let mut ebpf_shutdown_rx = shutdown_rx.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(15));
+            // Prometheus counters are monotonic, so export deltas of the kernel
+            // totals; a smaller value means the maps were reset on re-attach.
+            let mut last_packets: u64 = 0;
+            let mut last_bytes: u64 = 0;
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let stats = ebpf_for_metrics.stats();
+                        metrics_clone
+                            .ebpf_blocked_ips
+                            .set(stats.active_blocked_ips as f64);
+
+                        let packets = stats.packets_dropped_total;
+                        let bytes = stats.bytes_dropped_total;
+                        let packet_delta = packets.saturating_sub(last_packets);
+                        let byte_delta = bytes.saturating_sub(last_bytes);
+                        if packets < last_packets || bytes < last_bytes {
+                            debug!("eBPF kernel counters reset; rebasing Prometheus counters");
+                            last_packets = packets;
+                            last_bytes = bytes;
+                        } else {
+                            if packet_delta > 0 {
+                                metrics_clone
+                                    .ebpf_packets_dropped_total
+                                    .inc_by(packet_delta as f64);
+                            }
+                            if byte_delta > 0 {
+                                metrics_clone.ebpf_bytes_dropped_total.inc_by(byte_delta as f64);
+                            }
+                            last_packets = packets;
+                            last_bytes = bytes;
+                        }
+
+                        if !stats.attached {
+                            warn!(
+                                interface = %stats.interface,
+                                "eBPF XDP is enabled but no program is attached — traffic is not being filtered"
+                            );
+                        }
+                    }
+                    changed = ebpf_shutdown_rx.changed() => {
+                        if changed.is_ok() && *ebpf_shutdown_rx.borrow() {
+                            debug!("eBPF metrics reporter stopped");
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
 
     if let Some(auth_manager) = service.auth() {
         let mut auth_shutdown_rx = shutdown_rx.clone();

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -9,10 +9,11 @@ use bsdm_proxy::{
     http_cache_key, icp_server_bind_addr, load_hierarchy_config, load_policy_config,
     metrics_server, policy_config::reload_acl_engine, run_peer_discovery, should_start_htcp_server,
     should_start_icp_server, validate_mitm_policy, wait_shutdown_signal, AclAction, AuthManager,
-    CacheConfig, CertCache, ControlApiState, GlobalSessionStore, HtcpServer, HttpEventPipeline,
-    IcpServer, L2CacheConfig, Metrics, PeerDiscoveryConfig, PerfConfig, PolicyCacheConfig,
-    PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig, RedisL2Cache,
-    ThreatScoreCache, ThreatScoreConfig, ThreatSyncEngine, TiEnforceMatcher, UpstreamTlsConfig,
+    CacheConfig, CertCache, ControlApiState, EbpfXdpConfig, EbpfXdpManager, GlobalSessionStore,
+    HtcpServer, HttpEventPipeline, IcpServer, L2CacheConfig, Metrics, PeerDiscoveryConfig,
+    PerfConfig, PolicyCacheConfig, PolicyDecisionCache, ProxyPolicy, ProxyService, RateLimitConfig,
+    RedisL2Cache, ThreatScoreCache, ThreatScoreConfig, ThreatSyncEngine, TiEnforceMatcher,
+    UpstreamTlsConfig,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -370,10 +371,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "kafka")]
         kafka_for_control,
         http_for_control,
-    )
-    .with_mitm_circuit_breaker(service.mitm_circuit_breaker())
-    .with_cert_cache(cert_cache_for_control)
-    .with_config_apply(shutdown_tx.clone(), acl_api.clone());
+    );
+    let ebpf_manager = Arc::new(EbpfXdpManager::new(EbpfXdpConfig::from_env()));
+
+    control_builder = control_builder
+        .with_mitm_circuit_breaker(service.mitm_circuit_breaker())
+        .with_cert_cache(cert_cache_for_control)
+        .with_ebpf_manager(ebpf_manager)
+        .with_config_apply(shutdown_tx.clone(), acl_api.clone());
 
     // Multi-node agent device registry + CRL (Redis write-through).
     if let Some(url) = bsdm_proxy::device_registry::redis_url_from_env() {
@@ -395,8 +400,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let control_api = Arc::new(control_builder);
     info!(
-        "Control plane API on :{}/api/stats · :{}/api/cache/purge · :{}/api/hierarchy/* · :{}/api/upstream/tls · :{}/api/pinning/exceptions",
-        metrics_port, metrics_port, metrics_port, metrics_port, metrics_port
+        "Control plane API on :{}/api/stats · :{}/api/cache/purge · :{}/api/hierarchy/* · :{}/api/upstream/tls · :{}/api/ebpf/* · :{}/api/pinning/exceptions",
+        metrics_port, metrics_port, metrics_port, metrics_port, metrics_port, metrics_port
     );
     if !control_api.auth_required() {
         warn!(

--- a/proxy/src/metrics.rs
+++ b/proxy/src/metrics.rs
@@ -126,6 +126,14 @@ pub struct Metrics {
     pub awg_tx_bytes_total: Counter,
     /// AmneziaWG interface config reloads
     pub awg_reloads_total: CounterVec,
+
+    // eBPF / XDP metrics
+    /// Number of blocked IPs currently programmed in eBPF/XDP filter.
+    pub ebpf_blocked_ips: Gauge,
+    /// Total packets dropped by eBPF/XDP filter at kernel layer.
+    pub ebpf_packets_dropped_total: Counter,
+    /// Total bytes dropped by eBPF/XDP filter at kernel layer.
+    pub ebpf_bytes_dropped_total: Counter,
 }
 
 impl Metrics {
@@ -586,6 +594,24 @@ impl Metrics {
         )?;
         registry.register(Box::new(awg_reloads_total.clone()))?;
 
+        let ebpf_blocked_ips = Gauge::new(
+            "bsdm_proxy_ebpf_blocked_ips",
+            "Number of blocked IP addresses currently programmed in eBPF/XDP kernel filter",
+        )?;
+        registry.register(Box::new(ebpf_blocked_ips.clone()))?;
+
+        let ebpf_packets_dropped_total = Counter::new(
+            "bsdm_proxy_ebpf_packets_dropped_total",
+            "Total packets dropped by eBPF/XDP kernel packet filter",
+        )?;
+        registry.register(Box::new(ebpf_packets_dropped_total.clone()))?;
+
+        let ebpf_bytes_dropped_total = Counter::new(
+            "bsdm_proxy_ebpf_bytes_dropped_total",
+            "Total bytes dropped by eBPF/XDP kernel packet filter",
+        )?;
+        registry.register(Box::new(ebpf_bytes_dropped_total.clone()))?;
+
         Ok(Metrics {
             registry,
             requests_total,
@@ -650,6 +676,9 @@ impl Metrics {
             awg_rx_bytes_total,
             awg_tx_bytes_total,
             awg_reloads_total,
+            ebpf_blocked_ips,
+            ebpf_packets_dropped_total,
+            ebpf_bytes_dropped_total,
         })
     }
 


### PR DESCRIPTION
## Summary of Changes

Modernizes the experimental eBPF/XDP subsystem in BSDM-Proxy, removing mock/stub code and providing real dual-stack kernel filtering with Control Plane REST API management:

1. **BPF Kernel Program (`bpf/xdp_drop.c`)**:
   - Added dual-stack IPv4 (`ETH_P_IP`) and IPv6 (`ETH_P_IPV6`) packet inspection.
   - Added `bsdm_blocked_ips_v6` BPF hash map for IPv6 filtering.
   - Added `bsdm_drop_stats` BPF array map for atomic kernel-level packet and byte drop accounting (`__sync_fetch_and_add`).

2. **eBPF Manager (`proxy/src/ebpf.rs`)**:
   - Completely eliminated hardcoded dummy stub statistics in `stats()`.
   - Added `EbpfBlockedIp` audit metadata (`id`, `ip`, `addedAt`, `reason`, `packetsDropped`, `bytesDropped`) with camelCase serialization for Admin Console compatibility.
   - Supported dynamic config updates, atomic in-memory tracking, and safe simulation mode fallback on non-Linux systems.

3. **Control Plane REST API (`proxy/src/control_api.rs`)**:
   - Implemented full suite of authenticated `/api/ebpf/*` endpoints protected by `CONTROL_API_TOKEN`:
     - `GET /api/ebpf/config` & `PUT /api/ebpf/config`
     - `GET /api/ebpf/stats`
     - `GET /api/ebpf/ips`, `POST /api/ebpf/ips`
     - `DELETE /api/ebpf/ips/:id` & `DELETE /api/ebpf/ips`

4. **Integration & Telemetry (`proxy/src/main.rs`, `proxy/src/metrics.rs`)**:
   - Attached `EbpfXdpManager` to `ControlApiState` and proxy startup (`EBPF_XDP_ENABLED` opt-in, default `false`).
   - Added Prometheus metrics: `bsdm_proxy_ebpf_blocked_ips`, `bsdm_proxy_ebpf_packets_dropped_total`, `bsdm_proxy_ebpf_bytes_dropped_total`.

5. **Tests**:
   - Added unit tests for IPv4/IPv6 parsing, blocking, unblocking, and stats in `proxy/src/ebpf.rs`.
   - Added end-to-end integration test `test_ebpf_control_api_lifecycle` in `proxy/src/control_api.rs`.
   - Passed `cargo fmt`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and all 337+ workspace tests.