### PR TITLE
docs: correct eBPF metric names; default EBPF_XDP_ENABLED to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **alert-worker ClickHouse latency control** (`alert-worker::clickhouse`, `::config`, `::metrics`) — per-query client deadline (`ALERT_CLICKHOUSE_TIMEOUT_MS`) replacing the shared 30 s client timeout, server-side `max_execution_time` / `max_result_rows` (`result_overflow_mode=break`) and `readonly=2` guards (opt-out `ALERT_CLICKHOUSE_QUERY_GUARDS` for profiles pinned to `readonly=1`), slow-query logging (`ALERT_CLICKHOUSE_SLOW_QUERY_MS`), early cycle abort after `ALERT_CLICKHOUSE_FAILURE_THRESHOLD` consecutive failures with capped exponential poll backoff (`ALERT_CLICKHOUSE_BACKOFF_MAX_SECS`), and new metrics `alert_worker_clickhouse_query_seconds{rule}`, `alert_worker_clickhouse_query_errors_total{rule,kind}`, `alert_worker_clickhouse_slow_queries_total{rule}`, `alert_worker_cycle_duration_seconds`, `alert_worker_cycles_degraded_total`, `alert_worker_clickhouse_degraded`, `alert_worker_last_success_timestamp_seconds` plus four Prometheus alert rules in `prometheus/alerts/m4_threat.yml`.
 - **Grafana dashboard «BSDM Threat Intelligence (Shadow)»** — `grafana/dashboards/bsdm-threat-intel-shadow.json` (uid `bsdm-threat-intel-shadow`): enforcement posture of collector and proxy, per-feed `bsdm_proxy_ti_shadow_matches_total`, enforce-block guard, SOAR call rate, feed freshness / fetch results / drop reasons, RPZ records and rollbacks, and ClickHouse false-positive review tables over `threat_shadow_match`. Closes the last acceptance criterion of the August 2026 improvement proposal (ADR 0008).
 
+### Changed
+
+- **`EBPF_XDP_ENABLED` defaults to `false` in the shipped `bsdm-proxy.env`** — the eBPF/XDP filter is a lab-only component excluded from the single-node Day-1 pilot scope (`docs/project-status.md`), while the shipped file enabled it on `eth0`. The file now matches the code default (`proxy/src/ebpf.rs`). Deployments that rely on XDP filtering must set `EBPF_XDP_ENABLED=true` explicitly.
+
 ### Security
 
 - **`wasmtime` 46.0.2 → 46.0.3** — addresses RUSTSEC-2026-0268 and RUSTSEC-2026-0269 (`proxy`, optional feature `wasm`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **eBPF/XDP Modernization & Control API** (`proxy::ebpf`, `proxy::control_api`, `bpf/xdp_drop.c`) — kernel XDP packet filter modernized with dual-stack IPv4 and IPv6 packet inspection, kernel drop accounting via `bsdm_drop_stats` BPF map, full `/api/ebpf/*` REST Control API suite (`GET/PUT /config`, `GET /stats`, `GET/POST/DELETE /ips`), thread-safe locking eliminating ABBA deadlocks between configuration updates and IP management, kernel drop counters ingestion via `bpftool -j map dump`, and Prometheus metrics `bsdm_proxy_ebpf_dropped_packets_total`, `bsdm_proxy_ebpf_dropped_bytes_total`, `bsdm_proxy_ebpf_blocked_ips`.
-- **Dependencies** — bumped `wasmtime` 46.0.2 to 46.0.3 addressing RUSTSEC-2026-0268 and RUSTSEC-2026-0269.
+- **eBPF/XDP Modernization & Control API** (`proxy::ebpf`, `proxy::control_api`, `bpf/xdp_drop.c`) — kernel XDP packet filter modernized with dual-stack IPv4 and IPv6 packet inspection, kernel drop accounting via `bsdm_drop_stats` BPF map, full `/api/ebpf/*` REST Control API suite (`GET/PUT /config`, `GET /stats`, `GET/POST/DELETE /ips`), thread-safe locking eliminating ABBA deadlocks between configuration updates and IP management, kernel drop counters ingestion via `bpftool -j map dump`, and Prometheus metrics `bsdm_proxy_ebpf_packets_dropped_total`, `bsdm_proxy_ebpf_bytes_dropped_total`, `bsdm_proxy_ebpf_blocked_ips`.
 - **alert-worker ClickHouse latency control** (`alert-worker::clickhouse`, `::config`, `::metrics`) — per-query client deadline (`ALERT_CLICKHOUSE_TIMEOUT_MS`) replacing the shared 30 s client timeout, server-side `max_execution_time` / `max_result_rows` (`result_overflow_mode=break`) and `readonly=2` guards (opt-out `ALERT_CLICKHOUSE_QUERY_GUARDS` for profiles pinned to `readonly=1`), slow-query logging (`ALERT_CLICKHOUSE_SLOW_QUERY_MS`), early cycle abort after `ALERT_CLICKHOUSE_FAILURE_THRESHOLD` consecutive failures with capped exponential poll backoff (`ALERT_CLICKHOUSE_BACKOFF_MAX_SECS`), and new metrics `alert_worker_clickhouse_query_seconds{rule}`, `alert_worker_clickhouse_query_errors_total{rule,kind}`, `alert_worker_clickhouse_slow_queries_total{rule}`, `alert_worker_cycle_duration_seconds`, `alert_worker_cycles_degraded_total`, `alert_worker_clickhouse_degraded`, `alert_worker_last_success_timestamp_seconds` plus four Prometheus alert rules in `prometheus/alerts/m4_threat.yml`.
 - **Grafana dashboard «BSDM Threat Intelligence (Shadow)»** — `grafana/dashboards/bsdm-threat-intel-shadow.json` (uid `bsdm-threat-intel-shadow`): enforcement posture of collector and proxy, per-feed `bsdm_proxy_ti_shadow_matches_total`, enforce-block guard, SOAR call rate, feed freshness / fetch results / drop reasons, RPZ records and rollbacks, and ClickHouse false-positive review tables over `threat_shadow_match`. Closes the last acceptance criterion of the August 2026 improvement proposal (ADR 0008).
+
+### Security
+
+- **`wasmtime` 46.0.2 → 46.0.3** — addresses RUSTSEC-2026-0268 and RUSTSEC-2026-0269 (`proxy`, optional feature `wasm`).
 
 ## [0.9.14] - 2026-08-31
 

--- a/bsdm-proxy.env
+++ b/bsdm-proxy.env
@@ -120,8 +120,8 @@ PEER_DISCOVERY_ENABLED=true
 PEER_DISCOVERY_MULTICAST=239.255.77.77:3132
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_MAX_KEYS=100000
-# Lab-only компонент (см. docs/project-status.md): в Day-1 скоупе одноузлового
-# пилота должен быть выключен — установите EBPF_XDP_ENABLED=false.
-EBPF_XDP_ENABLED=true
+# Lab-only компонент (см. docs/project-status.md), в Day-1 скоупе одноузлового
+# пилота выключен; совпадает с дефолтом в коде (proxy/src/ebpf.rs).
+EBPF_XDP_ENABLED=false
 EBPF_XDP_IFACE=eth0
 EBPF_XDP_MODE=driver

--- a/bsdm-proxy.env
+++ b/bsdm-proxy.env
@@ -120,6 +120,8 @@ PEER_DISCOVERY_ENABLED=true
 PEER_DISCOVERY_MULTICAST=239.255.77.77:3132
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_MAX_KEYS=100000
+# Lab-only компонент (см. docs/project-status.md): в Day-1 скоупе одноузлового
+# пилота должен быть выключен — установите EBPF_XDP_ENABLED=false.
 EBPF_XDP_ENABLED=true
 EBPF_XDP_IFACE=eth0
 EBPF_XDP_MODE=driver

--- a/docs/ops-and-dev/configuration.md
+++ b/docs/ops-and-dev/configuration.md
@@ -513,6 +513,11 @@ ICAP-эндпоинта. `ICAP_FAIL_OPEN=true` возвращает прежне
 `EBPF_XDP_ENABLED`, `EBPF_XDP_IFACE`, `EBPF_XDP_MODE`,
 `EBPF_XDP_MAX_ENTRIES`.
 
+`EBPF_XDP_ENABLED` по умолчанию `false` (и в коде, и в поставляемом
+`bsdm-proxy.env`). Компонент lab-only и не входит в Day-1 скоуп одноузлового
+пилота — включайте его осознанно и только там, где XDP-фильтр на
+`EBPF_XDP_IFACE` действительно нужен.
+
 ### Reverse proxy/OIDC
 
 Runtime включается наличием `REVERSE_PROXY_UPSTREAM`. Дополнительно:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -88,10 +88,11 @@ Roadmap определяет порядок работ в рамках стра�
 ## Замороженные модули (Scope Freeze)
 
 Следующие экспериментальные модули заморожены в текущем виде для исключения фичер-крипа:
-- **eBPF/XDP**: Модернизирован в lab-режиме (dual-stack IPv4/IPv6, Control API, учет дропов ядра); не входит в Day-1 скоуп одноузлового пилота.
 - **Native String DLP**: Заморожен до появления полноценного спека.
 - **Mock OIDC Reverse Proxy**: Заморожен.
 - **Global Session / Threat Sync Scaffolding**: Заморожен до подтверждения однокластерной модели.
+
+Отдельно от заморозки: **eBPF/XDP** модернизирован в lab-режиме (dual-stack IPv4/IPv6, Control API `/api/ebpf/*`, учет дропов ядра через BPF-карту `bsdm_drop_stats`) и в Scope Freeze больше не входит. Компонент остаётся lab-only и не входит в Day-1 скоуп одноузлового пилота — см. [project-status.md](project-status.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up к docs-синку eBPF/XDP-модернизации (`cb1b662`) по результатам code-review закрытого PR #359 (в нём был нулевой diff — содержимое уже находилось в `main`).

1. **`CHANGELOG.md` — неверные имена Prometheus-метрик (основное).** В записи Unreleased были указаны `bsdm_proxy_ebpf_dropped_packets_total` и `bsdm_proxy_ebpf_dropped_bytes_total`, тогда как в реестре зарегистрированы `bsdm_proxy_ebpf_packets_dropped_total` и `bsdm_proxy_ebpf_bytes_dropped_total` (`proxy/src/metrics.rs:604,610`) — слова переставлены. Скопированное из CHANGELOG имя даёт пустой результат в PromQL. `bsdm_proxy_ebpf_blocked_ips` был указан верно и не тронут. Ни один dashboard в `grafana/` и ни одно правило в `prometheus/alerts/` эти метрики пока не использует, так что сломанных алертов нет.
2. **`CHANGELOG.md` — рубрика для бампа `wasmtime`.** Бамп 46.0.2 → 46.0.3 по RUSTSEC-2026-0268 / RUSTSEC-2026-0269 стоял под `### Added`; вынесен в `### Security` согласно формату Keep a Changelog, который декларирует шапка файла.
3. **`docs/roadmap.md` — противоречие в Scope Freeze.** Пункт eBPF/XDP описывал модернизированный компонент, но находился в списке замороженных модулей. Вынесен из списка в отдельное примечание со ссылкой на `project-status.md`.
4. **`bsdm-proxy.env` — `EBPF_XDP_ENABLED=true` → `false` (изменение поведения).** `docs/project-status.md` фиксирует eBPF/XDP как lab-only и OFF для Day-1 скоупа одноузлового пилота, а `proxy/src/ebpf.rs:106-108` при отсутствии переменной даёт `false` — но поставляемый `bsdm-proxy.env` включал XDP-фильтр на `eth0`. Файл приведён в соответствие с кодом и документацией; дефолт задокументирован в разделе eBPF/XDP файла `docs/ops-and-dev/configuration.md`, изменение записано в `CHANGELOG` → `### Changed`. **Установки, полагающиеся на XDP-фильтрацию, должны теперь выставлять `EBPF_XDP_ENABLED=true` явно.**

Исполняемый код, `Cargo.toml` и `Cargo.lock` не тронуты.

## Related Issues

Нет связанного issue. Контекст: закрытый PR #359, коммит `cb1b662`.

## Testing

Изменения затрагивают Markdown и одну переменную в `.env`; исполняемый код не тронут, поэтому результаты `cargo test` / `cargo clippy` определяются CI на этом PR. Имена метрик и дефолт флага сверены с исходником:

```bash
grep -n "bsdm_proxy_ebpf" proxy/src/metrics.rs
# 598: bsdm_proxy_ebpf_blocked_ips
# 604: bsdm_proxy_ebpf_packets_dropped_total
# 610: bsdm_proxy_ebpf_bytes_dropped_total

sed -n '106,108p' proxy/src/ebpf.rs
# EBPF_XDP_ENABLED ... .unwrap_or(false)
```

## Checklist

- [ ] CI is green (см. комментарий ниже о `github-advanced-security`)
- [x] Documentation updated (if behavior or env vars changed) — `docs/ops-and-dev/configuration.md` и `CHANGELOG` обновлены под смену дефолта `EBPF_XDP_ENABLED`
- [x] `docs/roadmap.md` / `docs/project-status.md` updated (if applicable) — обновлён `roadmap.md`; `project-status.md` уже корректен и не тронут

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ya9VsdeoShQsmsNE4PSgNA